### PR TITLE
A NodeAffinity Gomega matcher, a basic e2e case and minor fixes

### DIFF
--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -128,9 +128,14 @@ func buildDeployment(podPlacementConfig *v1alpha1.PodPlacementConfig,
 									{
 										MatchExpressions: []corev1.NodeSelectorRequirement{
 											{
-												Key:      "kubernetes.io/arch",
+												Key:      utils.ArchLabel,
 												Operator: corev1.NodeSelectorOpIn,
-												Values:   []string{"amd64", "s390x", "ppc64le", "arm64"},
+												Values: []string{
+													utils.ArchitectureAmd64,
+													utils.ArchitectureArm64,
+													utils.ArchitectureS390x,
+													utils.ArchitecturePpc64le,
+												},
 											},
 										},
 									},

--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -25,16 +25,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/openshift/multiarch-manager-operator/pkg/image"
-)
-
-const (
-	archLabel                       = "kubernetes.io/arch"
-	schedulingGateLabel             = "multiarch.openshift.io/scheduling-gate"
-	schedulingGateLabelValueGated   = "gated"
-	schedulingGateLabelValueRemoved = "removed"
-	nodeAffinityLabel               = "multiarch.openshift.io/node-affinity"
-	nodeAffinityLabelValueSet       = "set"
-	nodeAffinityLabelValueUnset     = "unset"
+	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 )
 
 var (
@@ -91,7 +82,7 @@ func (pod *Pod) RemoveSchedulingGate() {
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
-	pod.Labels[schedulingGateLabel] = schedulingGateLabelValueRemoved
+	pod.Labels[utils.SchedulingGateLabel] = utils.SchedulingGateLabelValueRemoved
 }
 
 // SetNodeAffinityArchRequirement wraps the logic to set the nodeAffinity for the pod.
@@ -103,7 +94,7 @@ func (pod *Pod) SetNodeAffinityArchRequirement(pullSecretDataList [][]byte) {
 
 	if pod.Spec.NodeSelector != nil {
 		for key := range pod.Spec.NodeSelector {
-			if key == archLabel {
+			if key == utils.ArchLabel {
 				// if the pod has the nodeSelector field set for the kubernetes.io/arch label, we ignore it.
 				// in fact, the nodeSelector field is ANDed with the nodeAffinity field, and we want to give the user the main control, if they
 				// manually set a predicate for the kubernetes.io/arch label.
@@ -177,7 +168,7 @@ func (pod *Pod) setArchNodeAffinity(requirement corev1.NodeSelectorRequirement) 
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
 		}
-		pod.Labels[nodeAffinityLabel] = nodeAffinityLabelValueSet
+		pod.Labels[utils.NodeAffinityLabel] = utils.NodeAffinityLabelValueSet
 	}
 }
 
@@ -188,7 +179,7 @@ func (pod *Pod) getArchitecturePredicate(pullSecretDataList [][]byte) (corev1.No
 		return corev1.NodeSelectorRequirement{}, err
 	}
 	return corev1.NodeSelectorRequirement{
-		Key:      archLabel,
+		Key:      utils.ArchLabel,
 		Operator: corev1.NodeSelectorOpIn,
 		Values:   architectures,
 	}, nil

--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -12,8 +12,9 @@ import (
 
 	mmoimage "github.com/openshift/multiarch-manager-operator/pkg/image"
 	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake"
+	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 
-	. "github.com/openshift/multiarch-manager-operator/pkg/testing/utils"
+	. "github.com/openshift/multiarch-manager-operator/pkg/testing/framework"
 )
 
 var ctx context.Context
@@ -215,27 +216,27 @@ func TestPod_intersectImagesArchitecture(t *testing.T) {
 		{
 			name:                       "pod with a single container and multi-arch image",
 			pod:                        NewPod().WithContainersImages(fake.MultiArchImage).Build(),
-			wantSupportedArchitectures: sets.New[string](fake.ArchitectureAmd64, fake.ArchitectureArm64),
+			wantSupportedArchitectures: sets.New[string](utils.ArchitectureAmd64, utils.ArchitectureArm64),
 		},
 		{
 			name:                       "pod with a single container and single-arch image",
 			pod:                        NewPod().WithContainersImages(fake.SingleArchArm64Image).Build(),
-			wantSupportedArchitectures: sets.New[string](fake.ArchitectureArm64),
+			wantSupportedArchitectures: sets.New[string](utils.ArchitectureArm64),
 		},
 		{
 			name:                       "pod with multiple containers and same image",
 			pod:                        NewPod().WithContainersImages(fake.MultiArchImage, fake.MultiArchImage).Build(),
-			wantSupportedArchitectures: sets.New[string](fake.ArchitectureAmd64, fake.ArchitectureArm64),
+			wantSupportedArchitectures: sets.New[string](utils.ArchitectureAmd64, utils.ArchitectureArm64),
 		},
 		{
 			name:                       "pod with multiple containers, single-arch image and multi-arch image",
 			pod:                        NewPod().WithContainersImages(fake.MultiArchImage, fake.SingleArchArm64Image).Build(),
-			wantSupportedArchitectures: sets.New[string](fake.ArchitectureArm64),
+			wantSupportedArchitectures: sets.New[string](utils.ArchitectureArm64),
 		},
 		{
 			name:                       "pod with multiple containers, two multi-arch images",
 			pod:                        NewPod().WithContainersImages(fake.MultiArchImage, fake.MultiArchImage2).Build(),
-			wantSupportedArchitectures: sets.New[string](fake.ArchitectureAmd64, fake.ArchitectureArm64),
+			wantSupportedArchitectures: sets.New[string](utils.ArchitectureAmd64, utils.ArchitectureArm64),
 		},
 		{
 			name:                       "pod with multiple containers, one non-existing image",
@@ -293,9 +294,9 @@ func TestPod_getArchitecturePredicate(t *testing.T) {
 				},
 			},
 			want: v1.NodeSelectorRequirement{
-				Key:      archLabel,
+				Key:      utils.ArchLabel,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+				Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 			},
 		},
 		{
@@ -347,9 +348,9 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 			want: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				},
 			).Build(),
@@ -361,9 +362,9 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 			want: NewPod().WithContainersImages(fake.SingleArchAmd64Image).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64},
+						Values:   []string{utils.ArchitectureAmd64},
 					},
 				},
 			).Build(),
