### PR TITLE
NO-JIRA: Fixes to the CSV, Godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,27 @@
 
 The Multiarch Tuning Operator enhances the user experience for administrators of Openshift clusters with
 multi-architecture compute nodes or Site Reliability Engineers willing to migrate from single-arch to multi-arch
-OpenShift. When diverse CPU architectures coexist within a cluster, the Multiarch Tuning Operator operator stands out as a pivotal tool to
+OpenShift. When diverse CPU architectures coexist within a cluster, the Multiarch Tuning Operator stands out as a pivotal tool to
 enhance efficiency and streamline operations such as architecture-aware scheduling of workloads.
 
 The development work is still ongoing and there is no official, general available, release of it yet.
 
-## Description
+## Operands
 
-- **Architecture aware Pod Placement**: The pod placement operand aims to automate the 
-  inspection of the container images, derive a set of architectures supported by a pod and use it to
-  automatically define strong predicates based on the `kubernetes.io/arch` label in the pod's nodeAffinity. 
+- **Architecture aware Pod Placement**: The pod placement operand consists of
+  the `PodPlacementController` and the `PodPlacementWebhook` and is managed through
+  a singleton custom resource - `podplacementconfigs.multiarch.openshift.io`.
+  Its aim is to automate the set up of strong predicates based on the
+  `kubernetes.io/arch` label in the pod's _nodeAffinity_ by inspecting the container
+  images in each pod and deriving a set of architectures supported by
+  the pod. When a pod is created, the `PodPlacementWebhook` will add the
+  `multiarch.openshift.io/scheduling-gate` scheduling gate.
+  It will prevent the pod from being scheduled until the `PodPlacementController`
+  computes a predicate for the `kubernetes.io/arch` label, adds it as a node affinity
+  requirement to the pod spec, and removes the scheduling gate.
   This operand is based on the [KEP-3521](https://github.com/kubernetes/enhancements/blob/afad6f270c7ac2ae853f4d1b72c379a6c3c7c042/keps/sig-scheduling/3521-pod-scheduling-readiness/README.md) and
   [KEP-3838](https://github.com/kubernetes/enhancements/blob/afad6f270c7ac2ae853f4d1b72c379a6c3c7c042/keps/sig-scheduling/3838-pod-mutable-scheduling-directives/README.md), as
   described in the [Openshift EP](https://github.com/openshift/enhancements/blob/6cebc13f0672c601ebfae669ea4fc8ca632721b5/enhancements/multi-arch/multiarch-manager-operator.md) introducing it.
-  When a pod is created, the mutating webhook will add the `multiarch.openshift.io/scheduling-gate` scheduling gate, that will
-  prevent the pod from being scheduled until the controller computes a predicate for the `kubernetes.io/arch` label,
-  adds it as node affinity requirement to the pod spec and removes the scheduling gate.
 
 ## Getting Started
 
@@ -26,6 +31,17 @@ will be carried out on Openshift clusters.
 
 
 ### Development
+
+### Prerequisites
+
+The development tooling of this repository depends on the following tools/technologies:
+
+- Golang
+- Docker (Community Edition)
+- Development headers and libraries for gpgme (`gpgme-devel` in Fedora/CS9/RHEL, `libgpgme-dev` in Debian)
+- `operator-sdk`
+- `make`
+- `qemu-user-static` (to support building multi-arch container images via `docker buildx`)
 
 ### Build the operator
 

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -8,13 +8,6 @@ metadata:
           "apiVersion": "multiarch.openshift.io/v1alpha1",
           "kind": "PodPlacementConfig",
           "metadata": {
-            "labels": {
-              "app.kubernetes.io/created-by": "multiarch-tuning-operator",
-              "app.kubernetes.io/instance": "podplacementconfig-sample",
-              "app.kubernetes.io/managed-by": "kustomize",
-              "app.kubernetes.io/name": "podplacementconfig",
-              "app.kubernetes.io/part-of": "multiarch-tuning-operator"
-            },
             "name": "cluster"
           },
           "spec": {
@@ -30,14 +23,19 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "true"
-    createdAt: "2024-03-19T21:51:59Z"
+    createdAt: "2024-04-05T16:28:15Z"
     operator.openshift.io/uninstall-message: This action won't automatically delete
       managed resources (operands). To prevent data loss or disruption, you'll need
       to manually delete them.
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: openshift-multiarch-tuning-operator
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/openshift/multiarch-tuning-operator
+    support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -49,18 +47,37 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: PodPlacementConfig is the Schema for the podplacementconfigs API
+    - description: PodPlacementConfig defines the configuration for the PodPlacement
+        operand. It is a singleton resource that can consist of an object named cluster.
+        Creating this object will trigger the deployment of the architecture aware
+        pod placement operand.
       displayName: Pod Placement Config
       kind: PodPlacementConfig
       name: podplacementconfigs.multiarch.openshift.io
       version: v1alpha1
-  description: The Multiarch Tuning Operator enhances the user experience for administrators
-    of Openshift clusters  with multi-architecture compute nodes or Site Reliability
-    Engineers willing to migrate from single-arch to multi-arch OpenShift. When diverse
-    CPU architectures coexist within a cluster, the Multiarch Tuning Operator operator
-    stands out as a pivotal tool to enhance efficiency and streamline operations such
-    as architecture-aware scheduling of workloads.
-  displayName: multiarch-tuning-operator
+  description: |
+    The Multiarch Tuning Operator enhances the user experience for administrators of
+    Openshift clusters with multi-architecture compute nodes or Site Reliability
+    Engineers willing to migrate from single-arch to multi-arch OpenShift. When
+    diverse CPU architectures coexist within a cluster,
+    the Multiarch Tuning Operator stands out as a pivotal tool to
+    enhance efficiency and streamline operations such as architecture-aware
+    scheduling of workloads.
+
+    ## Operands
+
+    - **Architecture aware Pod Placement**: The pod placement operand consists of
+      the `PodPlacementController` and the `PodPlacementWebhook` and is managed through
+      a singleton custom resource - `podplacementconfigs.multiarch.openshift.io`.
+      Its aim is to automate the set up of strong predicates based on the
+      `kubernetes.io/arch` label in the pod's _nodeAffinity_ by inspecting the container
+      images in each pod and deriving a set of architectures supported by
+      the pod. When a pod is created, the `PodPlacementWebhook` will add the
+      `multiarch.openshift.io/scheduling-gate` scheduling gate.
+      It will prevent the pod from being scheduled until the `PodPlacementController`
+      computes a predicate for the `kubernetes.io/arch` label, adds it as a node affinity
+      requirement to the pod spec, and removes the scheduling gate.
+  displayName: Multiarch Tuning Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAVQAAAC1CAYAAAAA/QcmAAARRElEQVR4nO3dTWgjaWLG8cfuj2n3eKbkpqGHkNmqueSwJJH6kLlkEtVcwkII1pLLHhYkJ7AJ5OC6DCQnqZlDAlmwOqfksLgMCSTsBMuBXSZLQGXYHLJM4nKyl82lS9tZyGZMS/J0tz1utyuHXgvbbX2/Ukny/weCGUuqel1tPXq/ay6O41gAgKHNJ10AAJgVBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgYqxehqFOoqiv13/huqrPzak+N6cvXFfPPU/HQTCyMgKDmovjOE66EJhtcaOhg1JJR76vuNmUJM1Zlm4WCrrleZp3nEvfdxqmp++5aM6ydCOX081cTjdyuVEVH+gZgYqR289k9HJ3t+3zN/N53fI8XctkWj/7slzWQanUNkwvmrdt3cjlOgY0MGoEKkbqoFTS4YMHPb123rY17zg6iSKd1GoDn/N6Nqs3CgXdLBQGPgYwCAIVI3MSRWq+915i55+37Va3wlwqlVg5cHUwKIWR+dL3Ez3/Sa2mwwcP1HScV90HjUai5cHso4aKkWk6zlBNd9PmLEtveJ4WSqWki4IZRaBiJF6Gofbv30+6GJeat20tVirnBsEAE2jyYyQOy+Wki9DWSa2m/fv3dZRwlwRmDzVUjEQjlep5ylOS3qpWdd11ky4GZgQ1VBj3olKZijCVpGdMrYJBBCqMO6pUki5Cz05qNb0Mw6SLgRlBoMK4F1MUqNJ0fQFgshGoMOrsev1pwUYrMIVAhVHTWNujyQ9TGOWHMXGjocbSUtLFGMjbOzvMS8XQqKHCmGnrOz2LZj9MIFBhzLPvfjfpIgzsmGY/DKDJDyOiKNLtr35VNw4Oki7KQOZtW1YfdxIALkMNFUb4vq+DmzeTLsbATmq1vm7NAlyGQIURvu/r46OjpIsxFEb7MSwCFQM7iSIdB4H+ZW1NtVpN3zk40E/u3k26WAN7wcAUhnQ96QJg8r0MQx0HgY5/ccfS4+3tc88fvvtu67+/trenf71zR7/05Mm4izk0RvoxLAalcKmXYajDcrmnjU4+WljQd84MRlnS1IbqEh8HDIEmP845iSJ94bqv9gvd2OhpGelPLozsNyX95pMnemxZIyrl6FBLxTAIVLS8qFS0n8m81qQfRFNSutnUD+7cGb5gY0Q/KoZBoELSq5rZ069/faCNTX67w3LTbzx5om/dvq2jW7eGKd7YPPv006SLgClGoELScBstf/PatY7Pf/L8ud4/PNSPpmAGwOd7e0kXAVOMQIWOfH+ou5O+s7enD7q85qd6NQPgW7dva3+C+1bv/OxnCpmPigERqDCy5d7fWpZ6iclPnj9XutnU31iWXiwsDH1e0/7v3j0F9KNiQAQqjKwQervZ1D/02KRvSvqzZlO/cnAwccH6b8+e6cff/77iRiPpomAKEagYqrl/1vt7e/r7Pkb1zwbrRwsLarz1lpFyDOr49m19vLene599pqbj6KBUIljRFyb2Q/W5OaPH+8GdO/rGgJP6P5Dk3bun39rfH/vOVacLFD6Q9E+/+NmcZel2uayb3B0VPSBQoS9c18jc07OGCdVTvyvpj999V7/x+ee6eXhopmCX2LcsfbPZ1A/P/Oxiya9ns3rT9zXvOCMrB6YfTX6M5NYfv/PkiX58546+MsQxvifp9x4/1juHh8pK+vbSkv7jnXeMzRL437t39dHCgpwLYSpJe/funfv/4+1t7WcyU31XAoweNVToZRhq//79kRz7xcKC/mRuTp88f2782B9I+oqkD2xbbx4f69clXbvefr+f2smJHs/P63u1mn6oV3247fynbeuX2/Qtv7m+ThcALkWgQtJomv1n/ejuXX1rb08/HdkZzOrWWUGo4jI0+SFJWiiVRnr89/f29Nnt2/rzHuerJqnbIgVJerayoiPfH3VRMGWooaLlaS6nF1tbIz/PvmXp46Ojc1v+TZJP797V+z0uQeX20ziLQEVL3GhoP5MxNi+1m6dLS/q7kxP9RbPZsT9znP5wYUF/2UfQc3M/nEWTHy1zqZQWKxXNjWmt/WK9rj9qNvXfCwv65N49/dpYztpev2EqvVoUcTDi7hJMD2qoeM2R7+vZykoi5366tKR/vnZNf7W3p/8a0zktSd++e1e/P+BOU3OWpRQrqiACFW0kGaqnni4taXdxUX/9+HHXaU6DsCT9qWXpD46Ohl6Vxag/JAIVHRz5vp573kCbTo/C06UlRYuL+vejI/3jz3+uptR3LfYDvdoQ+2uLi/rVx4+Nle1mPq83GfW/8ghUdPQyDPWF605MqLbzP7bd8fnU/r4W6/WRnf9aOq232Uf1yiNQ0dVJFOlpLqeXu7tJF2WiccdUMMqPruYdR28FgW7m80kXBZhoBCp6MpdK6U3f1+Lm5timVU0TrgkkAhV9upHLyYoi3VheTrooE4XVUpAIVAzgdAHA4uam5rsMBl0VBCokAhVDuJHL6e0w1K1i8co3eW+4btJFwARglB9GnESRDkolHW1sJF2UsWOlFE5RQ4UR846jN31f1qNHV242wBuel3QRMCGooWIkrkqNdd629XYYai6VSroomAAEKkbqJIr0pe/ry3J54ldbDYL9UHEWgYqxOfJ9HZbLM7Piig1RcBGBirE7iSIdlst6UamMbTNr0whTXIZARaJeVCo6qlT0olKZii6BedvWYqVCMx+XIlAxMV6Gob70fR0HwcR1C8xZlt7wvJHfzBDTjUDFRDqJIh0HgV4EgY6DILGugXnb1s1CQbc8j5F8dEWgYiqcRJFehqGOw/BVDTYMR9ZFcC2d1nXX1RuFAk179IVAxVQ7DoJXYRtFihsNvTyzyfPx9nbb911Lp1s1zuuuq/lUStcyGV1nCSmGQKACgCEsPQUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADDketIFAM4Kw/DcIwiCpIsE9IxAHSFTYeA4jhzHMXKsSRNFkXzfVxAECsNQzQF3kIqiSFEUtX1+kGsYhqEaHW4PnclklJrALf3CMJTjOBNZtpkXY2QkGXtYlhUvLy/Hm5ubSf9aRhWLxY6/t6njFIvFvsuWzWY7HrNarfZ9TNPq9Xq8ubkZF4vFOJvNxpZlTUzZriJqqFOi2Wxqa2tLW1tbSqfT8n1fGfbqvLLCMFQul1NtSu/JNasYlJpCu7u7un//vnzfT7ooSEij0SBMJxCBOsVWVlYIVWCCEKhTzvO8joMxAMaHQJ1yzWZTJe7ECUwEBqUSVCwW2z7XaDRaczG7TSXa2NhQuVxmmgyQMAI1Qb3ULBuNhgqFgra2tjq+rlKpqFAodDxOpVJpzffcPXPf+3Q6LcdxlMvllMvljATz2XNd5LqucrnczM9SOF2YEIahoii69Msxm80qk8m0rkk7F/9WunXznM7t7eVYMCjpeVuzTF3mlvaqXq/Htm0PNM+yXq/HxWKxNT+x28OyrLhYLMb1er3v37ffc9m23XWuZ68mZR7qzs5OnM/nu/57tbse6+vrl5al32OZuKboH1d3hEz+Ya+urvYdGDs7O3E6nR7oQ2fbdryzs9Nz+XZ2dgYKEVPXKOlArVarxn7/fD7/WlkI1OnAoNSU6LcZHoahXNc917TvR61Wk+u6lzbZL/J9X/fv37/y8yJN/f4bGxsdu28wuehDnRL9zDc9DdNB18WfajabrVBttw4+CAKtrKwMdZ5xiKKo770VOq3jv8h1XWWzWW1vb/dZssudhqrrukaOhzFJuoo8y2So6ZXP57se6+wa/0Gb+e0e2Wz20nLV6/We+0sHffSqW5N/FI+LfajVatXo8ZeXl3v+WxrFNUX/qKEmqNto62mtqltT0rKs1ghxqVTq2szP5/NyXVeO47R2e+pUs9re3lalUnltFNrzvJ5qwbZtnzvfxVkGs6JdLfV0JN9xHGUyGQVBoCiKtLGx0fF4Z2d2ZLPZc881Go2O1zCdTjONLglJJ/os05hqSmcHXDrVGC3LarsL0fr6esdzXKylPnr0qGu5bNtue75qtdp10KefP89JqKHGcRxvbm62rtf6+nrH2RI7Oztda/idrt8g78NoEagjNI4PtW3brQ/t6Ye53WNtba1jedfW1jq+/9GjRz2/Np1O9zT1qlv3RK8mJVDjOD53nbrp9kVGoE4XmvxTzLIsVSqVVtOuUql0fO1pc7OdTCYjy7LaNuODIGiNPnc6l/RqEK2XJucsNkv72ch6VjcOv6oI1Cll27Yqlcq51UadVs80m019+OGHQ53z7BSqTn2uy8vLM78KqpsoilSpVFqrpC7DCP7sIVCnjGVZ8jxPnue9VrvrZc7oMHo9/lUOijAM5XleT9OnTE2xwuQgUKdMs9lUoVC4tKk87LxTUyaxdprP5/ueLO95Xl+zEXzfn4o5uRgdAjVBcRy/9rNGoyHHcTqGY6lUunSif6f+z3E6XVgwSRzH6btM/fTvVioVwhTshzppUqmUPM/r+JqNjY1LB5cmpWZ4FW/93O3fDFcDgTqBPM+TZVkdX3PZooBugfro0SPFr6bKDfQ4G5QXJ5qftbW1NfL+3EkShmHHxRf5fF7ValX1el1xHGtnZ0fValVra2uybXuMJcWoEagTqJda6vb29ms1wW5N2lwu19P69F5eM85zTbpOXx7FYlG+78t13VYXwun+p57njWza1Cxc12lEoE6oXmqpFwdZcrlcxxrP7u6uXNdtO42n0Wi0PuTdapjdBnhqtZocx2m7qUsQBMpkMjOxBLXTdLWkumG4eWMyCNQJ1UsttVarvfbB6fae3d1dvffee8rlciqXywqCQOVyWYVCQY7j6OHDh61dpjp9KB3HUT6f73iuZrOplZUVpVKpVo0sl8vJcRx9+OGHMxGmUufJ+aVSqW1tMYqikd1gcWtrS47jyPM8lUoleZ4n13UnbrBw5ox9bdYVoi5LF3vRbdNiy7JeW+JpcrepdjvIx/F07TY1yg2md3Z2Or7Otu14dXU1LhaLcbFYjFdXV3v+N2q3hLRerw90PdvtHAYzqKFOuG47UjWbTZXL5XM/q1QqXbsLerWystK2eZ9KpWha6lWzPp1Ot32+Vqvp4cOHevDggR48eKCHDx8OXTtPpVIdBwaRDAJ1whUKha4jweVy+Vyz0nEcBUFgLFQrlUrbpmkul9P6+rqR80yzi19q48DN9iYPgToFeqmlXuw7zWQyiqJo6FpMNptVFEUd+wkLhYKq1aqxAJ9GruuO/YvFdV2trq6O9ZzojECdAr3UUjc2Nl6rRaZSKQVBoPX19b7nO6bTaVWrVQVB0NOKodPZA8VisedgXV1dnalAKBQK2tzc7PlaW5al5eXloc5ZLpe1trZ2pb/MJslcHF+y/hFGdKtZ9tNkC4Kg6wqkbqO4YRjK932FYfjaPeJt224tz8zlckNN92k0Gq2dli5Ovzp7jtPA7/R79XqNuh1nkBFu3/c7jsKfzoxo994gCF67O0E2mz13DRqNRsd+6E7nOKvTNZfUumOA67oTs6JuFhGoAGAITX4AMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBD/h+fh1Gb7+ZNngAAAABJRU5ErkJggg==
     mediatype: image/png
@@ -353,10 +370,11 @@ spec:
   - multiarch-tuning-operator
   - pod-placement
   links:
-  - name: Multiarch Tuning Operator
-    url: https://github.com/openshift/multiarch-tuning-operator
+  - name: Multiarch Tuning Operator Documentation
+    url: https://docs.openshift.com/container-platform/4.16/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html
   maturity: alpha
   minKubeVersion: 1.27.0
   provider:
     name: Red Hat
+    url: https://github.com/openshift/multiarch-tuning-operator
   version: 0.0.1

--- a/bundle/manifests/multiarch.openshift.io_podplacementconfigs.yaml
+++ b/bundle/manifests/multiarch.openshift.io_podplacementconfigs.yaml
@@ -17,8 +17,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PodPlacementConfig is the Schema for the podplacementconfigs
-          API
+        description: PodPlacementConfig defines the configuration for the PodPlacement
+          operand. It is a singleton resource that can consist of an object named
+          cluster. Creating this object will trigger the deployment of the architecture
+          aware pod placement operand.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -38,7 +40,7 @@ spec:
               logVerbosity:
                 default: Normal
                 description: 'LogVerbosity is the log level for the pod placement
-                  controller Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+                  controller. Valid values are: "Normal", "Debug", "Trace", "TraceAll".
                   Defaults to "Normal".'
                 enum:
                 - Normal
@@ -47,23 +49,19 @@ spec:
                 - TraceAll
                 type: string
               namespaceSelector:
-                description: "NamespaceSelector decides whether to run the admission
-                  control policy on an object based on whether the namespace for that
-                  object matches the selector. If the object itself is a namespace,
-                  the matching is performed on object.metadata.labels. If the object
-                  is another cluster scoped resource, it never skips the policy. \n
-                  For example, to run the webhook on any objects whose namespace is
-                  not associated with \"runlevel\" of \"0\" or \"1\";  you will set
-                  the selector as follows: \"namespaceSelector\": { \"matchExpressions\":
-                  [ { \"key\": \"runlevel\", \"operator\": \"NotIn\", \"values\":
-                  [ \"0\", \"1\" ] } ] } \n If instead you want to only run the policy
-                  on any objects whose namespace is associated with the \"environment\"
-                  of \"prod\" or \"staging\"; you will set the selector as follows:
-                  \"namespaceSelector\": { \"matchExpressions\": [ { \"key\": \"environment\",
-                  \"operator\": \"In\", \"values\": [ \"prod\", \"staging\" ] } ]
-                  } \n See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                description: "NamespaceSelector filters the namespaces that the architecture
+                  aware pod placement can operate. \n For example, users can configure
+                  an opt-out filter to disallow the operand from operating on namespaces
+                  with a given label: \n {\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"multiarch.openshift.io/exclude-pod-placement\",\"operator\":\"DoesNotExist\"}]}}
+                  \n The operand will set the node affinity requirement in all the
+                  pods created in namespaces that do not have the `multiarch.openshift.io/exclude-pod-placement`
+                  label. \n Alternatively, users can configure an opt-in filter to
+                  operate only on namespaces with specific labels: \n {\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"multiarch.openshift.io/include-pod-placement\",\"operator\":\"Exists\"}]}}
+                  \n The operand will set the node affinity requirement in all the
+                  pods created in namespace labeled with the key `multiarch.ioenshift.io/include-pod-placement`.
+                  \n See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                   for more examples of label selectors. \n Default to the empty LabelSelector,
-                  which matches everything."
+                  which matches everything. Selectors are ANDed."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/config/crd/bases/multiarch.openshift.io_podplacementconfigs.yaml
+++ b/config/crd/bases/multiarch.openshift.io_podplacementconfigs.yaml
@@ -18,8 +18,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PodPlacementConfig is the Schema for the podplacementconfigs
-          API
+        description: PodPlacementConfig defines the configuration for the PodPlacement
+          operand. It is a singleton resource that can consist of an object named
+          cluster. Creating this object will trigger the deployment of the architecture
+          aware pod placement operand.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -39,7 +41,7 @@ spec:
               logVerbosity:
                 default: Normal
                 description: 'LogVerbosity is the log level for the pod placement
-                  controller Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+                  controller. Valid values are: "Normal", "Debug", "Trace", "TraceAll".
                   Defaults to "Normal".'
                 enum:
                 - Normal
@@ -48,23 +50,19 @@ spec:
                 - TraceAll
                 type: string
               namespaceSelector:
-                description: "NamespaceSelector decides whether to run the admission
-                  control policy on an object based on whether the namespace for that
-                  object matches the selector. If the object itself is a namespace,
-                  the matching is performed on object.metadata.labels. If the object
-                  is another cluster scoped resource, it never skips the policy. \n
-                  For example, to run the webhook on any objects whose namespace is
-                  not associated with \"runlevel\" of \"0\" or \"1\";  you will set
-                  the selector as follows: \"namespaceSelector\": { \"matchExpressions\":
-                  [ { \"key\": \"runlevel\", \"operator\": \"NotIn\", \"values\":
-                  [ \"0\", \"1\" ] } ] } \n If instead you want to only run the policy
-                  on any objects whose namespace is associated with the \"environment\"
-                  of \"prod\" or \"staging\"; you will set the selector as follows:
-                  \"namespaceSelector\": { \"matchExpressions\": [ { \"key\": \"environment\",
-                  \"operator\": \"In\", \"values\": [ \"prod\", \"staging\" ] } ]
-                  } \n See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                description: "NamespaceSelector filters the namespaces that the architecture
+                  aware pod placement can operate. \n For example, users can configure
+                  an opt-out filter to disallow the operand from operating on namespaces
+                  with a given label: \n {\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"multiarch.openshift.io/exclude-pod-placement\",\"operator\":\"DoesNotExist\"}]}}
+                  \n The operand will set the node affinity requirement in all the
+                  pods created in namespaces that do not have the `multiarch.openshift.io/exclude-pod-placement`
+                  label. \n Alternatively, users can configure an opt-in filter to
+                  operate only on namespaces with specific labels: \n {\"namespaceSelector\":{\"matchExpressions\":[{\"key\":\"multiarch.openshift.io/include-pod-placement\",\"operator\":\"Exists\"}]}}
+                  \n The operand will set the node affinity requirement in all the
+                  pods created in namespace labeled with the key `multiarch.ioenshift.io/include-pod-placement`.
+                  \n See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                   for more examples of label selectors. \n Default to the empty LabelSelector,
-                  which matches everything."
+                  which matches everything. Selectors are ANDed."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -3,11 +3,16 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "true"
     operator.openshift.io/uninstall-message: This action won't automatically delete
       managed resources (operands). To prevent data loss or disruption, you'll need
       to manually delete them.
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: openshift-multiarch-tuning-operator
+    repository: https://github.com/openshift/multiarch-tuning-operator
+    support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -19,18 +24,37 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: PodPlacementConfig is the Schema for the podplacementconfigs API
+    - description: PodPlacementConfig defines the configuration for the PodPlacement
+        operand. It is a singleton resource that can consist of an object named cluster.
+        Creating this object will trigger the deployment of the architecture aware
+        pod placement operand.
       displayName: Pod Placement Config
       kind: PodPlacementConfig
       name: podplacementconfigs.multiarch.openshift.io
       version: v1alpha1
-  description: The Multiarch Tuning Operator enhances the user experience for administrators
-    of Openshift clusters  with multi-architecture compute nodes or Site Reliability
-    Engineers willing to migrate from single-arch to multi-arch OpenShift. When diverse
-    CPU architectures coexist within a cluster, the Multiarch Tuning Operator operator
-    stands out as a pivotal tool to enhance efficiency and streamline operations such
-    as architecture-aware scheduling of workloads.
-  displayName: multiarch-tuning-operator
+  description: |
+    The Multiarch Tuning Operator enhances the user experience for administrators of
+    Openshift clusters with multi-architecture compute nodes or Site Reliability
+    Engineers willing to migrate from single-arch to multi-arch OpenShift. When
+    diverse CPU architectures coexist within a cluster,
+    the Multiarch Tuning Operator stands out as a pivotal tool to
+    enhance efficiency and streamline operations such as architecture-aware
+    scheduling of workloads.
+
+    ## Operands
+
+    - **Architecture aware Pod Placement**: The pod placement operand consists of
+      the `PodPlacementController` and the `PodPlacementWebhook` and is managed through
+      a singleton custom resource - `podplacementconfigs.multiarch.openshift.io`.
+      Its aim is to automate the set up of strong predicates based on the
+      `kubernetes.io/arch` label in the pod's _nodeAffinity_ by inspecting the container
+      images in each pod and deriving a set of architectures supported by
+      the pod. When a pod is created, the `PodPlacementWebhook` will add the
+      `multiarch.openshift.io/scheduling-gate` scheduling gate.
+      It will prevent the pod from being scheduled until the `PodPlacementController`
+      computes a predicate for the `kubernetes.io/arch` label, adds it as a node affinity
+      requirement to the pod spec, and removes the scheduling gate.
+  displayName: Multiarch Tuning Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAVQAAAC1CAYAAAAA/QcmAAARRElEQVR4nO3dTWgjaWLG8cfuj2n3eKbkpqGHkNmqueSwJJH6kLlkEtVcwkII1pLLHhYkJ7AJ5OC6DCQnqZlDAlmwOqfksLgMCSTsBMuBXSZLQGXYHLJM4nKyl82lS9tZyGZMS/J0tz1utyuHXgvbbX2/Ukny/weCGUuqel1tPXq/ay6O41gAgKHNJ10AAJgVBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgYqxehqFOoqiv13/huqrPzak+N6cvXFfPPU/HQTCyMgKDmovjOE66EJhtcaOhg1JJR76vuNmUJM1Zlm4WCrrleZp3nEvfdxqmp++5aM6ydCOX081cTjdyuVEVH+gZgYqR289k9HJ3t+3zN/N53fI8XctkWj/7slzWQanUNkwvmrdt3cjlOgY0MGoEKkbqoFTS4YMHPb123rY17zg6iSKd1GoDn/N6Nqs3CgXdLBQGPgYwCAIVI3MSRWq+915i55+37Va3wlwqlVg5cHUwKIWR+dL3Ez3/Sa2mwwcP1HScV90HjUai5cHso4aKkWk6zlBNd9PmLEtveJ4WSqWki4IZRaBiJF6Gofbv30+6GJeat20tVirnBsEAE2jyYyQOy+Wki9DWSa2m/fv3dZRwlwRmDzVUjEQjlep5ylOS3qpWdd11ky4GZgQ1VBj3olKZijCVpGdMrYJBBCqMO6pUki5Cz05qNb0Mw6SLgRlBoMK4F1MUqNJ0fQFgshGoMOrsev1pwUYrMIVAhVHTWNujyQ9TGOWHMXGjocbSUtLFGMjbOzvMS8XQqKHCmGnrOz2LZj9MIFBhzLPvfjfpIgzsmGY/DKDJDyOiKNLtr35VNw4Oki7KQOZtW1YfdxIALkMNFUb4vq+DmzeTLsbATmq1vm7NAlyGQIURvu/r46OjpIsxFEb7MSwCFQM7iSIdB4H+ZW1NtVpN3zk40E/u3k26WAN7wcAUhnQ96QJg8r0MQx0HgY5/ccfS4+3tc88fvvtu67+/trenf71zR7/05Mm4izk0RvoxLAalcKmXYajDcrmnjU4+WljQd84MRlnS1IbqEh8HDIEmP845iSJ94bqv9gvd2OhpGelPLozsNyX95pMnemxZIyrl6FBLxTAIVLS8qFS0n8m81qQfRFNSutnUD+7cGb5gY0Q/KoZBoELSq5rZ069/faCNTX67w3LTbzx5om/dvq2jW7eGKd7YPPv006SLgClGoELScBstf/PatY7Pf/L8ud4/PNSPpmAGwOd7e0kXAVOMQIWOfH+ou5O+s7enD7q85qd6NQPgW7dva3+C+1bv/OxnCpmPigERqDCy5d7fWpZ6iclPnj9XutnU31iWXiwsDH1e0/7v3j0F9KNiQAQqjKwQervZ1D/02KRvSvqzZlO/cnAwccH6b8+e6cff/77iRiPpomAKEagYqrl/1vt7e/r7Pkb1zwbrRwsLarz1lpFyDOr49m19vLene599pqbj6KBUIljRFyb2Q/W5OaPH+8GdO/rGgJP6P5Dk3bun39rfH/vOVacLFD6Q9E+/+NmcZel2uayb3B0VPSBQoS9c18jc07OGCdVTvyvpj999V7/x+ee6eXhopmCX2LcsfbPZ1A/P/Oxiya9ns3rT9zXvOCMrB6YfTX6M5NYfv/PkiX58546+MsQxvifp9x4/1juHh8pK+vbSkv7jnXeMzRL437t39dHCgpwLYSpJe/funfv/4+1t7WcyU31XAoweNVToZRhq//79kRz7xcKC/mRuTp88f2782B9I+oqkD2xbbx4f69clXbvefr+f2smJHs/P63u1mn6oV3247fynbeuX2/Qtv7m+ThcALkWgQtJomv1n/ejuXX1rb08/HdkZzOrWWUGo4jI0+SFJWiiVRnr89/f29Nnt2/rzHuerJqnbIgVJerayoiPfH3VRMGWooaLlaS6nF1tbIz/PvmXp46Ojc1v+TZJP797V+z0uQeX20ziLQEVL3GhoP5MxNi+1m6dLS/q7kxP9RbPZsT9znP5wYUF/2UfQc3M/nEWTHy1zqZQWKxXNjWmt/WK9rj9qNvXfCwv65N49/dpYztpev2EqvVoUcTDi7hJMD2qoeM2R7+vZykoi5366tKR/vnZNf7W3p/8a0zktSd++e1e/P+BOU3OWpRQrqiACFW0kGaqnni4taXdxUX/9+HHXaU6DsCT9qWXpD46Ohl6Vxag/JAIVHRz5vp573kCbTo/C06UlRYuL+vejI/3jz3+uptR3LfYDvdoQ+2uLi/rVx4+Nle1mPq83GfW/8ghUdPQyDPWF605MqLbzP7bd8fnU/r4W6/WRnf9aOq232Uf1yiNQ0dVJFOlpLqeXu7tJF2WiccdUMMqPruYdR28FgW7m80kXBZhoBCp6MpdK6U3f1+Lm5timVU0TrgkkAhV9upHLyYoi3VheTrooE4XVUpAIVAzgdAHA4uam5rsMBl0VBCokAhVDuJHL6e0w1K1i8co3eW+4btJFwARglB9GnESRDkolHW1sJF2UsWOlFE5RQ4UR846jN31f1qNHV242wBuel3QRMCGooWIkrkqNdd629XYYai6VSroomAAEKkbqJIr0pe/ry3J54ldbDYL9UHEWgYqxOfJ9HZbLM7Piig1RcBGBirE7iSIdlst6UamMbTNr0whTXIZARaJeVCo6qlT0olKZii6BedvWYqVCMx+XIlAxMV6Gob70fR0HwcR1C8xZlt7wvJHfzBDTjUDFRDqJIh0HgV4EgY6DILGugXnb1s1CQbc8j5F8dEWgYiqcRJFehqGOw/BVDTYMR9ZFcC2d1nXX1RuFAk179IVAxVQ7DoJXYRtFihsNvTyzyfPx9nbb911Lp1s1zuuuq/lUStcyGV1nCSmGQKACgCEsPQUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADDketIFAM4Kw/DcIwiCpIsE9IxAHSFTYeA4jhzHMXKsSRNFkXzfVxAECsNQzQF3kIqiSFEUtX1+kGsYhqEaHW4PnclklJrALf3CMJTjOBNZtpkXY2QkGXtYlhUvLy/Hm5ubSf9aRhWLxY6/t6njFIvFvsuWzWY7HrNarfZ9TNPq9Xq8ubkZF4vFOJvNxpZlTUzZriJqqFOi2Wxqa2tLW1tbSqfT8n1fGfbqvLLCMFQul1NtSu/JNasYlJpCu7u7un//vnzfT7ooSEij0SBMJxCBOsVWVlYIVWCCEKhTzvO8joMxAMaHQJ1yzWZTJe7ECUwEBqUSVCwW2z7XaDRaczG7TSXa2NhQuVxmmgyQMAI1Qb3ULBuNhgqFgra2tjq+rlKpqFAodDxOpVJpzffcPXPf+3Q6LcdxlMvllMvljATz2XNd5LqucrnczM9SOF2YEIahoii69Msxm80qk8m0rkk7F/9WunXznM7t7eVYMCjpeVuzTF3mlvaqXq/Htm0PNM+yXq/HxWKxNT+x28OyrLhYLMb1er3v37ffc9m23XWuZ68mZR7qzs5OnM/nu/57tbse6+vrl5al32OZuKboH1d3hEz+Ya+urvYdGDs7O3E6nR7oQ2fbdryzs9Nz+XZ2dgYKEVPXKOlArVarxn7/fD7/WlkI1OnAoNSU6LcZHoahXNc917TvR61Wk+u6lzbZL/J9X/fv37/y8yJN/f4bGxsdu28wuehDnRL9zDc9DdNB18WfajabrVBttw4+CAKtrKwMdZ5xiKKo770VOq3jv8h1XWWzWW1vb/dZssudhqrrukaOhzFJuoo8y2So6ZXP57se6+wa/0Gb+e0e2Wz20nLV6/We+0sHffSqW5N/FI+LfajVatXo8ZeXl3v+WxrFNUX/qKEmqNto62mtqltT0rKs1ghxqVTq2szP5/NyXVeO47R2e+pUs9re3lalUnltFNrzvJ5qwbZtnzvfxVkGs6JdLfV0JN9xHGUyGQVBoCiKtLGx0fF4Z2d2ZLPZc881Go2O1zCdTjONLglJJ/os05hqSmcHXDrVGC3LarsL0fr6esdzXKylPnr0qGu5bNtue75qtdp10KefP89JqKHGcRxvbm62rtf6+nrH2RI7Oztda/idrt8g78NoEagjNI4PtW3brQ/t6Ye53WNtba1jedfW1jq+/9GjRz2/Np1O9zT1qlv3RK8mJVDjOD53nbrp9kVGoE4XmvxTzLIsVSqVVtOuUql0fO1pc7OdTCYjy7LaNuODIGiNPnc6l/RqEK2XJucsNkv72ch6VjcOv6oI1Cll27Yqlcq51UadVs80m019+OGHQ53z7BSqTn2uy8vLM78KqpsoilSpVFqrpC7DCP7sIVCnjGVZ8jxPnue9VrvrZc7oMHo9/lUOijAM5XleT9OnTE2xwuQgUKdMs9lUoVC4tKk87LxTUyaxdprP5/ueLO95Xl+zEXzfn4o5uRgdAjVBcRy/9rNGoyHHcTqGY6lUunSif6f+z3E6XVgwSRzH6btM/fTvVioVwhTshzppUqmUPM/r+JqNjY1LB5cmpWZ4FW/93O3fDFcDgTqBPM+TZVkdX3PZooBugfro0SPFr6bKDfQ4G5QXJ5qftbW1NfL+3EkShmHHxRf5fF7ValX1el1xHGtnZ0fValVra2uybXuMJcWoEagTqJda6vb29ms1wW5N2lwu19P69F5eM85zTbpOXx7FYlG+78t13VYXwun+p57njWza1Cxc12lEoE6oXmqpFwdZcrlcxxrP7u6uXNdtO42n0Wi0PuTdapjdBnhqtZocx2m7qUsQBMpkMjOxBLXTdLWkumG4eWMyCNQJ1UsttVarvfbB6fae3d1dvffee8rlciqXywqCQOVyWYVCQY7j6OHDh61dpjp9KB3HUT6f73iuZrOplZUVpVKpVo0sl8vJcRx9+OGHMxGmUufJ+aVSqW1tMYqikd1gcWtrS47jyPM8lUoleZ4n13UnbrBw5ox9bdYVoi5LF3vRbdNiy7JeW+JpcrepdjvIx/F07TY1yg2md3Z2Or7Otu14dXU1LhaLcbFYjFdXV3v+N2q3hLRerw90PdvtHAYzqKFOuG47UjWbTZXL5XM/q1QqXbsLerWystK2eZ9KpWha6lWzPp1Ot32+Vqvp4cOHevDggR48eKCHDx8OXTtPpVIdBwaRDAJ1whUKha4jweVy+Vyz0nEcBUFgLFQrlUrbpmkul9P6+rqR80yzi19q48DN9iYPgToFeqmlXuw7zWQyiqJo6FpMNptVFEUd+wkLhYKq1aqxAJ9GruuO/YvFdV2trq6O9ZzojECdAr3UUjc2Nl6rRaZSKQVBoPX19b7nO6bTaVWrVQVB0NOKodPZA8VisedgXV1dnalAKBQK2tzc7PlaW5al5eXloc5ZLpe1trZ2pb/MJslcHF+y/hFGdKtZ9tNkC4Kg6wqkbqO4YRjK932FYfjaPeJt224tz8zlckNN92k0Gq2dli5Ovzp7jtPA7/R79XqNuh1nkBFu3/c7jsKfzoxo994gCF67O0E2mz13DRqNRsd+6E7nOKvTNZfUumOA67oTs6JuFhGoAGAITX4AMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBD/h+fh1Gb7+ZNngAAAABJRU5ErkJggg==
     mediatype: image/png
@@ -51,10 +75,11 @@ spec:
   - multiarch-tuning-operator
   - pod-placement
   links:
-  - name: Multiarch Tuning Operator
-    url: https://github.com/openshift/multiarch-tuning-operator
+  - name: Multiarch Tuning Operator Documentation
+    url: https://docs.openshift.com/container-platform/4.16/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html
   maturity: alpha
   minKubeVersion: 1.27.0
   provider:
     name: Red Hat
+    url: https://github.com/openshift/multiarch-tuning-operator
   version: 0.0.1

--- a/config/samples/multiarch_v1alpha1_podplacementconfig.yaml
+++ b/config/samples/multiarch_v1alpha1_podplacementconfig.yaml
@@ -1,12 +1,6 @@
 apiVersion: multiarch.openshift.io/v1alpha1
 kind: PodPlacementConfig
 metadata:
-  labels:
-    app.kubernetes.io/name: podplacementconfig
-    app.kubernetes.io/instance: podplacementconfig-sample
-    app.kubernetes.io/part-of: multiarch-tuning-operator
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: multiarch-tuning-operator
   name: cluster
 spec:
   logVerbosity: Normal


### PR DESCRIPTION
This PR proposes minor fixes to adjust how the operator's pages are shown in the OperatorHub sections of the console.
- Improved Golang doc for the CRD 
- Improved description of the operator and operand
- Removed some labels from the CR (@Prashanth684 we were unsure of this, but checked other operators and they don't ship those labels either)
- Added an annotation to declare the minimum openshift version we can install this operator on: unfortunately, this needed an hack in the Makefile `bundle` target as operator-sdk doesn't consider custom annotations in the `bundle/metadata/annotations.yaml` file (xref threads in the internal slack)
- Adds suggested namespace to deploy the operator in the default `openshift-multiarch-tuning-operator` namespace.

~Finally, when deploying the operator through OLM or OperatorHub in a namespace different than the default one (`openshift-multiarch-tuning-operator`), the operand's serviceaccount are not bound to the expected Roles and ClusterRoles properly. This is because OLM doesn't patch the subject's namespace in the ClusterRoleBinding and RoleBinding manifests shipped by the bundle.~

~I like neither this solution, nor alternatives:~
~1. The operator should be able to create ad-hoc cluster role, roles and clusterolebindings. (And maybe the operator's service account should be allowed to perform the same actions that the role or clusterrole is meant to perform, plus the ones for managing clusterroles, clusterrolebindings, roles and rolebindings)~
~2. Create a single service account and use it for both the operator and the operands~
~3. Deploy all the operands, with 0 replicas, and scale them based on the CR config~

~IMO, the best would be that OLM patches the subjects' namespaces (perhaps with some condition/selector) like Kustomize does.~

Here some screenshots showing the changing in the console.

![Screenshot_20240405_155513](https://github.com/openshift/multiarch-tuning-operator/assets/13661032/88daa05b-d76b-4361-9622-bf8c5582e638)
![Screenshot_20240405_155530](https://github.com/openshift/multiarch-tuning-operator/assets/13661032/79c91327-7eec-4fb5-a3dc-5fb8071ed40d)
![Screenshot_20240405_162034](https://github.com/openshift/multiarch-tuning-operator/assets/13661032/4f093bf7-5a73-4d14-982e-b69d7ad7e2a9)
![Screenshot_20240405_162128](https://github.com/openshift/multiarch-tuning-operator/assets/13661032/ad538f3e-a94d-45fd-938c-06e3ed9a3693)


