### PR TITLE
MIXEDARCH-442: Add test for nodeAffinity conflict or non conflict

### DIFF
--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake"
 	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 
-	. "github.com/openshift/multiarch-manager-operator/pkg/testing/framework"
+	. "github.com/openshift/multiarch-manager-operator/pkg/testing/builder"
 )
 
 var ctx context.Context

--- a/controllers/podplacement/pod_reconciler_test.go
+++ b/controllers/podplacement/pod_reconciler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/multiarch-manager-operator/pkg/utils"
 
+	. "github.com/openshift/multiarch-manager-operator/pkg/testing/builder"
 	. "github.com/openshift/multiarch-manager-operator/pkg/testing/framework"
 	"github.com/openshift/multiarch-manager-operator/pkg/testing/image/fake/registry"
 )

--- a/pkg/testing/builder/cluster_role_binding_builder.go
+++ b/pkg/testing/builder/cluster_role_binding_builder.go
@@ -1,0 +1,40 @@
+package builder
+
+import (
+	v1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRoleBindingBuilder is a builder for v1.ClusterRoleBinding objects to be used only in unit tests.
+type ClusterRoleBindingBuilder struct {
+	clusterRoleBinding v1.ClusterRoleBinding
+}
+
+// NewClusterRoleBinding returns a new ClusterRoleBindingBuilder to build v1.ClusterRoleBinding objects. It is meant to be used only in unit tests.
+func NewClusterRoleBinding() *ClusterRoleBindingBuilder {
+	return &ClusterRoleBindingBuilder{
+		clusterRoleBinding: v1.ClusterRoleBinding{},
+	}
+}
+
+func (c *ClusterRoleBindingBuilder) WithRoleRef(apiGroup string, kind string, name string) *ClusterRoleBindingBuilder {
+	c.clusterRoleBinding.RoleRef = v1.RoleRef{
+		APIGroup: apiGroup,
+		Kind:     kind,
+		Name:     name,
+	}
+	return c
+}
+
+func (c *ClusterRoleBindingBuilder) WithName(name string) *ClusterRoleBindingBuilder {
+	c.clusterRoleBinding.Name = name
+	return c
+}
+
+func (c *ClusterRoleBindingBuilder) WithSubjects(subjects ...v1.Subject) *ClusterRoleBindingBuilder {
+	c.clusterRoleBinding.Subjects = subjects
+	return c
+}
+
+func (c *ClusterRoleBindingBuilder) Build() v1.ClusterRoleBinding {
+	return c.clusterRoleBinding
+}

--- a/pkg/testing/builder/container_builder.go
+++ b/pkg/testing/builder/container_builder.go
@@ -1,0 +1,45 @@
+package builder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// ContainerBuilder is a builder for v1.Container objects to be used only in unit tests.
+type ContainerBuilder struct {
+	container v1.Container
+}
+
+// NewContainer returns a new ContainerBuilder to build v1.Container objects. It is meant to be used only in unit tests.
+func NewContainer() *ContainerBuilder {
+	return &ContainerBuilder{
+		container: v1.Container{},
+	}
+}
+
+func (c *ContainerBuilder) WithImage(image string) *ContainerBuilder {
+	hasher := sha256.New()
+	hasher.Write([]byte(image))
+
+	c.container = v1.Container{
+		Image: image,
+		Name:  hex.EncodeToString(hasher.Sum(nil))[:63], // hash of the image name (63 is max)
+	}
+	return c
+}
+
+func (c *ContainerBuilder) WithSecurityContext(securityContext *v1.SecurityContext) *ContainerBuilder {
+	c.container.SecurityContext = securityContext
+	return c
+}
+
+func (c *ContainerBuilder) WithVolumeMounts(volumeMounts ...v1.VolumeMount) *ContainerBuilder {
+	c.container.VolumeMounts = volumeMounts
+	return c
+}
+
+func (c *ContainerBuilder) Build() v1.Container {
+	return c.container
+}

--- a/pkg/testing/builder/deployment_builder.go
+++ b/pkg/testing/builder/deployment_builder.go
@@ -1,0 +1,63 @@
+package builder
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DeploymentBuilder is a builder for appsv1.Deployment objects to be used only in unit tests.
+type DeploymentBuilder struct {
+	deployment appsv1.Deployment
+}
+
+// NewDeployment returns a new DeploymentBuilder to build appsv1.Deployment objects. It is meant to be used only in unit tests.
+func NewDeployment() *DeploymentBuilder {
+	return &DeploymentBuilder{
+		deployment: appsv1.Deployment{},
+	}
+}
+
+func (d *DeploymentBuilder) WithPodSpec(ps corev1.PodSpec) *DeploymentBuilder {
+	d.deployment.Spec.Template.Spec = ps
+	return d
+}
+
+func (d *DeploymentBuilder) WithReplicas(num *int32) *DeploymentBuilder {
+	d.deployment.Spec.Replicas = num
+	return d
+}
+
+func (d *DeploymentBuilder) WithSelectorAndPodLabels(kv ...string) *DeploymentBuilder {
+	if d.deployment.Spec.Template.Labels == nil {
+		d.deployment.Spec.Template.Labels = make(map[string]string)
+	}
+	if d.deployment.Spec.Selector == nil {
+		d.deployment.Spec.Selector = &metav1.LabelSelector{}
+	}
+	if d.deployment.Spec.Selector.MatchLabels == nil {
+		d.deployment.Spec.Selector.MatchLabels = make(map[string]string)
+	}
+	if len(kv)%2 != 0 {
+		panic("the number of arguments must be even")
+	}
+	for i := 0; i < len(kv); i += 2 {
+		d.deployment.Spec.Template.Labels[kv[i]] = kv[i+1]
+		d.deployment.Spec.Selector.MatchLabels[kv[i]] = kv[i+1]
+	}
+	return d
+}
+
+func (d *DeploymentBuilder) WithName(name string) *DeploymentBuilder {
+	d.deployment.Name = name
+	return d
+}
+
+func (d *DeploymentBuilder) WithNamespace(namespace string) *DeploymentBuilder {
+	d.deployment.Namespace = namespace
+	return d
+}
+
+func (d *DeploymentBuilder) Build() appsv1.Deployment {
+	return d.deployment
+}

--- a/pkg/testing/builder/node_selector_requirement_builder.go
+++ b/pkg/testing/builder/node_selector_requirement_builder.go
@@ -1,0 +1,28 @@
+package builder
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// NodeSelectorRequirementBuilder is a builder for v1.NodeSelectorRequirement objects to be used only in unit tests.
+type NodeSelectorRequirementBuilder struct {
+	nodeSelectorRequirement v1.NodeSelectorRequirement
+}
+
+// NewNodeSelectorRequirement returns a new NodeSelectorRequirementBuilder to build v1.NodeSelectorRequirement objects. It is meant to be used only in unit tests.
+func NewNodeSelectorRequirement() *NodeSelectorRequirementBuilder {
+	return &NodeSelectorRequirementBuilder{
+		nodeSelectorRequirement: v1.NodeSelectorRequirement{},
+	}
+}
+
+func (n *NodeSelectorRequirementBuilder) WithKeyAndValues(key string, operator v1.NodeSelectorOperator, values ...string) *NodeSelectorRequirementBuilder {
+	n.nodeSelectorRequirement.Key = key
+	n.nodeSelectorRequirement.Operator = operator
+	n.nodeSelectorRequirement.Values = values
+	return n
+}
+
+func (n *NodeSelectorRequirementBuilder) Build() v1.NodeSelectorRequirement {
+	return n.nodeSelectorRequirement
+}

--- a/pkg/testing/builder/node_selector_term_builder.go
+++ b/pkg/testing/builder/node_selector_term_builder.go
@@ -1,0 +1,41 @@
+package builder
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// NodeSelectorTermBuilder is a builder for v1.NodeSelectorTerm objects to be used only in unit tests.
+type NodeSelectorTermBuilder struct {
+	nodeSelectorTerm v1.NodeSelectorTerm
+}
+
+// NewNodeSelectorTerm returns a new NodeSelectorTermBuilder to build v1.NodeSelectorTerm objects. It is meant to be used only in unit tests.
+func NewNodeSelectorTerm() *NodeSelectorTermBuilder {
+	return &NodeSelectorTermBuilder{
+		nodeSelectorTerm: v1.NodeSelectorTerm{},
+	}
+}
+
+func (n *NodeSelectorTermBuilder) WithMatchExpressions(values ...*v1.NodeSelectorRequirement) *NodeSelectorTermBuilder {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithMatchExpressions")
+		}
+		n.nodeSelectorTerm.MatchExpressions = append(n.nodeSelectorTerm.MatchExpressions, *values[i])
+	}
+	return n
+}
+
+func (n *NodeSelectorTermBuilder) WithMatchFields(values ...*v1.NodeSelectorRequirement) *NodeSelectorTermBuilder {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithMatchExpressions")
+		}
+		n.nodeSelectorTerm.MatchFields = append(n.nodeSelectorTerm.MatchFields, *values[i])
+	}
+	return n
+}
+
+func (n *NodeSelectorTermBuilder) Build() v1.NodeSelectorTerm {
+	return n.nodeSelectorTerm
+}

