### PR TITLE
MIXEDARCH-328: Change ICache implementation to use and review storeGlobalPullSecret indirection

### DIFF
--- a/pkg/image/cache.go
+++ b/pkg/image/cache.go
@@ -45,7 +45,8 @@ func (c *cacheProxy) GetCompatibleArchitecturesSet(ctx context.Context, imageRef
 	return architectures, nil
 }
 
-func newCache() ICache {
+//nolint:unused
+func newCacheProxy() ICache {
 	return &cacheProxy{
 		imageRefsArchitectureMap: map[string]sets.Set[string]{},
 		registryInspector:        newRegistryInspector(),

--- a/pkg/image/cache.go
+++ b/pkg/image/cache.go
@@ -23,12 +23,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+//nolint:unused
 type cacheProxy struct {
 	registryInspector        IRegistryInspector
 	imageRefsArchitectureMap map[string]sets.Set[string]
 	mutex                    sync.Mutex
 }
 
+//nolint:unused
 func (c *cacheProxy) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (sets.Set[string], error) {
 	if c.imageRefsArchitectureMap[imageReference] != nil {
 		return c.imageRefsArchitectureMap[imageReference], nil

--- a/pkg/image/facade.go
+++ b/pkg/image/facade.go
@@ -30,16 +30,23 @@ var (
 )
 
 type Facade struct {
-	inspectionCache ICache
+	inspectionCache       ICache
+	storeGlobalPullSecret func(pullSecret []byte)
 }
 
 func (i *Facade) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (architectures sets.Set[string], err error) {
 	return i.inspectionCache.GetCompatibleArchitecturesSet(ctx, imageReference, secrets)
 }
 
+func (i *Facade) StoreGlobalPullSecret(pullSecret []byte) {
+	i.storeGlobalPullSecret(pullSecret)
+}
+
 func newImageFacade() *Facade {
+	inspectionCache := newCache()
 	return &Facade{
-		inspectionCache: newCache(),
+		inspectionCache:       inspectionCache,
+		storeGlobalPullSecret: inspectionCache.storeGlobalPullSecret,
 	}
 }
 
@@ -48,8 +55,4 @@ func FacadeSingleton() *Facade {
 		singletonImageFacade = newImageFacade()
 	})
 	return singletonImageFacade
-}
-
-func (i *Facade) StoreGlobalPullSecret(pullSecret []byte) {
-	i.inspectionCache.(*cacheProxy).registryInspector.StoreGlobalPullSecret(pullSecret)
 }

--- a/pkg/image/facade.go
+++ b/pkg/image/facade.go
@@ -43,7 +43,8 @@ func (i *Facade) StoreGlobalPullSecret(pullSecret []byte) {
 }
 
 func newImageFacade() *Facade {
-	inspectionCache := newCache()
+	// TODO: restore to use the cacheProxy once an eviction policy is implemented
+	inspectionCache := newRegistryInspector()
 	return &Facade{
 		inspectionCache:       inspectionCache,
 		storeGlobalPullSecret: inspectionCache.storeGlobalPullSecret,

--- a/pkg/image/inspector.go
+++ b/pkg/image/inspector.go
@@ -164,7 +164,7 @@ func writeMemFile(name string, b []byte) (int, error) {
 	return fd, nil
 }
 
-func (i *registryInspector) StoreGlobalPullSecret(pullSecret []byte) {
+func (i *registryInspector) storeGlobalPullSecret(pullSecret []byte) {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
 	i.globalPullSecret = pullSecret

--- a/pkg/image/interfaces.go
+++ b/pkg/image/interfaces.go
@@ -30,8 +30,8 @@ type ICache interface {
 
 type IRegistryInspector interface {
 	ICache
-	// StoreGlobalPullSecret takes a pull secret and stores it in the ImageFacade. It will be used by the controller
+	// storeGlobalPullSecret takes a pull secret and stores it in the ImageFacade. It will be used by the controller
 	// in charge of watching the global pull secret and to store it in the ImageFacade's relevant private field.
 	// Then, the ImageFacade will be responsible for consuming it during the inspection.
-	StoreGlobalPullSecret(pullSecret []byte)
+	storeGlobalPullSecret(pullSecret []byte)
 }


### PR DESCRIPTION
The current caching mechanism comes from the PoC implementation but is not ready yet to be used because (1) it misses a cache eviction policy, (2) it may need a few further fixes to avoid leaking images' metadata when the inspection happens with different pull secrets.

This PR skips the `cacheProxy`'s use to rely solely on the remote registry inspector.

Moreover, the first commit improves the storeGlobalPullSecret indirection (through the facade) implementation to easily allow other ICache implementation to be used by the Facade (e.g., for unit tests).