### PR TITLE
MULTIARCH-4547: Add labels, annotations, reconcile konflux and other konflux-related fixes

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -569,6 +569,35 @@ spec:
             operator: in
             values:
               - "false"
+      - name: build-source-image
+        params:
+          - name: BINARY_IMAGE
+            value: $(params.output-image)
+          - name: BASE_IMAGES
+            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
+        runAfter:
+          - build-container
+        taskRef:
+          params:
+            - name: name
+              value: source-build
+            - name: bundle
+              value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:90dc9c66eb0123b5e5ff8a1b8c3891e91f0e952899e427eeca79b635fe81a348
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+          - input: $(params.build-source-image)
+            operator: in
+            values:
+              - "true"
+        workspaces:
+          - name: workspace
+            workspace: workspace
       - name: sbom-json-check
         params:
           - name: IMAGE_URL

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -566,6 +566,35 @@ spec:
             operator: in
             values:
               - "false"
+      - name: build-source-image
+        params:
+          - name: BINARY_IMAGE
+            value: $(params.output-image)
+          - name: BASE_IMAGES
+            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
+        runAfter:
+          - build-container
+        taskRef:
+          params:
+            - name: name
+              value: source-build
+            - name: bundle
+              value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:90dc9c66eb0123b5e5ff8a1b8c3891e91f0e952899e427eeca79b635fe81a348
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+          - input: $(params.build-source-image)
+            operator: in
+            values:
+              - "true"
+        workspaces:
+          - name: workspace
+            workspace: workspace
       - name: sbom-json-check
         params:
           - name: IMAGE_URL

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -571,6 +571,35 @@ spec:
             operator: in
             values:
               - "false"
+      - name: build-source-image
+        params:
+          - name: BINARY_IMAGE
+            value: $(params.output-image)
+          - name: BASE_IMAGES
+            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
+        runAfter:
+          - build-container
+        taskRef:
+          params:
+            - name: name
+              value: source-build
+            - name: bundle
+              value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:90dc9c66eb0123b5e5ff8a1b8c3891e91f0e952899e427eeca79b635fe81a348
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+          - input: $(params.build-source-image)
+            operator: in
+            values:
+              - "true"
+        workspaces:
+          - name: workspace
+            workspace: workspace
       - name: sbom-json-check
         params:
           - name: IMAGE_URL

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -392,7 +392,6 @@ spec:
         workspaces:
           - name: source
             workspace: workspace-s390x
-
       - name: build-container-ppc64le
         params:
           - name: IMAGE
@@ -568,6 +567,35 @@ spec:
             operator: in
             values:
               - "false"
+      - name: build-source-image
+        params:
+          - name: BINARY_IMAGE
+            value: $(params.output-image)
+          - name: BASE_IMAGES
+            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
+        runAfter:
+          - build-container
+        taskRef:
+          params:
+            - name: name
+              value: source-build
+            - name: bundle
+              value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:90dc9c66eb0123b5e5ff8a1b8c3891e91f0e952899e427eeca79b635fe81a348
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
+          - input: $(params.build-source-image)
+            operator: in
+            values:
+              - "true"
+        workspaces:
+          - name: workspace
+            workspace: workspace
       - name: sbom-json-check
         params:
           - name: IMAGE_URL

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,26 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM ${RUNTIME_IMAGE}
+
+LABEL com.redhat.component="Multiarch Tuning Operator"
+LABEL distribution-scope="public"
+LABEL name="multiarch-tuning-operator-bundle"
+LABEL release="0.9.0"
+LABEL version="0.9.0"
+LABEL url="https://github.com/openshift/multiarch-tuning-operator"
+LABEL vendor="Red Hat, Inc."
+LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL summary="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.display-name="Multiarch Tuning Operator"
+LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 	cd config/manager && $(KUSTOMIZE) edit set annotation multiarch.openshift.io/image:$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
+	hack/patch-bundle-dockerfile.sh
 
 .PHONY: bundle-verify
 bundle-verify:

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -19,3 +19,23 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
+
+# Labels from hack/patch-bundle-dockerfile.sh
+LABEL com.redhat.component="Multiarch Tuning Operator"
+LABEL distribution-scope="public"
+LABEL name="multiarch-tuning-operator-bundle"
+LABEL release="0.9.0"
+LABEL version="0.9.0"
+LABEL url="https://github.com/openshift/multiarch-tuning-operator"
+LABEL vendor="Red Hat, Inc."
+LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL summary="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.display-name="Multiarch Tuning Operator"
+LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -1,6 +1,4 @@
 FROM quay.io/operator-framework/operator-sdk:v1.31.0 as osdk
-
-# TODO: use another base image when possible (we depend on gpgme-devel)
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21 as builder
 ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:6eb3e10671b6bb8f54139312e4acf291a7078e2912bec75105c84e65ab495460
 COPY . /code
