### PR TITLE
MIXEDARCH-325: Add flags to enable a subset of the controllers

### DIFF
--- a/config/default/default/manager_auth_proxy_patch.yaml
+++ b/config/default/default/manager_auth_proxy_patch.yaml
@@ -53,3 +53,8 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--enable-operator"
+        # TODO: remove the following lines once the operator controller is capable of managing
+        # the lifecycle of the operand (see MIXEDARCH-352 and #12)
+        - "--enable-ppc-controllers"
+        - "--enable-ppc-webhook"


### PR DESCRIPTION
This PR adds three flags to allow enabling a subset of the controllers:
- `--enable-operator` enables the operator controllers (the PodPlacementConfig now)
- `--enable-ppc-webhook` will register the webhook to mutate pods
- `--enable-ppc-controllers` will enable the controllers related to the arch-aware pod placement

Currently, the manifests are changed to enable all the controllers. Once we go concluding #12 , we will disable the PPC-related controllers from running in operator pod.

This is related to #12 and closes [MIXEDARCH-325](https://issues.redhat.com//browse/MIXEDARCH-325)