### PR TITLE
MULTIARCH-4312: Add more e2e test for ppo

### DIFF
--- a/pkg/e2e/podplacement/e2e_test.go
+++ b/pkg/e2e/podplacement/e2e_test.go
@@ -11,6 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	ocpappsv1 "github.com/openshift/api/apps/v1"
+	ocpbuildv1 "github.com/openshift/api/build/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,7 +41,13 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	client, clientset, ctx, suiteLog = e2e.CommonBeforeSuite()
-	err := client.Create(ctx, &v1alpha1.PodPlacementConfig{
+	err := ocpappsv1.Install(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ocpbuildv1.Install(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = client.Create(ctx, &v1alpha1.PodPlacementConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
 		},

--- a/pkg/testing/builder/build_builder.go
+++ b/pkg/testing/builder/build_builder.go
@@ -1,0 +1,40 @@
+package builder
+
+import (
+	ocpv1 "github.com/openshift/api/build/v1"
+)
+
+// BuildBuilder is a builder for appsv1.DeploymentConfig objects to be usebonly in unit tests.
+type BuildBuilder struct {
+	build ocpv1.Build
+}
+
+// NewDeployment returns a new BuildBuilder to builbappsv1.DeploymentConfig objects. It is meant to be usebonly in unit tests.
+func NewBuild() *BuildBuilder {
+	return &BuildBuilder{
+		build: ocpv1.Build{},
+	}
+}
+
+func (b *BuildBuilder) WithDockerImage(image string) *BuildBuilder {
+	if b.build.Spec.CommonSpec.Strategy.SourceStrategy == nil {
+		b.build.Spec.CommonSpec.Strategy.SourceStrategy = &ocpv1.SourceBuildStrategy{}
+	}
+	b.build.Spec.CommonSpec.Strategy.SourceStrategy.From.Kind = "DockerImage"
+	b.build.Spec.CommonSpec.Strategy.SourceStrategy.From.Name = image
+	return b
+}
+
+func (b *BuildBuilder) WithName(name string) *BuildBuilder {
+	b.build.Name = name
+	return b
+}
+
+func (b *BuildBuilder) WithNamespace(namespace string) *BuildBuilder {
+	b.build.Namespace = namespace
+	return b
+}
+
+func (b *BuildBuilder) Build() ocpv1.Build {
+	return b.build
+}

--- a/pkg/testing/builder/daemonset_builder.go
+++ b/pkg/testing/builder/daemonset_builder.go
@@ -1,0 +1,55 @@
+package builder
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DaemonSetBuilder is a builder for appsv1.DaemonSet objects to be used only in unit tests.
+type DaemonSetBuilder struct {
+	daemonset appsv1.DaemonSet
+}
+
+// NewDaemonSet returns a new DaemonSetBuilder to build appsv1.DaemonSet objects. It is meant to be used only in unit tests.
+func NewDaemonSet() *DaemonSetBuilder {
+	return &DaemonSetBuilder{
+		daemonset: appsv1.DaemonSet{},
+	}
+}
+
+func (d *DaemonSetBuilder) WithPodSpec(ps corev1.PodSpec) *DaemonSetBuilder {
+	d.daemonset.Spec.Template.Spec = ps
+	return d
+}
+
+func (d *DaemonSetBuilder) WithSelectorAndPodLabels(entries map[string]string) *DaemonSetBuilder {
+	if d.daemonset.Spec.Template.Labels == nil && len(entries) > 0 {
+		d.daemonset.Spec.Template.Labels = make(map[string]string, len(entries))
+	}
+	if d.daemonset.Spec.Selector == nil {
+		d.daemonset.Spec.Selector = &metav1.LabelSelector{}
+	}
+	if d.daemonset.Spec.Selector.MatchLabels == nil && len(entries) > 0 {
+		d.daemonset.Spec.Selector.MatchLabels = make(map[string]string, len(entries))
+	}
+	for k, v := range entries {
+		d.daemonset.Spec.Template.Labels[k] = v
+		d.daemonset.Spec.Selector.MatchLabels[k] = v
+	}
+	return d
+}
+
+func (d *DaemonSetBuilder) WithName(name string) *DaemonSetBuilder {
+	d.daemonset.Name = name
+	return d
+}
+
+func (d *DaemonSetBuilder) WithNamespace(namespace string) *DaemonSetBuilder {
+	d.daemonset.Namespace = namespace
+	return d
+}
+
+func (d *DaemonSetBuilder) Build() appsv1.DaemonSet {
+	return d.daemonset
+}

--- a/pkg/testing/builder/deployment_builder.go
+++ b/pkg/testing/builder/deployment_builder.go
@@ -28,22 +28,19 @@ func (d *DeploymentBuilder) WithReplicas(num *int32) *DeploymentBuilder {
 	return d
 }
 
-func (d *DeploymentBuilder) WithSelectorAndPodLabels(kv ...string) *DeploymentBuilder {
-	if d.deployment.Spec.Template.Labels == nil {
-		d.deployment.Spec.Template.Labels = make(map[string]string)
+func (d *DeploymentBuilder) WithSelectorAndPodLabels(entries map[string]string) *DeploymentBuilder {
+	if d.deployment.Spec.Template.Labels == nil && len(entries) > 0 {
+		d.deployment.Spec.Template.Labels = make(map[string]string, len(entries))
 	}
 	if d.deployment.Spec.Selector == nil {
 		d.deployment.Spec.Selector = &metav1.LabelSelector{}
 	}
-	if d.deployment.Spec.Selector.MatchLabels == nil {
-		d.deployment.Spec.Selector.MatchLabels = make(map[string]string)
+	if d.deployment.Spec.Selector.MatchLabels == nil && len(entries) > 0 {
+		d.deployment.Spec.Selector.MatchLabels = make(map[string]string, len(entries))
 	}
-	if len(kv)%2 != 0 {
-		panic("the number of arguments must be even")
-	}
-	for i := 0; i < len(kv); i += 2 {
-		d.deployment.Spec.Template.Labels[kv[i]] = kv[i+1]
-		d.deployment.Spec.Selector.MatchLabels[kv[i]] = kv[i+1]
+	for k, v := range entries {
+		d.deployment.Spec.Template.Labels[k] = v
+		d.deployment.Spec.Selector.MatchLabels[k] = v
 	}
 	return d
 }

--- a/pkg/testing/builder/deployment_config_builder.go
+++ b/pkg/testing/builder/deployment_config_builder.go
@@ -1,0 +1,62 @@
+package builder
+
+import (
+	ocpv1 "github.com/openshift/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// DeploymentConfigBuilder is a builder for ocpv1.DeploymentConfig objects to be usedc only in unit tests.
+type DeploymentConfigBuilder struct {
+	deploymentconfig ocpv1.DeploymentConfig
+}
+
+// NewDeployment returns a new DeploymentConfigBuilder to buildc ocpv1.DeploymentConfig objects. It is meant to be usedc only in unit tests.
+func NewDeploymentConfig() *DeploymentConfigBuilder {
+	return &DeploymentConfigBuilder{
+		deploymentconfig: ocpv1.DeploymentConfig{},
+	}
+}
+
+func (dc *DeploymentConfigBuilder) WithPodSpec(ps corev1.PodSpec) *DeploymentConfigBuilder {
+	if dc.deploymentconfig.Spec.Template == nil {
+		dc.deploymentconfig.Spec.Template = &corev1.PodTemplateSpec{}
+	}
+	dc.deploymentconfig.Spec.Template.Spec = ps
+	return dc
+}
+
+func (dc *DeploymentConfigBuilder) WithReplicas(num int32) *DeploymentConfigBuilder {
+	dc.deploymentconfig.Spec.Replicas = num
+	return dc
+}
+
+func (dc *DeploymentConfigBuilder) WithSelectorAndPodLabels(entries map[string]string) *DeploymentConfigBuilder {
+	if dc.deploymentconfig.Spec.Template == nil {
+		dc.deploymentconfig.Spec.Template = &corev1.PodTemplateSpec{}
+	}
+	if dc.deploymentconfig.Spec.Template.Labels == nil && len(entries) > 0 {
+		dc.deploymentconfig.Spec.Template.Labels = make(map[string]string, len(entries))
+	}
+	if dc.deploymentconfig.Spec.Selector == nil && len(entries) > 0 {
+		dc.deploymentconfig.Spec.Selector = make(map[string]string, len(entries))
+	}
+	for k, v := range entries {
+		dc.deploymentconfig.Spec.Template.Labels[k] = v
+		dc.deploymentconfig.Spec.Selector[k] = v
+	}
+	return dc
+}
+
+func (dc *DeploymentConfigBuilder) WithName(name string) *DeploymentConfigBuilder {
+	dc.deploymentconfig.Name = name
+	return dc
+}
+
+func (dc *DeploymentConfigBuilder) WithNamespace(namespace string) *DeploymentConfigBuilder {
+	dc.deploymentconfig.Namespace = namespace
+	return dc
+}
+
+func (dc *DeploymentConfigBuilder) Build() ocpv1.DeploymentConfig {
+	return dc.deploymentconfig
+}

--- a/pkg/testing/builder/job_builder.go
+++ b/pkg/testing/builder/job_builder.go
@@ -1,0 +1,47 @@
+package builder
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Jobbuilder is a builder for batchv1.Job objects to be used only in unit tests.
+type Jobbuilder struct {
+	job batchv1.Job
+}
+
+// NewJob returns a new Jobbuilder to build batchv1.Job objects. It is meant to be used only in unit tests.
+func NewJob() *Jobbuilder {
+	return &Jobbuilder{
+		job: batchv1.Job{},
+	}
+}
+
+func (j *Jobbuilder) WithPodSpec(ps corev1.PodSpec) *Jobbuilder {
+	j.job.Spec.Template.Spec = ps
+	return j
+}
+
+func (j *Jobbuilder) WithPodLabels(entries map[string]string) *Jobbuilder {
+	if j.job.Spec.Template.Labels == nil && len(entries) > 0 {
+		j.job.Spec.Template.Labels = make(map[string]string, len(entries))
+	}
+	for k, v := range entries {
+		j.job.Spec.Template.Labels[k] = v
+	}
+	return j
+}
+
+func (j *Jobbuilder) WithName(name string) *Jobbuilder {
+	j.job.Name = name
+	return j
+}
+
+func (j *Jobbuilder) WithNamespace(namespace string) *Jobbuilder {
+	j.job.Namespace = namespace
+	return j
+}
+
+func (j *Jobbuilder) Build() batchv1.Job {
+	return j.job
+}

--- a/pkg/testing/builder/pod_spec_builder.go
+++ b/pkg/testing/builder/pod_spec_builder.go
@@ -44,6 +44,11 @@ func (ps *PodSpecBuilder) WithContainers(containers ...v1.Container) *PodSpecBui
 	return ps
 }
 
+func (ps *PodSpecBuilder) WithRestartPolicy(restartPolicy v1.RestartPolicy) *PodSpecBuilder {
+	ps.podspec.RestartPolicy = restartPolicy
+	return ps
+}
+
 func (ps *PodSpecBuilder) WithContainersImages(images ...string) *PodSpecBuilder {
 	ps.podspec.Containers = make([]v1.Container, len(images))
 
@@ -114,15 +119,12 @@ func (ps *PodSpecBuilder) WithNodeSelectorTerms(nodeSelectorTerms ...v1.NodeSele
 	return ps
 }
 
-func (ps *PodSpecBuilder) WithNodeSelectors(kv ...string) *PodSpecBuilder {
-	if ps.podspec.NodeSelector == nil {
-		ps.podspec.NodeSelector = make(map[string]string)
+func (ps *PodSpecBuilder) WithNodeSelectors(entries map[string]string) *PodSpecBuilder {
+	if ps.podspec.NodeSelector == nil && len(entries) > 0 {
+		ps.podspec.NodeSelector = make(map[string]string, len(entries))
 	}
-	if len(kv)%2 != 0 {
-		panic("the number of arguments must be even")
-	}
-	for i := 0; i < len(kv); i += 2 {
-		ps.podspec.NodeSelector[kv[i]] = kv[i+1]
+	for k, v := range entries {
+		ps.podspec.NodeSelector[k] = v
 	}
 	return ps
 }

--- a/pkg/testing/builder/statefulset_builder.go
+++ b/pkg/testing/builder/statefulset_builder.go
@@ -1,0 +1,60 @@
+package builder
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// StatefulSetBuilder is a builder for appsv1.StatefulSet objects to be used only in unit tests.
+type StatefulSetBuilder struct {
+	statefulset appsv1.StatefulSet
+}
+
+// NewStatefulSet returns a new StatefulSetBuilder to build appsv1.StatefulSet objects. It is meant to be used only in unit tests.
+func NewStatefulSet() *StatefulSetBuilder {
+	return &StatefulSetBuilder{
+		statefulset: appsv1.StatefulSet{},
+	}
+}
+
+func (s *StatefulSetBuilder) WithPodSpec(ps corev1.PodSpec) *StatefulSetBuilder {
+	s.statefulset.Spec.Template.Spec = ps
+	return s
+}
+
+func (s *StatefulSetBuilder) WithReplicas(num *int32) *StatefulSetBuilder {
+	s.statefulset.Spec.Replicas = num
+	return s
+}
+
+func (s *StatefulSetBuilder) WithSelectorAndPodLabels(entries map[string]string) *StatefulSetBuilder {
+	if s.statefulset.Spec.Template.Labels == nil && len(entries) > 0 {
+		s.statefulset.Spec.Template.Labels = make(map[string]string, len(entries))
+	}
+	if s.statefulset.Spec.Selector == nil {
+		s.statefulset.Spec.Selector = &metav1.LabelSelector{}
+	}
+	if s.statefulset.Spec.Selector.MatchLabels == nil && len(entries) > 0 {
+		s.statefulset.Spec.Selector.MatchLabels = make(map[string]string, len(entries))
+	}
+	for k, v := range entries {
+		s.statefulset.Spec.Template.Labels[k] = v
+		s.statefulset.Spec.Selector.MatchLabels[k] = v
+	}
+	return s
+}
+
+func (s *StatefulSetBuilder) WithName(name string) *StatefulSetBuilder {
+	s.statefulset.Name = name
+	return s
+}
+
+func (s *StatefulSetBuilder) WithNamespace(namespace string) *StatefulSetBuilder {
+	s.statefulset.Namespace = namespace
+	return s
+}
+
+func (s *StatefulSetBuilder) Build() appsv1.StatefulSet {
+	return s.statefulset
+}


### PR DESCRIPTION
- Add e2e for  [Single/Multi container images](https://issues.redhat.com/browse/MULTIARCH-4318) and [high-level resources ](https://issues.redhat.com/browse/MULTIARCH-4312).
- Change func `WithSelectorAndPodLabels` to recive map[string]string instand of []string to make code more match the name
-  fix the description typo for nodeSelector test