### PR TITLE
Add e2e for image pull secrets

### DIFF
--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -467,8 +467,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 	})
-	Context("When a deployment with images that require global vs local pull secrets", func() {
-		It("should not set the node affinity when pod with image that requires the pull secret but doest not be provided", func() {
+	Context("When deploying workloads with public and private images", func() {
+		It("should not set the node affinity if missing a pull secret", func() {
 			var err error
 			ns := framework.NewEphemeralNamespace()
 			err = client.Create(ctx, ns)
@@ -489,7 +489,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Expect(err).NotTo(HaveOccurred())
 			verifyPodNodeAffinity(ns, "app", "test")
 		})
-		It("should set the node affinity when pod with image that requires the global pull secret", func() {
+		It("should set the node affinity in pods with images requiring credentials set in the global pull secret", func() {
 			var err error
 			ns := framework.NewEphemeralNamespace()
 			err = client.Create(ctx, ns)
@@ -514,7 +514,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
-		It("should set the node affinity when pod with image that requires the local pull secret", func() {
+		It("should set the node affinity in pods with images requiring credentials set in a pull secret associated with the service account running the pods", func() {
 			var err error
 			ns := framework.NewEphemeralNamespace()
 			err = client.Create(ctx, ns)
@@ -555,7 +555,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
-		It("should set the node affinity when pod with images that require both global and local pull secrets", func() {
+		It("should set the node affinity in pods with images that require both global and local pull secrets", func() {
 			var err error
 			ns := framework.NewEphemeralNamespace()
 			err = client.Create(ctx, ns)

--- a/pkg/testing/builder/secret_builder.go
+++ b/pkg/testing/builder/secret_builder.go
@@ -1,0 +1,48 @@
+package builder
+
+import v1 "k8s.io/api/core/v1"
+
+// SecretBuilder is a builder for v1.Secret objects to be used only in unit tests.
+type SecretBuilder struct {
+	secret v1.Secret
+}
+
+// NewSecret returns a new SecretBuilder to build v1.Secret objects. It is meant to be used only in unit tests.
+func NewSecret() *SecretBuilder {
+	return &SecretBuilder{
+		secret: v1.Secret{},
+	}
+}
+
+func (s *SecretBuilder) WithName(name string) *SecretBuilder {
+	s.secret.Name = name
+	return s
+}
+
+func (s *SecretBuilder) WithNameSpace(namespace string) *SecretBuilder {
+	s.secret.Namespace = namespace
+	return s
+}
+
+func (s *SecretBuilder) WithData(entries map[string][]byte) *SecretBuilder {
+	if s.secret.Data == nil && len(entries) > 0 {
+		s.secret.Data = make(map[string][]byte, len(entries))
+	}
+	for k, v := range entries {
+		s.secret.Data[k] = v
+	}
+	return s
+}
+
+func (s *SecretBuilder) WithType(value v1.SecretType) *SecretBuilder {
+	s.secret.Type = value
+	return s
+}
+
+func (s *SecretBuilder) WithDockerConfigJsonType() *SecretBuilder {
+	return s.WithType("kubernetes.io/dockerconfigjson")
+}
+
+func (s *SecretBuilder) Build() v1.Secret {
+	return s.secret
+}


### PR DESCRIPTION
refer to [MULTIARCH-4317](https://issues.redhat.com/browse/MULTIARCH-4317)

Add 4 test cases for pull secrets:

- no pull secret provided
- image that requires global pull secret
- image that requires local pull secret 
- images that requires both global and local pull secret 