--- a/pkg/testing/builder/pod_spec_builder.go
+++ b/pkg/testing/builder/pod_spec_builder.go
@@ -1,0 +1,132 @@
+package builder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// PodSpecBuilder is a builder for v1.PodSpec objects to be used only in unit tests.
+type PodSpecBuilder struct {
+	podspec v1.PodSpec
+}
+
+// NewPodSpec returns a new PodSpecBuilder to build v1.PodSpec objects. It is meant to be used only in unit tests.
+func NewPodSpec() *PodSpecBuilder {
+	return &PodSpecBuilder{
+		podspec: v1.PodSpec{},
+	}
+}
+
+func (ps *PodSpecBuilder) WithImagePullSecrets(imagePullSecrets ...string) *PodSpecBuilder {
+	ps.podspec.ImagePullSecrets = make([]v1.LocalObjectReference, len(imagePullSecrets))
+	for i, secret := range imagePullSecrets {
+		ps.podspec.ImagePullSecrets[i] = v1.LocalObjectReference{
+			Name: secret,
+		}
+	}
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithSchedulingGates(schedulingGates ...string) *PodSpecBuilder {
+	ps.podspec.SchedulingGates = make([]v1.PodSchedulingGate, len(schedulingGates))
+	for i, gate := range schedulingGates {
+		ps.podspec.SchedulingGates[i] = v1.PodSchedulingGate{
+			Name: gate,
+		}
+	}
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithContainers(containers ...v1.Container) *PodSpecBuilder {
+	ps.podspec.Containers = containers
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithContainersImages(images ...string) *PodSpecBuilder {
+	ps.podspec.Containers = make([]v1.Container, len(images))
+
+	for i, image := range images {
+		// compute hash of the image name using SHA-256
+		hasher := sha256.New()
+		hasher.Write([]byte(image))
+
+		ps.podspec.Containers[i] = v1.Container{
+			Image: image,
+			Name:  hex.EncodeToString(hasher.Sum(nil))[:63], // hash of the image name (63 is max)
+		}
+	}
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithInitContainersImages(images ...string) *PodSpecBuilder {
+	ps.podspec.InitContainers = make([]v1.Container, len(images))
+	for i, image := range images {
+		ps.podspec.InitContainers[i] = v1.Container{
+			Image: image,
+		}
+	}
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithVolumes(volumes ...v1.Volume) *PodSpecBuilder {
+	ps.podspec.Volumes = volumes
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithServiceAccountName(serviceAccountName string) *PodSpecBuilder {
+	ps.podspec.ServiceAccountName = serviceAccountName
+	return ps
+}
+
+// WithAffinity adds the affinity to the pod. If initialAffinity is not nil, it is used as the initial value
+// of the pod's affinity. Otherwise, the pod's affinity is initialized to an empty affinity if it is nil.
+func (ps *PodSpecBuilder) WithAffinity(initialAffinity *v1.Affinity) *PodSpecBuilder {
+	if ps.podspec.Affinity == nil {
+		ps.podspec.Affinity = &v1.Affinity{}
+	}
+	if initialAffinity != nil {
+		ps.podspec.Affinity = initialAffinity
+	}
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithNodeAffinity() *PodSpecBuilder {
+	ps.WithAffinity(nil)
+	if ps.podspec.Affinity.NodeAffinity == nil {
+		ps.podspec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithRequiredDuringSchedulingIgnoredDuringExecution() *PodSpecBuilder {
+	ps.WithNodeAffinity()
+	if ps.podspec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		ps.podspec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+	}
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithNodeSelectorTerms(nodeSelectorTerms ...v1.NodeSelectorTerm) *PodSpecBuilder {
+	ps.WithRequiredDuringSchedulingIgnoredDuringExecution()
+	ps.podspec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = nodeSelectorTerms
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithNodeSelectors(kv ...string) *PodSpecBuilder {
+	if ps.podspec.NodeSelector == nil {
+		ps.podspec.NodeSelector = make(map[string]string)
+	}
+	if len(kv)%2 != 0 {
+		panic("the number of arguments must be even")
+	}
+	for i := 0; i < len(kv); i += 2 {
+		ps.podspec.NodeSelector[kv[i]] = kv[i+1]
+	}
+	return ps
+}
+
+func (ps *PodSpecBuilder) Build() v1.PodSpec {
+	return ps.podspec
+}

--- a/pkg/testing/builder/security_context_builder.go
+++ b/pkg/testing/builder/security_context_builder.go
@@ -1,0 +1,41 @@
+package builder
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// SecurityContextBuilder is a builder for v1.SecurityContext objects to be used only in unit tests.
+type SecurityContextBuilder struct {
+	securityContext v1.SecurityContext
+}
+
+// NewSecurityContext returns a new SecurityContextBuilder to build v1.SecurityContext objects. It is meant to be used only in unit tests.
+func NewSecurityContext() *SecurityContextBuilder {
+	return &SecurityContextBuilder{
+		securityContext: v1.SecurityContext{},
+	}
+}
+
+func (s *SecurityContextBuilder) WithPrivileged(privileged *bool) *SecurityContextBuilder {
+	s.securityContext.Privileged = privileged
+	return s
+}
+
+func (s *SecurityContextBuilder) WithRunAsGroup(group *int64) *SecurityContextBuilder {
+	s.securityContext.RunAsGroup = group
+	return s
+}
+
+func (s *SecurityContextBuilder) WithRunAsUSer(user *int64) *SecurityContextBuilder {
+	s.securityContext.RunAsUser = user
+	return s
+}
+
+func (s *SecurityContextBuilder) WithSeccompProfileType(seccompProfileType v1.SeccompProfileType) *SecurityContextBuilder {
+	s.securityContext.SeccompProfile.Type = seccompProfileType
+	return s
+}
+
+func (s *SecurityContextBuilder) Build() v1.SecurityContext {
+	return s.securityContext
+}

--- a/pkg/testing/builder/subject_builder.go
+++ b/pkg/testing/builder/subject_builder.go
@@ -1,0 +1,36 @@
+package builder
+
+import (
+	v1 "k8s.io/api/rbac/v1"
+)
+
+// DeploymentBuilder is a builder for v1.Subject objects to be used only in unit tests.
+type SubjectBuilder struct {
+	subject v1.Subject
+}
+
+// NewSubject returns a new DeploymentBuilder to build v1.Subject objects. It is meant to be used only in unit tests.
+func NewSubject() *SubjectBuilder {
+	return &SubjectBuilder{
+		subject: v1.Subject{},
+	}
+}
+
+func (s *SubjectBuilder) WithKind(kind string) *SubjectBuilder {
+	s.subject.Kind = kind
+	return s
+}
+
+func (s *SubjectBuilder) WithName(name string) *SubjectBuilder {
+	s.subject.Name = name
+	return s
+}
+
+func (s *SubjectBuilder) WithNamespace(namespace string) *SubjectBuilder {
+	s.subject.Namespace = namespace
+	return s
+}
+
+func (s *SubjectBuilder) Build() v1.Subject {
+	return s.subject
+}

--- a/pkg/testing/builder/volume_builder.go
+++ b/pkg/testing/builder/volume_builder.go
@@ -1,0 +1,33 @@
+package builder
+
+import v1 "k8s.io/api/core/v1"
+
+// VolumeBuilder is a builder for v1.Volume objects to be used only in unit tests.
+type VolumeBuilder struct {
+	volume v1.Volume
+}
+
+// NewVolume returns a new VolumeBuilder to build v1.Volume objects. It is meant to be used only in unit tests.
+func NewVolume() *VolumeBuilder {
+	return &VolumeBuilder{
+		volume: v1.Volume{},
+	}
+}
+
+func (v *VolumeBuilder) WithName(name string) *VolumeBuilder {
+	v.volume.Name = name
+	return v
+}
+
+func (v *VolumeBuilder) WithVolumeSourceHostPath(path string, pathType *v1.HostPathType) *VolumeBuilder {
+	if v.volume.VolumeSource.HostPath == nil {
+		v.volume.VolumeSource.HostPath = &v1.HostPathVolumeSource{}
+	}
+	v.volume.VolumeSource.HostPath.Path = path
+	v.volume.VolumeSource.HostPath.Type = pathType
+	return v
+}
+
+func (v *VolumeBuilder) Build() v1.Volume {
+	return v.volume
+}

--- a/pkg/testing/builder/volume_mount_builder.go
+++ b/pkg/testing/builder/volume_mount_builder.go
@@ -1,0 +1,29 @@
+package builder
+
+import v1 "k8s.io/api/core/v1"
+
+// VolumeMountBuilder is a builder for v1.VolumeMount objects to be used only in unit tests.
+type VolumeMountBuilder struct {
+	volumeMount v1.VolumeMount
+}
+
+// NewVolumeMount returns a new VolumeMountBuilder to build v1.VolumeMount objects. It is meant to be used only in unit tests.
+func NewVolumeMount() *VolumeMountBuilder {
+	return &VolumeMountBuilder{
+		volumeMount: v1.VolumeMount{},
+	}
+}
+
+func (v *VolumeMountBuilder) WithName(name string) *VolumeMountBuilder {
+	v.volumeMount.Name = name
+	return v
+}
+
+func (v *VolumeMountBuilder) WithMountPath(path string) *VolumeMountBuilder {
+	v.volumeMount.MountPath = path
+	return v
+}
+
+func (v *VolumeMountBuilder) Build() v1.VolumeMount {
+	return v.volumeMount
+}

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -18,6 +18,7 @@ const (
 	NodeAffinityLabel               = "multiarch.openshift.io/node-affinity"
 	NodeAffinityLabelValueSet       = "set"
 	NodeAffinityLabelValueUnset     = "unset"
+	HostnameLabel                   = "kubernetes.io/hostname"
 	SchedulingGateLabel             = "multiarch.openshift.io/scheduling-gate"
 	SchedulingGateLabelValueGated   = "gated"
 	SchedulingGateLabelValueRemoved = "removed"

--- a/test/manifests/08-example-node-selector.yaml
+++ b/test/manifests/08-example-node-selector.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: example-node-selector-
+  labels:
+    app: httpd
+  annotations:
+    result: "This pod should set Affinity to nil."
+spec:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: httpd
+      image: 'quay.io/openshifttest/hello-openshift:1.2.0'
+      ports:
+        - containerPort: 8080
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL

--- a/test/manifests/09-example-multiple-affinity.yaml
+++ b/test/manifests/09-example-multiple-affinity.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: node-multiple-affinity-
+  labels:
+    app: httpd
+  annotations:
+    result: "This pod should get an affinity set in the non-conflicting matchExpressions, while keep the original set in the conflicting one."
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - arm64
+          - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: Exists
+  containers:
+    - name: httpd
+      image: 'quay.io/openshifttest/hello-openshift:1.2.0'
+      ports:
+        - containerPort: 8080
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL


### PR DESCRIPTION
Add test for nodeAffinity conflict or non conflict

- Add one testcase for nodeAffinity non-conflicting test
- Add one testcase for nodeAffinity conflicting test
- Add one testcase for nodeSeletor test
- Add one testcase for multiple MatchExpressions test, one has conflicting, another doesn't