@@ -375,9 +376,9 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 			want: NewPod().WithContainersImages(fake.SingleArchArm64Image).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureArm64},
 					},
 				},
 			).Build(),
@@ -406,9 +407,9 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 						Values:   []string{"bar"},
 					},
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				}, []v1.NodeSelectorRequirement{
 					{
@@ -417,9 +418,9 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 						Values:   []string{"foo"},
 					},
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				},
 			).Build(),
@@ -434,9 +435,9 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 						Values:   []string{"bar"},
 					},
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureS390x},
+						Values:   []string{utils.ArchitectureS390x},
 					},
 				}, []v1.NodeSelectorRequirement{
 					{
@@ -453,9 +454,9 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 						Values:   []string{"bar"},
 					},
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureS390x},
+						Values:   []string{utils.ArchitectureS390x},
 					},
 				}, []v1.NodeSelectorRequirement{
 					{
@@ -463,9 +464,9 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 						Operator: v1.NodeSelectorOpIn,
 						Values:   []string{"foo"},
 					}, {
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				}).Build(),
 		},
@@ -500,9 +501,9 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 			want: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				},
 			).Build(),
@@ -514,18 +515,18 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 				"foo", "bar").WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				}).Build(),
 		},
 		{
 			name: "pod with node selector and architecture requirement",
 			pod: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectors("foo", "bar",
-				archLabel, fake.ArchitectureArm64).Build(),
+				utils.ArchLabel, utils.ArchitectureArm64).Build(),
 			want: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectors("foo", "bar",
-				archLabel, fake.ArchitectureArm64).Build(),
+				utils.ArchLabel, utils.ArchitectureArm64).Build(),
 		},
 		{
 			name: "pod with no affinity",
@@ -533,9 +534,9 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 			want: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				}).Build(),
 		},
