### PR TITLE
Konflux build bundle with image ref replacement

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
     - name: dockerfile
-      value: bundle.Dockerfile
+      value: bundle.konflux.Dockerfile
     - name: git-url
       value: '{{source_url}}'
     - name: image-expires-after

--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -26,6 +26,8 @@ spec:
       value: 5d
     - name: output-image
       value: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator-bundle:on-pr-{{revision}}
+    - name: operator-image
+      value: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator:on-pr-{{revision}}
     - name: path-context
       value: .
     - name: revision
@@ -134,6 +136,74 @@ spec:
         name: JAVA_COMMUNITY_DEPENDENCIES
         value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
+      - name: replace-img-arg
+        runAfter:
+          - clone-repository
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - image: quay.io/centos/centos:stream9-minimal
+              command:
+                - /bin/sed
+              args:
+                - -i
+                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
+                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
+        workspaces:
+          - name: workspace
+            workspace: workspace
+      - name: replace-img-arg-arm64
+        runAfter:
+          - clone-repository-arm64
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - image: quay.io/centos/centos:stream9-minimal
+              command:
+                - /bin/sed
+              args:
+                - -i
+                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
+                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
+        workspaces:
+          - name: workspace
+            workspace: workspace-arm64
+      - name: replace-img-arg-ppc64le
+        runAfter:
+          - clone-repository-ppc64le
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - image: quay.io/centos/centos:stream9-minimal
+              command:
+                - /bin/sed
+              args:
+                - -i
+                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
+                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
+        workspaces:
+          - name: workspace
+            workspace: workspace-ppc64le
+      - name: replace-img-arg-s390x
+        runAfter:
+          - clone-repository-s390x
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - image: quay.io/centos/centos:stream9-minimal
+              command:
+                - /bin/sed
+              args:
+                - -i
+                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
+                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
+        workspaces:
+          - name: workspace
+            workspace: workspace-s390x
       - name: init
         params:
           - name: image-url
@@ -303,6 +373,7 @@ spec:
             value: $(tasks.clone-repository.results.commit)
         runAfter:
           - prefetch-dependencies
+          - replace-img-arg
         taskRef:
           params:
             - name: name
@@ -339,7 +410,7 @@ spec:
           - name: PLATFORM
             value: linux/arm64
         runAfter:
-          - clone-repository-arm64
+          - replace-img-arg-arm64
         taskRef:
           params:
             - name: name
@@ -376,7 +447,7 @@ spec:
           - name: PLATFORM
             value: linux/s390x
         runAfter:
-          - clone-repository-s390x
+          - replace-img-arg-s390x
         taskRef:
           params:
             - name: name
@@ -414,7 +485,7 @@ spec:
           - name: PLATFORM
             value: linux/ppc64le
         runAfter:
-          - clone-repository-ppc64le
+          - replace-img-arg-ppc64le
         taskRef:
           params:
             - name: name

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
     - name: dockerfile
-      value: bundle.Dockerfile
+      value: bundle.konflux.Dockerfile
     - name: git-url
       value: '{{source_url}}'
     - name: output-image

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -23,6 +23,8 @@ spec:
       value: '{{source_url}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator-bundle:{{revision}}
+    - name: operator-image
+      value: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator:{{revision}}
     - name: path-context
       value: .
     - name: revision
@@ -131,6 +133,74 @@ spec:
         name: JAVA_COMMUNITY_DEPENDENCIES
         value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
+      - name: replace-img-arg
+        runAfter:
+          - clone-repository
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - image: quay.io/centos/centos:stream9-minimal
+              command:
+                - /bin/sed
+              args:
+                - -i
+                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
+                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
+        workspaces:
+          - name: workspace
+            workspace: workspace
+      - name: replace-img-arg-arm64
+        runAfter:
+          - clone-repository-arm64
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - image: quay.io/centos/centos:stream9-minimal
+              command:
+                - /bin/sed
+              args:
+                - -i
+                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
+                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
+        workspaces:
+          - name: workspace
+            workspace: workspace-arm64
+      - name: replace-img-arg-ppc64le
+        runAfter:
+          - clone-repository-ppc64le
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - image: quay.io/centos/centos:stream9-minimal
+              command:
+                - /bin/sed
+              args:
+                - -i
+                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
+                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
+        workspaces:
+          - name: workspace
+            workspace: workspace-ppc64le
+      - name: replace-img-arg-s390x
+        runAfter:
+          - clone-repository-s390x
+        taskSpec:
+          workspaces:
+            - name: workspace
+          steps:
+            - image: quay.io/centos/centos:stream9-minimal
+              command:
+                - /bin/sed
+              args:
+                - -i
+                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
+                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
+        workspaces:
+          - name: workspace
+            workspace: workspace-s390x
       - name: init
         params:
           - name: image-url
@@ -300,6 +370,7 @@ spec:
             value: $(tasks.clone-repository.results.commit)
         runAfter:
           - prefetch-dependencies
+          - replace-image-arg
         taskRef:
           params:
             - name: name
@@ -336,7 +407,7 @@ spec:
           - name: PLATFORM
             value: linux/arm64
         runAfter:
