### PR TITLE
Removed temporary <1.29 bug workaround for nil affinity

### DIFF
--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -542,7 +542,7 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 		},
 		{
 			name: "pod with no node affinity",
-			pod:  NewPod().WithContainersImages(fake.MultiArchImage).WithAffinity(nil).Build(),
+			pod:  NewPod().WithContainersImages(fake.MultiArchImage).Build(),
 			want: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectorTermsMatchExpressions(
 				[]v1.NodeSelectorRequirement{
 					{

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -86,11 +86,6 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 
 	pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, schedulingGate)
 
-	// Temporary workaround. TODO[aleskandro]: remove when kubernetes/kubernetes#118052 is fixed.
-	if pod.Spec.Affinity == nil {
-		pod.Spec.Affinity = &corev1.Affinity{}
-	}
-
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -236,8 +236,7 @@ func verifyPodNodeAffinity(ns *corev1.Namespace, labelKey string, labelInValue s
 		if len(nodeSelectorTerms) == 0 {
 			g.Expect(pods.Items).To(HaveEach(WithTransform(func(p corev1.Pod) *corev1.Affinity {
 				return p.Spec.Affinity
-			}, Equal(&corev1.Affinity{NodeAffinity: nil, PodAffinity: nil, PodAntiAffinity: nil}))))
-			// TODO: Change Equal(...) to BeNil() when MIXEDARCH-430 is done.
+			}, BeNil())))
 		} else {
 			g.Expect(pods.Items).To(HaveEach(framework.HaveEquivalentNodeAffinity(
 				&corev1.NodeAffinity{


### PR DESCRIPTION
[MIXEDARCH-430](https://issues.redhat.com//browse/MIXEDARCH-430): Removed temporary <1.29 bug workaround for nil affinity