@@ -545,9 +546,9 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 			want: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				}).Build(),
 		},
@@ -557,9 +558,9 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 			want: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				}).Build(),
 		},
@@ -580,9 +581,9 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 						Values:   []string{"bar"},
 					},
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				}).Build(),
 		},
@@ -640,9 +641,9 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 			}).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{
-						Key:      archLabel,
+						Key:      utils.ArchLabel,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{fake.ArchitectureAmd64, fake.ArchitectureArm64},
+						Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64},
 					},
 				}).Build(),
 		},

--- a/controllers/podplacement/pod_reconciler_test.go
+++ b/controllers/podplacement/pod_reconciler_test.go
@@ -11,10 +11,10 @@ import (
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake/registry"
 	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 
-	. "github.com/openshift/multiarch-manager-operator/pkg/testing/utils"
+	. "github.com/openshift/multiarch-manager-operator/pkg/testing/framework"
+	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake/registry"
 )
 
 var _ = Describe("Controllers/Podplacement/PodReconciler", func() {

--- a/controllers/podplacement/pod_reconciler_test.go
+++ b/controllers/podplacement/pod_reconciler_test.go
@@ -11,7 +11,6 @@ import (
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake"
 	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake/registry"
 	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 
@@ -42,7 +41,7 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					g.Expect(pod.Spec.SchedulingGates).NotTo(ContainElement(corev1.PodSchedulingGate{
 						Name: schedulingGateName,
 					}), "scheduling gate not removed")
-					g.Expect(pod.Labels).To(HaveKeyWithValue(schedulingGateLabel, schedulingGateLabelValueRemoved),
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				Eventually(func(g Gomega) {
@@ -59,17 +58,17 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 								{
 									MatchExpressions: []corev1.NodeSelectorRequirement{
 										{
-											Key:      archLabel,
 											Operator: corev1.NodeSelectorOpIn,
 											Values:   supportedArchitectures,
+											Key:      utils.ArchLabel,
 										},
 									},
 								},
 							}))), "unexpected node selector terms")
 				}).Should(Succeed(), "failed to set node affinity to pod")
 			},
-				Entry("OCI Index Images", imgspecv1.MediaTypeImageIndex, fake.ArchitectureAmd64, fake.ArchitectureArm64),
-				Entry("Docker images", imgspecv1.MediaTypeImageManifest, fake.ArchitecturePpc64le),
+				Entry("OCI Index Images", imgspecv1.MediaTypeImageIndex, utils.ArchitectureAmd64, utils.ArchitectureArm64),
+				Entry("Docker images", imgspecv1.MediaTypeImageManifest, utils.ArchitecturePpc64le),
 			)
 		},
 		)

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -98,7 +98,7 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	// and this pod expects processing by the operator. That's useful for testing and debugging, but also gives the user
 	// an indication that the pod is waiting for processing and can support kubectl queries to find out which pods are
 	// waiting for processing, for example when the operator is being uninstalled.
-	pod.Labels[schedulingGateLabel] = schedulingGateLabelValueGated
-	pod.Labels[nodeAffinityLabel] = nodeAffinityLabelValueUnset
+	pod.Labels[utils.SchedulingGateLabel] = utils.SchedulingGateLabelValueGated
+	pod.Labels[utils.NodeAffinityLabel] = utils.NodeAffinityLabelValueUnset
 	return a.patchedPodResponse(pod, req)
 }

--- a/controllers/podplacement/suite_test.go
+++ b/controllers/podplacement/suite_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -48,8 +49,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	testingutils "github.com/openshift/multiarch-manager-operator/pkg/testing/framework"
 	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake/registry"
-	testingutils "github.com/openshift/multiarch-manager-operator/pkg/testing/utils"
 	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 	//+kubebuilder:scaffold:imports
 )

