### PR TITLE
The PodPlacementController need to use SecurityContextConstraints

### DIFF
--- a/bundle/manifests/multiarch-manager-operator-podplacement-controller-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/multiarch-manager-operator-podplacement-controller-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -55,3 +55,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/config/podplacement/podplacement_controller_role.yaml
+++ b/config/podplacement/podplacement_controller_role.yaml
@@ -55,3 +55,9 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -195,6 +195,19 @@ func buildDeployment(podPlacementConfig *v1alpha1.PodPlacementConfig,
 									corev1.ResourceMemory: resource.MustParse("128Mi"),
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: utils.NewPtr(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
+								Privileged:   utils.NewPtr(false),
+								RunAsNonRoot: utils.NewPtr(true),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "webhook-server-cert",

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -6,6 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -58,9 +59,109 @@ var _ = Describe("The Pod Placement Operand", func() {
 			}
 			err = client.Create(ctx, &d)
 			Expect(err).NotTo(HaveOccurred())
-			r, err := labels.NewRequirement("app", "in", []string{"test"})
-			labelSelector := labels.NewSelector().Add(*r)
+			verifyPodNodeAffinity(ns, "app", "test", utils.ArchitectureAmd64,
+				utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le)
+		})
+		It("should set the node affinity on privileged deployments", func() {
+			var err error
+			ns := framework.NewEphemeralNamespace()
+			ns.Labels = map[string]string{
+				"pod-security.kubernetes.io/audit":               "privileged",
+				"pod-security.kubernetes.io/warn":                "privileged",
+				"pod-security.kubernetes.io/enforce":             "privileged",
+				"security.openshift.io/scc.podSecurityLabelSync": "false",
+			}
+			err = client.Create(ctx, ns)
 			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, ns)
+			// Since the CRB to enable using SCCs is cluster-scoped, build its name based on the NS to
+			// ensure concurrency safety with other possible test cases
+			ephemeralCRBName := framework.NormalizeNameString("priv-scc-" + ns.Name)
+
+			crb := &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ephemeralCRBName,
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     "system:openshift:scc:privileged",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "default",
+						Namespace: ns.Name,
+					},
+				},
+			}
+			err = client.Create(ctx, crb)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, crb)
+
+			d := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: ns.Name,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: utils.NewPtr(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "test",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test",
+									Image: helloOpenshiftPublicMultiarchImage,
+									SecurityContext: &corev1.SecurityContext{
+										Privileged: utils.NewPtr(true),
+										RunAsGroup: utils.NewPtr(int64(0)),
+										RunAsUser:  utils.NewPtr(int64(0)),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeUnconfined,
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "test-hostpath",
+											MountPath: "/mnt/hostpath",
+										},
+									},
+								},
+							},
+							ServiceAccountName: "default",
+							Volumes: []corev1.Volume{
+								{
+									Name: "test-hostpath",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/var/lib/kubelet/config.json",
+											Type: utils.NewPtr(corev1.HostPathFile),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err = client.Create(ctx, &d)
+			Expect(err).NotTo(HaveOccurred())
+			// TODO: verify the pod has some scc label
+			r, err := labels.NewRequirement("app", "in", []string{"test"})
+			Expect(err).NotTo(HaveOccurred())
+			labelSelector := labels.NewSelector().Add(*r)
 			Eventually(func(g Gomega) {
 				pods := &corev1.PodList{}
 				err := client.List(ctx, pods, &runtimeclient.ListOptions{
@@ -69,24 +170,43 @@ var _ = Describe("The Pod Placement Operand", func() {
 				})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(pods.Items).NotTo(BeEmpty())
-				g.Expect(pods.Items).To(HaveEach(framework.HaveEquivalentNodeAffinity(
-					&corev1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-							NodeSelectorTerms: []corev1.NodeSelectorTerm{
-								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{
-										{
-											Key:      utils.ArchLabel,
-											Operator: corev1.NodeSelectorOpIn,
-											Values:   []string{utils.ArchitectureAmd64, utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le},
-										},
-									},
-								},
-							},
-						},
-					})))
-			}, e2e.WaitShort).Should(Succeed())
-			Expect(err).NotTo(HaveOccurred())
+				pod := pods.Items[0]
+				g.Expect(pod.Annotations).NotTo(BeEmpty())
+				g.Expect(pod.Annotations).To(HaveKeyWithValue("openshift.io/scc", "privileged"))
+			})
+			verifyPodNodeAffinity(ns, "app", "test", utils.ArchitectureAmd64,
+				utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le)
 		})
 	})
 })
+
+func verifyPodNodeAffinity(ns *corev1.Namespace, labelKey string, labelInValue string, supportedArch ...string) {
+	r, err := labels.NewRequirement(labelKey, "in", []string{labelInValue})
+	labelSelector := labels.NewSelector().Add(*r)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(func(g Gomega) {
+		pods := &corev1.PodList{}
+		err := client.List(ctx, pods, &runtimeclient.ListOptions{
+			Namespace:     ns.Name,
+			LabelSelector: labelSelector,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(pods.Items).NotTo(BeEmpty())
+		g.Expect(pods.Items).To(HaveEach(framework.HaveEquivalentNodeAffinity(
+			&corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      utils.ArchLabel,
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   supportedArch,
+								},
+							},
+						},
+					},
+				},
+			})))
+	}, e2e.WaitShort).Should(Succeed())
+}

--- a/pkg/testing/framework/namespace.go
+++ b/pkg/testing/framework/namespace.go
@@ -7,14 +7,18 @@ import (
 )
 
 func NewEphemeralNamespace() *corev1.Namespace {
-	name := "t-" + uuid.NewString()
-	if len(name) > 63 {
-		name = name[:63]
-	}
+	name := NormalizeNameString("t-" + uuid.NewString())
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
 	return ns
+}
+
+func NormalizeNameString(name string) string {
+	if len(name) > 63 {
+		return name[:63]
+	}
+	return name
 }


### PR DESCRIPTION
When the PodPlacementController tries to patch a pod that requires a SecurityContextConstraint different than the default one in OCP (restricted-v2), the patch was not be admitted because the service account it uses was not allowed to "use" securitycontextconstrains. This commit adds this permission in the PodPlacementController's ClusterRoleBinding. Since it can now use SCC different than the default, we also force the security context constraint specs in the deployments of the operands.

The webhook is already ok as the request being patched when it operates comes from another user/service account: the user's one.

Fixes #41 