### PR TITLE
Revert "[REVERT-ME] Use els as a base for the bundle" and "use rhel:9.2-1222 to overcome CDN/signature issues"

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /code
 # VERSION is set in the base image to the golang version. However, we want to default to the one set in the Makefile.
 RUN unset VERSION; test -n "${IMG}" && make bundle IMG="${IMG}"
 
-FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
+FROM scratch
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -25,7 +25,7 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
-FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
This reverts commit f5e1b6fe1d2466a5f1f4145016e6b13f943c93be as enterprise-contract/ec-policies#985 landed