--- a/hack/deploy-and-e2e.sh
+++ b/hack/deploy-and-e2e.sh
@@ -5,9 +5,9 @@ if ! which kubectl >/dev/null; then
   mkdir -p /tmp/bin
   export PATH=/tmp/bin:${PATH}
   ln -s "$(which oc)" "/tmp/bin/kubectl"
-  export NO_DOCKER=1
 fi
 
+export NO_DOCKER=1
 NAMESPACE=openshift-multiarch-manager-operator
 oc create namespace ${NAMESPACE}
 oc annotate namespace ${NAMESPACE} \

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -26,12 +26,12 @@ var _ = Describe("The Multiarch Manager Operator", func() {
 				d, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementControllerName,
 					metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(d.Status.AvailableReplicas).To(Equal(d.Status.Replicas),
+				g.Expect(d.Status.ReadyReplicas).To(Equal(*d.Spec.Replicas),
 					"at least one pod placement controller replicas is not available yet")
 				d, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementWebhookName,
 					metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(d.Status.AvailableReplicas).To(Equal(d.Status.Replicas),
+				g.Expect(d.Status.ReadyReplicas).To(Equal(*d.Spec.Replicas),
 					"at least one pod placement webhook replicas is not available yet")
 			}).Should(Succeed())
 		})

--- a/pkg/e2e/podplacement/e2e_test.go
+++ b/pkg/e2e/podplacement/e2e_test.go
@@ -1,17 +1,23 @@
-package operator_test
+package podplacement_test
 
 import (
 	"context"
 	"testing"
 
-	"github.com/openshift/multiarch-manager-operator/pkg/e2e"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/multiarch-manager-operator/apis/multiarch/v1alpha1"
+	"github.com/openshift/multiarch-manager-operator/controllers/operator"
+	"github.com/openshift/multiarch-manager-operator/pkg/e2e"
+	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 )
 
 var (
@@ -32,4 +38,45 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	client, clientset, ctx, suiteLog = e2e.CommonBeforeSuite()
+	err := client.Create(ctx, &v1alpha1.PodPlacementConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(deploymentsAreRunning).Should(Succeed())
 })
