### PR TITLE
Remove manual replacement of the IMG build arg, refer a possibly published image and use component dependencies (nudging)

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -26,8 +26,6 @@ spec:
       value: 5d
     - name: output-image
       value: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator-bundle:on-pr-{{revision}}
-    - name: operator-image
-      value: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator:on-pr-{{revision}}
     - name: path-context
       value: .
     - name: revision
@@ -136,74 +134,6 @@ spec:
         name: JAVA_COMMUNITY_DEPENDENCIES
         value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
-      - name: replace-img-arg
-        runAfter:
-          - clone-repository
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - image: quay.io/centos/centos:stream9-minimal
-              command:
-                - /bin/sed
-              args:
-                - -i
-                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
-                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
-        workspaces:
-          - name: workspace
-            workspace: workspace
-      - name: replace-img-arg-arm64
-        runAfter:
-          - clone-repository-arm64
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - image: quay.io/centos/centos:stream9-minimal
-              command:
-                - /bin/sed
-              args:
-                - -i
-                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
-                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
-        workspaces:
-          - name: workspace
-            workspace: workspace-arm64
-      - name: replace-img-arg-ppc64le
-        runAfter:
-          - clone-repository-ppc64le
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - image: quay.io/centos/centos:stream9-minimal
-              command:
-                - /bin/sed
-              args:
-                - -i
-                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
-                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
-        workspaces:
-          - name: workspace
-            workspace: workspace-ppc64le
-      - name: replace-img-arg-s390x
-        runAfter:
-          - clone-repository-s390x
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - image: quay.io/centos/centos:stream9-minimal
-              command:
-                - /bin/sed
-              args:
-                - -i
-                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
-                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
-        workspaces:
-          - name: workspace
-            workspace: workspace-s390x
       - name: init
         params:
           - name: image-url
@@ -373,7 +303,6 @@ spec:
             value: $(tasks.clone-repository.results.commit)
         runAfter:
           - prefetch-dependencies
-          - replace-img-arg
         taskRef:
           params:
             - name: name
@@ -410,7 +339,7 @@ spec:
           - name: PLATFORM
             value: linux/arm64
         runAfter:
-          - replace-img-arg-arm64
+          - clone-repository-arm64
         taskRef:
           params:
             - name: name
@@ -447,7 +376,7 @@ spec:
           - name: PLATFORM
             value: linux/s390x
         runAfter:
-          - replace-img-arg-s390x
+          - clone-repository-s390x
         taskRef:
           params:
             - name: name
@@ -485,7 +414,7 @@ spec:
           - name: PLATFORM
             value: linux/ppc64le
         runAfter:
-          - replace-img-arg-ppc64le
+          - clone-repository-ppc64le
         taskRef:
           params:
             - name: name

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -23,8 +23,6 @@ spec:
       value: '{{source_url}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator-bundle:{{revision}}
-    - name: operator-image
-      value: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator:{{revision}}
     - name: path-context
       value: .
     - name: revision
@@ -133,74 +131,6 @@ spec:
         name: JAVA_COMMUNITY_DEPENDENCIES
         value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
-      - name: replace-img-arg
-        runAfter:
-          - clone-repository
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - image: quay.io/centos/centos:stream9-minimal
-              command:
-                - /bin/sed
-              args:
-                - -i
-                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
-                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
-        workspaces:
-          - name: workspace
-            workspace: workspace
-      - name: replace-img-arg-arm64
-        runAfter:
-          - clone-repository-arm64
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - image: quay.io/centos/centos:stream9-minimal
-              command:
-                - /bin/sed
-              args:
-                - -i
-                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
-                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
-        workspaces:
-          - name: workspace
-            workspace: workspace-arm64
-      - name: replace-img-arg-ppc64le
-        runAfter:
-          - clone-repository-ppc64le
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - image: quay.io/centos/centos:stream9-minimal
-              command:
-                - /bin/sed
-              args:
-                - -i
-                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
-                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
-        workspaces:
-          - name: workspace
-            workspace: workspace-ppc64le
-      - name: replace-img-arg-s390x
-        runAfter:
-          - clone-repository-s390x
-        taskSpec:
-          workspaces:
-            - name: workspace
-          steps:
-            - image: quay.io/centos/centos:stream9-minimal
-              command:
-                - /bin/sed
-              args:
-                - -i
-                - s|^ARG IMG=''|ARG IMG='$(params.operator-image)'|
-                - $(workspaces.workspace.path)/source/bundle.konflux.Dockerfile
-        workspaces:
-          - name: workspace
-            workspace: workspace-s390x
       - name: init
         params:
           - name: image-url
@@ -370,7 +300,6 @@ spec:
             value: $(tasks.clone-repository.results.commit)
         runAfter:
           - prefetch-dependencies
-          - replace-image-arg
         taskRef:
           params:
             - name: name
@@ -407,7 +336,7 @@ spec:
           - name: PLATFORM
             value: linux/arm64
         runAfter:
-          - replace-img-arg-arm64
+          - clone-repository-arm64
         taskRef:
           params:
             - name: name
@@ -444,7 +373,7 @@ spec:
           - name: PLATFORM
             value: linux/s390x
         runAfter:
-          - replace-image-arg-s390x
+          - clone-repository-s390x
         taskRef:
           params:
             - name: name
@@ -482,7 +411,7 @@ spec:
           - name: PLATFORM
             value: linux/ppc64le
         runAfter:
-          - replace-image-arg-ppc64le
+          - clone-repository-ppc64le
         taskRef:
           params:
             - name: name

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/operator-framework/operator-sdk:v1.26.0 as osdk
 
 # TODO: use another base image when possible (we depend on gpgme-devel)
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
-ARG IMG=''
+ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:9e0a14311ae40821dbb83359b5d1037ba06469b599c79241f2eb0a55d4dbbe43
 COPY . /code
 COPY --from=osdk /usr/local/bin/operator-sdk /usr/local/bin/
 RUN chmod -R g+rwX /code


### PR DESCRIPTION
We refer to a possibly published image in the Dockerfile responsible to build the bundle in Konflux and defer to a cluster's ImageContentSourcePolicy the responsibility of pointing the images in quay.io when testing a non-relesed operator's image.