-          - clone-repository-arm64
+          - replace-img-arg-arm64
         taskRef:
           params:
             - name: name
@@ -373,7 +444,7 @@ spec:
           - name: PLATFORM
             value: linux/s390x
         runAfter:
-          - clone-repository-s390x
+          - replace-image-arg-s390x
         taskRef:
           params:
             - name: name
@@ -411,7 +482,7 @@ spec:
           - name: PLATFORM
             value: linux/ppc64le
         runAfter:
-          - clone-repository-ppc64le
+          - replace-image-arg-ppc64le
         taskRef:
           params:
             - name: name

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/base:latest
+FROM scratch
+
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -8,7 +8,8 @@ COPY --from=osdk /usr/local/bin/operator-sdk /usr/local/bin/
 RUN chmod -R g+rwX /code
 WORKDIR /code
 
-RUN test -n "${IMG}" && make bundle IMG="${IMG}"
+# VERSION is set in the base image to the golang version. However, we want to default to the one set in the Makefile.
+RUN unset VERSION; test -n "${IMG}" && make bundle IMG="${IMG}"
 
 FROM gcr.io/distroless/base:latest
 # Core bundle labels.

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -1,0 +1,31 @@
+FROM quay.io/operator-framework/operator-sdk:v1.26.0 as osdk
+
+# TODO: use another base image when possible (we depend on gpgme-devel)
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
+ARG IMG=''
+COPY . /code
+COPY --from=osdk /usr/local/bin/operator-sdk /usr/local/bin/
+RUN chmod -R g+rwX /code
+WORKDIR /code
+
+RUN test [ -n "${IMG}" ] && make bundle IMG="${IMG}"
+
+FROM gcr.io/distroless/base:latest
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=multiarch-tuning-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.26.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY --from=builder /code/bundle/manifests /manifests/
+COPY --from=builder /code/bundle/metadata /metadata/
+COPY --from=builder /code/bundle/tests/scorecard /tests/scorecard/

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -8,7 +8,7 @@ COPY --from=osdk /usr/local/bin/operator-sdk /usr/local/bin/
 RUN chmod -R g+rwX /code
 WORKDIR /code
 
-RUN test [ -n "${IMG}" ] && make bundle IMG="${IMG}"
+RUN test -n "${IMG}" && make bundle IMG="${IMG}"
 
 FROM gcr.io/distroless/base:latest
 # Core bundle labels.

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -45,12 +45,12 @@ spec:
       kind: PodPlacementConfig
       name: podplacementconfigs.multiarch.openshift.io
       version: v1alpha1
-  description: The Multiarch Tuning Operator enhances the user experience for
-    administrators of Openshift clusters  with multi-architecture compute nodes or
-    Site Reliability Engineers willing to migrate from single-arch to multi-arch OpenShift.
-    When diverse CPU architectures coexist within a cluster, the Multiarch Tuning Operator operator stands
-    out as a pivotal tool to enhance efficiency and streamline operations such as
-    architecture-aware scheduling of workloads.
+  description: The Multiarch Tuning Operator enhances the user experience for administrators
+    of Openshift clusters  with multi-architecture compute nodes or Site Reliability
+    Engineers willing to migrate from single-arch to multi-arch OpenShift. When diverse
+    CPU architectures coexist within a cluster, the Multiarch Tuning Operator operator
+    stands out as a pivotal tool to enhance efficiency and streamline operations such
+    as architecture-aware scheduling of workloads.
   displayName: multiarch-tuning-operator
   icon:
   - base64data: ""

--- a/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -15,12 +15,12 @@ spec:
       kind: PodPlacementConfig
       name: podplacementconfigs.multiarch.openshift.io
       version: v1alpha1
-  description: The Multiarch Tuning Operator enhances the user experience for
-    administrators of Openshift clusters  with multi-architecture compute nodes or
-    Site Reliability Engineers willing to migrate from single-arch to multi-arch OpenShift.
-    When diverse CPU architectures coexist within a cluster, the Multiarch Tuning Operator operator stands
-    out as a pivotal tool to enhance efficiency and streamline operations such as
-    architecture-aware scheduling of workloads.
+  description: The Multiarch Tuning Operator enhances the user experience for administrators
+    of Openshift clusters  with multi-architecture compute nodes or Site Reliability
+    Engineers willing to migrate from single-arch to multi-arch OpenShift. When diverse
+    CPU architectures coexist within a cluster, the Multiarch Tuning Operator operator
+    stands out as a pivotal tool to enhance efficiency and streamline operations such
+    as architecture-aware scheduling of workloads.
   displayName: multiarch-tuning-operator
   icon:
   - base64data: ""


### PR DESCRIPTION
The bundle Dockerfile is re-generated each time make bundle is run. Until the full support for OLM operators is available in konflux, we must use an ad-hoc dockerfile. Therefore we shouldn't modify it for the workarounds due to the Konflux missing features.

Also, Konflux doesn't support setting the build-arg in the buildah(-remote) tasks (see https://issues.redhat.com/browse/KONFLUX-268). This PR adds a task for each arch for each pipelinerun (for each branch?) to build the bundle and refer the correct operator image.