+
+var _ = AfterSuite(func() {
+	err := client.Delete(ctx, &v1alpha1.PodPlacementConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(deploymentsAreDeleted).Should(Succeed())
+})
+
+func deploymentsAreRunning(g Gomega) {
+	d, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementControllerName,
+		metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(d.Status.AvailableReplicas).To(Equal(*d.Spec.Replicas),
+		"at least one pod placement controller replicas is not available yet")
+	d, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementWebhookName,
+		metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(d.Status.AvailableReplicas).To(Equal(*d.Spec.Replicas),
+		"at least one pod placement webhook replicas is not available yet")
+}
+
+func deploymentsAreDeleted(g Gomega) {
+	_, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementControllerName,
+		metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	_, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementWebhookName,
+		metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -1,15 +1,92 @@
-package operator_test
+package podplacement_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/multiarch-manager-operator/pkg/e2e"
+	"github.com/openshift/multiarch-manager-operator/pkg/testing/framework"
+	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 )
 
+const helloOpenshiftPublicMultiarchImage = "quay.io/openshifttest/hello-openshift:1.2.0"
+
 var _ = Describe("The Pod Placement Operand", func() {
-	Context("When a workload is deployed", func() {
+	Context("When a deployment is deployed with a single container and a public image", func() {
 		It("should set the node affinity", func() {
-			// Your test code goes here
-			Expect(true).To(BeTrue())
+			var err error
+			ns := framework.NewEphemeralNamespace()
+			err = client.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, ns)
+			d := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: ns.Name,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: utils.NewPtr(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "test",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test",
+									Image: helloOpenshiftPublicMultiarchImage,
+								},
+							},
+						},
+					},
+				},
+			}
+			err = client.Create(ctx, &d)
+			Expect(err).NotTo(HaveOccurred())
+			r, err := labels.NewRequirement("app", "in", []string{"test"})
+			labelSelector := labels.NewSelector().Add(*r)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) {
+				pods := &corev1.PodList{}
+				err := client.List(ctx, pods, &runtimeclient.ListOptions{
+					Namespace:     ns.Name,
+					LabelSelector: labelSelector,
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods.Items).NotTo(BeEmpty())
+				g.Expect(pods.Items).To(HaveEach(framework.HaveEquivalentNodeAffinity(
+					&corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      utils.ArchLabel,
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le},
+										},
+									},
+								},
+							},
+						},
+					})))
+			}, e2e.WaitShort).Should(Succeed())
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/pkg/e2e/suites_lifecycle.go
+++ b/pkg/e2e/suites_lifecycle.go
@@ -16,11 +16,11 @@ import (
 	"github.com/go-logr/logr"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/openshift/multiarch-manager-operator/pkg/testing/utils"
+	"github.com/openshift/multiarch-manager-operator/pkg/testing/framework"
 )
 
 func CommonInit() {
-	err := utils.RegisterScheme(scheme.Scheme)
+	err := framework.RegisterScheme(scheme.Scheme)
 	if err != nil {
 		panic(err)
 	}
@@ -29,10 +29,10 @@ func CommonInit() {
 func CommonBeforeSuite() (client runtimeclient.Client, clientset *kubernetes.Clientset,
 	ctx context.Context, suiteLog logr.Logger) {
 	var err error
-	client, err = utils.LoadClient()
+	client, err = framework.LoadClient()
 	Expect(err).ToNot(HaveOccurred())
 
-	clientset, err = utils.LoadClientset()
+	clientset, err = framework.LoadClientset()
 	Expect(err).ToNot(HaveOccurred())
 
 	suiteLog = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.Level(-5)))

--- a/pkg/testing/framework/namespace.go
+++ b/pkg/testing/framework/namespace.go
@@ -1,0 +1,20 @@
+package framework
+
+import (
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewEphemeralNamespace() *corev1.Namespace {
+	name := "t-" + uuid.NewString()
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	return ns
+}

--- a/pkg/testing/framework/node_affinity_equivalence_matcher.go
+++ b/pkg/testing/framework/node_affinity_equivalence_matcher.go
@@ -1,0 +1,111 @@
+package framework
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func HaveEquivalentNodeAffinity(expected interface{}) types.GomegaMatcher {
+	return &equivalentNodeAffinityMatcher{
+		expected: expected,
+	}
+}
+
+type equivalentNodeAffinityMatcher struct {
+	expected interface{}
+}
+
+func (matcher *equivalentNodeAffinityMatcher) Match(actual interface{}) (success bool, err error) {
+	actualPod, ok := actual.(corev1.Pod)
+	if !ok {
+		return false, fmt.Errorf("HaveEquivalentNodeAffinity matcher expects a *corev1.Pod in the actual value, got %T", actual)
+	}
+	expectedNodeAffinity, ok := matcher.expected.(*corev1.NodeAffinity)
+	if !ok {
+		return false, fmt.Errorf("HaveEquivalentNodeAffinity matcher expects a *corev1.NodeAffinity")
+	}
+	var actualNodeAffinity *corev1.NodeAffinity
+	if actualPod.Spec.Affinity != nil && actualPod.Spec.Affinity.NodeAffinity != nil {
+		actualNodeAffinity = actualPod.Spec.Affinity.NodeAffinity
+	}
+
+	if actualNodeAffinity == nil && expectedNodeAffinity == nil {
+		return true, nil
+	}
+	if actualNodeAffinity == nil || expectedNodeAffinity == nil {
+		return false, fmt.Errorf("expectedNodeAffinity: %v, actualNodeAffinity: %v", expectedNodeAffinity, actualNodeAffinity)
+	}
+
+	if actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil && expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return true, nil
+	}
+	if actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil || expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return false, fmt.Errorf("expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution: %v, "+
+			"actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution: %v",
+			expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	}
+
+	actualTerms := actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	expectedTerms := expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(actualTerms) != len(expectedTerms) {
+		return false, fmt.Errorf("expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms: %v, "+
+			"actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms: %v",
+			expectedTerms, actualTerms)
+	}
+
+	actualTerms = sortMatchExpressions(actualTerms)
+	expectedTerms = sortMatchExpressions(expectedTerms)
+
+	// now we can compare with the reflect.DeepEqual method
+	return reflect.DeepEqual(actualTerms, expectedTerms), nil
+}
+
+func (matcher *equivalentNodeAffinityMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto have an equivalent node affinity with \n\t%#v", actual, matcher.expected)
+}
+
+func (matcher *equivalentNodeAffinityMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nnot have an equivalent node affinity with \n\t%#v", actual, matcher.expected)
+}
+
+func sortMatchExpressions(nst []corev1.NodeSelectorTerm) []corev1.NodeSelectorTerm {
+	for _, term := range nst {
+		for _, req := range term.MatchExpressions {
+			sort.Strings(req.Values)
+		}
+		for _, req := range term.MatchFields {
+			sort.Strings(req.Values)
+		}
+		sort.SliceStable(term.MatchExpressions, func(i, j int) bool {
+			return term.MatchExpressions[i].Key < term.MatchExpressions[j].Key
+		})
+		sort.SliceStable(term.MatchFields, func(i, j int) bool {
+			return term.MatchFields[i].Key < term.MatchFields[j].Key
+		})
+	}
+	sort.SliceStable(nst, func(i, j int) bool {
+		term1 := nst[i]
+		term2 := nst[j]
+		term1Key := ""
+		term2Key := ""
+		for _, expr := range term1.MatchExpressions {
+			term1Key += expr.Key
+		}
+		for _, field := range term1.MatchFields {
+			term1Key += field.Key
+		}
+		for _, expr := range term2.MatchExpressions {
+			term2Key += expr.Key
+		}
+		for _, field := range term2.MatchFields {
+			term2Key += field.Key
+		}
+		return term1Key < term2Key
+	})
+	return nst
+}

--- a/pkg/testing/framework/pod_factory.go
+++ b/pkg/testing/framework/pod_factory.go
@@ -1,4 +1,4 @@
-package utils
+package framework
 
 import (
 	//#nosec G505: Blocklisted import crypto/sha1: weak cryptographic primitive
@@ -65,7 +65,7 @@ func (p *PodFactory) WithInitContainersImages(images ...string) *PodFactory {
 	return p
 }
 
-// withNodeAffinity adds a node affinity to the pod. If initialAffinity is not nil, it is used as the initial value
+// WithAffinity adds the affinity to the pod. If initialAffinity is not nil, it is used as the initial value
 // of the pod's affinity. Otherwise, the pod's affinity is initialized to an empty affinity if it is nil.
 func (p *PodFactory) WithAffinity(initialAffinity *v1.Affinity) *PodFactory {
 	if p.pod.Spec.Affinity == nil {

--- a/pkg/testing/framework/utils.go
+++ b/pkg/testing/framework/utils.go
@@ -1,4 +1,4 @@
-package utils
+package framework
 
 import (
 	"context"

--- a/pkg/testing/image/fake/inspector.go
+++ b/pkg/testing/image/fake/inspector.go
@@ -5,19 +5,14 @@ import (
 	"errors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 )
 
 type registryInspector struct {
 	// TBD: implement test with global pull secret merging
 	// globalPullSecret []byte
 }
-
-const (
-	ArchitectureAmd64   = "amd64"
-	ArchitectureArm64   = "arm64"
-	ArchitecturePpc64le = "ppc64le"
-	ArchitectureS390x   = "s390x"
-)
 
 const (
 	SingleArchAmd64Image = "my-registry.io/library/single-arch-amd64-image:latest"
@@ -30,11 +25,11 @@ const (
 // We use a function instead of a global variable to force immutability
 func MockImagesArchitectureMap() map[string]sets.Set[string] {
 	return map[string]sets.Set[string]{
-		SingleArchAmd64Image: sets.New[string](ArchitectureAmd64),
-		SingleArchArm64Image: sets.New[string](ArchitectureArm64),
-		MultiArchImage:       sets.New[string](ArchitectureAmd64, ArchitectureArm64),
-		MultiArchImage2: sets.New[string](ArchitectureAmd64, ArchitectureArm64,
-			ArchitecturePpc64le, ArchitectureS390x),
+		SingleArchAmd64Image: sets.New[string](utils.ArchitectureAmd64),
+		SingleArchArm64Image: sets.New[string](utils.ArchitectureArm64),
+		MultiArchImage:       sets.New[string](utils.ArchitectureAmd64, utils.ArchitectureArm64),
+		MultiArchImage2: sets.New[string](utils.ArchitectureAmd64, utils.ArchitectureArm64,
+			utils.ArchitecturePpc64le, utils.ArchitectureS390x),
 	}
 }
 

--- a/pkg/testing/image/fake/registry/seed.go
+++ b/pkg/testing/image/fake/registry/seed.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake"
+	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 )
 
 const (
@@ -56,7 +56,7 @@ func GetMockImages() []MockImage {
 		for _, mediaType := range imageMediaTypes() {
 			if manifest.MIMETypeIsMultiImage(mediaType) {
 				mockImages = append(mockImages, MockImage{
-					Architectures: sets.New[string](fake.ArchitectureArm64, fake.ArchitectureAmd64),
+					Architectures: sets.New[string](utils.ArchitectureArm64, utils.ArchitectureAmd64),
 					MediaType:     mediaType,
 					Repository:    repo,
 					Name:          ComputeNameByMediaType(mediaType),
@@ -64,7 +64,7 @@ func GetMockImages() []MockImage {
 				})
 			} else {
 				mockImages = append(mockImages, MockImage{
-					Architectures: sets.New[string](fake.ArchitecturePpc64le),
+					Architectures: sets.New[string](utils.ArchitecturePpc64le),
 					MediaType:     mediaType,
 					Repository:    repo,
 					Name:          ComputeNameByMediaType(mediaType),

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -1,7 +1,24 @@
 package utils
 
 const (
-	OperandLabelKey   = "multiarch.openshift.io/operand"
 	ControllerNameKey = "controller"
+	OperandLabelKey   = "multiarch.openshift.io/operand"
 	OperatorName      = "multiarch-manager-operator"
+)
+
+const (
+	ArchitectureAmd64   = "amd64"
+	ArchitectureArm64   = "arm64"
+	ArchitecturePpc64le = "ppc64le"
+	ArchitectureS390x   = "s390x"
+)
+
+const (
+	ArchLabel                       = "kubernetes.io/arch"
+	NodeAffinityLabel               = "multiarch.openshift.io/node-affinity"
+	NodeAffinityLabelValueSet       = "set"
+	NodeAffinityLabelValueUnset     = "unset"
+	SchedulingGateLabel             = "multiarch.openshift.io/scheduling-gate"
+	SchedulingGateLabelValueGated   = "gated"
+	SchedulingGateLabelValueRemoved = "removed"
 )

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,20 +1,5 @@
 package utils
 
-import (
-	"sort"
-
-	v1 "k8s.io/api/core/v1"
-)
-
 func NewPtr[T any](a T) *T {
 	return &a
-}
-
-func SortMatchExpressions(nst []v1.NodeSelectorTerm) []v1.NodeSelectorTerm {
-	for _, term := range nst {
-		for _, req := range term.MatchExpressions {
-			sort.Strings(req.Values)
-		}
-	}
-	return nst
 }


### PR DESCRIPTION
This PR implements a Gomega matcher between a Pod and an expected affinity. It also adds a basic e2e test case that checks whether the pods of a deployment consuming an image hosted by a public registry get their patch.

Furthermore, minor fixes and general enhancement in the code base are performed:
- Some const have been moved to the utils package so that they can be consumed without risks of raising circular dependencies
- The testing.utils package is renamed to testing.framework as too many utils files were arising
- The (testing-focused) sortMatcheExpression function has been improved to consider more edge cases (and it also needs testing yet)
- Minor fixes related to the testing suite(s)