### PR TITLE
Enable konflux prefetch

### DIFF
--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -102,7 +102,7 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
-      - default: ""
+      - default: "gomod"
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -99,7 +99,7 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
-      - default: ""
+      - default: "gomod"
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string


### PR DESCRIPTION
This is a pre-requisite for hermetic builds, but it has other benefits. It will enable populating a more accurate SBOM for you and enable the production of source containers: https://access.redhat.com/articles/3410171