@@ -11,7 +9,7 @@ WORKDIR /code
 # VERSION is set in the base image to the golang version. However, we want to default to the one set in the Makefile.
 RUN unset VERSION; test -n "${IMG}" && make bundle IMG="${IMG}"
 
-FROM gcr.io/distroless/base:latest
+FROM scratch
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -29,3 +29,23 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY --from=builder /code/bundle/manifests /manifests/
 COPY --from=builder /code/bundle/metadata /metadata/
 COPY --from=builder /code/bundle/tests/scorecard /tests/scorecard/
+
+# Labels from hack/patch-bundle-dockerfile.sh
+LABEL com.redhat.component="Multiarch Tuning Operator"
+LABEL distribution-scope="public"
+LABEL name="multiarch-tuning-operator-bundle"
+LABEL release="0.9.0"
+LABEL version="0.9.0"
+LABEL url="https://github.com/openshift/multiarch-tuning-operator"
+LABEL vendor="Red Hat, Inc."
+LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL summary="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.display-name="Multiarch Tuning Operator"
+LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /code
 # VERSION is set in the base image to the golang version. However, we want to default to the one set in the Makefile.
 RUN unset VERSION; test -n "${IMG}" && make bundle IMG="${IMG}"
 
-FROM scratch
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -293,7 +293,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -26,12 +26,24 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "true"
-    createdAt: "2024-04-25T19:15:40Z"
+    createdAt: "2024-04-29T14:40:38Z"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operator.openshift.io/uninstall-message: This action won't automatically delete
       managed resources (operands). To prevent data loss or disruption, you'll need
       to manually delete them.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-multiarch-tuning-operator
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/multiarch-tuning-operator

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -6,11 +6,23 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "true"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operator.openshift.io/uninstall-message: This action won't automatically delete
       managed resources (operands). To prevent data loss or disruption, you'll need
       to manually delete them.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-multiarch-tuning-operator
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
     repository: https://github.com/openshift/multiarch-tuning-operator
     support: Red Hat
   labels:

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -222,7 +222,7 @@ func buildDeployment(podPlacementConfig *v1alpha1.PodPlacementConfig,
 							},
 						}, {
 							Name:            "kube-rbac-proxy",
-							Image:           "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1",
+							Image:           "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522",
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"--secure-listen-address=0.0.0.0:8443",

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -2,5 +2,5 @@
 
 set -eux
 echo "Running golangci-lint..."
-GOFLAGS='' go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+GOFLAGS='' go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
 golangci-lint run --timeout 5m0s --verbose --skip-dirs vendor --skip-files zz_generated*

--- a/hack/gosec.sh
+++ b/hack/gosec.sh
@@ -3,6 +3,6 @@
 set -eux
 
 #cd /tmp
-GOFLAGS='' go install github.com/securego/gosec/v2/cmd/gosec@v2.17.0
+GOFLAGS='' go install github.com/securego/gosec/v2/cmd/gosec@v2.19.0
 gosec -severity medium -confidence medium "${@}"
 #cd -

--- a/hack/patch-bundle-dockerfile.sh
+++ b/hack/patch-bundle-dockerfile.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+cat <<EOF >>bundle.Dockerfile
+
+# Labels from hack/patch-bundle-dockerfile.sh
+LABEL com.redhat.component="Multiarch Tuning Operator"
+LABEL distribution-scope="public"
+LABEL name="multiarch-tuning-operator-bundle"
+LABEL release="0.9.0"
+LABEL version="0.9.0"
+LABEL url="https://github.com/openshift/multiarch-tuning-operator"
+LABEL vendor="Red Hat, Inc."
+LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \\
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \\
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \\
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \\
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL summary="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \\
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \\
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.display-name="Multiarch Tuning Operator"
+LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"
+EOF

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -30,4 +30,24 @@ WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
 
+LABEL com.redhat.component="Multiarch Tuning Operator"
+LABEL distribution-scope="public"
+LABEL name="multiarch-tuning-operator"
+LABEL release="0.9.0"
+LABEL version="0.9.0"
+LABEL url="https://github.com/openshift/multiarch-tuning-operator"
+LABEL vendor="Red Hat, Inc."
+LABEL description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.description="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+
+LABEL summary="The Multiarch Tuning Operator enhances the user experience for administrators of Openshift \
+                   clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
+                   migrate from single-arch to multi-arch OpenShift"
+LABEL io.k8s.display-name="Multiarch Tuning Operator"
+LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"
+
 ENTRYPOINT ["/manager"]

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -10,7 +10,7 @@ COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 COPY vendor/ vendor/
-RUN go mod download
+#RUN go mod download
 
 # Copy the go source
 COPY main.go main.go

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -25,7 +25,7 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
-FROM registry.redhat.io/rhel9-2-els/rhel:9.2
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
This should unblock some alerts that prevent us from testing the (staging) `Release` pipelines in Konflux.