### PR TITLE
Fix vendoring issue when building the container image with the internal base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
+COPY vendor/ vendor/
 RUN go mod download
 
 # Copy the go source
@@ -19,7 +20,6 @@ COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
-COPY vendor/ vendor/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -9,6 +9,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
+COPY vendor/ vendor/
 RUN go mod download
 
 # Copy the go source
@@ -16,7 +17,6 @@ COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
-COPY vendor/ vendor/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
vendor should be copied before go mod download to avoid:
> module is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt