### PR TITLE
Enable source build and fork the Dockerfile to build the enterprise image with Konflux

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -113,7 +113,7 @@ spec:
         description: Image tag expiration time, time values could be something like
           1h, 2d, 3w for hours, days, and weeks, respectively.
         name: image-expires-after
-      - default: "false"
+      - default: "true"
         description: Build a source image.
         name: build-source-image
         type: string

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -110,7 +110,7 @@ spec:
         description: Image tag expiration time, time values could be something like
           1h, 2d, 3w for hours, days, and weeks, respectively.
         name: image-expires-after
-      - default: "false"
+      - default: "true"
         description: Build a source image.
         name: build-source-image
         type: string

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -113,7 +113,7 @@ spec:
         description: Image tag expiration time, time values could be something like
           1h, 2d, 3w for hours, days, and weeks, respectively.
         name: image-expires-after
-      - default: "false"
+      - default: "true"
         description: Build a source image.
         name: build-source-image
         type: string

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -19,7 +19,8 @@ metadata:
 spec:
   params:
     - name: dockerfile
-      value: Dockerfile
+      value: konflux.Dockerfile
+      # TODO: change to Dockerfile when https://issues.redhat.com/browse/KONFLUX-2361
     - name: git-url
       value: '{{source_url}}'
     - name: image-expires-after

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -110,7 +110,7 @@ spec:
         description: Image tag expiration time, time values could be something like
           1h, 2d, 3w for hours, days, and weeks, respectively.
         name: image-expires-after
-      - default: "false"
+      - default: "true"
         description: Build a source image.
         name: build-source-image
         type: string

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -18,7 +18,8 @@ metadata:
 spec:
   params:
     - name: dockerfile
-      value: Dockerfile
+      value: konflux.Dockerfile
+      # TODO: change to Dockerfile when https://issues.redhat.com/browse/KONFLUX-2361
     - name: git-url
       value: '{{source_url}}'
     - name: output-image

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,0 +1,34 @@
+# TODO: delete this Dockerfile when https://issues.redhat.com/browse/KONFLUX-2361
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
+ARG TARGETARCH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY apis/ apis/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+COPY vendor/ vendor/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-enterprise-base-multi-openshift-4.16
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Continuing with the Konflux builds onboarding. The release plan and the pipeline changes required for replacing the images refs in the bundle will follow up.

As Konflux cannot replace build contexts yet, this PR includes a temporary commit to revert when Konflux will make us able to replace base images without manual changes to the Dockerfile: https://github.com/openshift/multiarch-tuning-operator/pull/56/commits/4075e32c6181cece370ee7e12b69518524adcea7