### PR TITLE
OCPBUGS-33008: do not add scheduling gates to pods with nodeName set …

### DIFF
--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -68,7 +68,8 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 
 	// ignore the openshift-* namespace as those are infra components, and ignore the namespace where the operand is running too
 	if utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "openshift-") ||
-		strings.HasPrefix(pod.Namespace, "hypershift-") || strings.HasPrefix(pod.Namespace, "kube-") {
+		strings.HasPrefix(pod.Namespace, "hypershift-") || strings.HasPrefix(pod.Namespace, "kube-") ||
+		pod.Spec.NodeName != "" {
 		return a.patchedPodResponse(pod, req)
 	}
 

--- a/controllers/podplacement/scheduling_gate_mutating_webhook_test.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook_test.go
@@ -1,0 +1,31 @@
+package podplacement
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/image/fake/registry"
+)
+
+var _ = Describe("Controllers/PodPlacement/scheduling_gate_mutating_webhook", func() {
+	When("The scheduling gat mutating webhook", func() {
+		Context("is handling the mutation of pods", func() {
+			It("should ignore pods with a non-empty nodeName", func() {
+				pod := builder.NewPod().
+					WithContainersImages(fmt.Sprintf("%s/%s/%s:latest", registryAddress,
+						registry.PublicRepo, registry.ComputeNameByMediaType(imgspecv1.MediaTypeImageIndex))).
+					WithGenerateName("test-pod-").
+					WithNamespace("test-namespace").
+					WithNodeName("test-node-name").
+					Build()
+				err := k8sClient.Create(ctx, &pod)
+				Expect(err).NotTo(HaveOccurred(), "failed to create the pod", err)
+			})
+		})
+	})
+})

--- a/pkg/testing/builder/pod_builder.go
+++ b/pkg/testing/builder/pod_builder.go
@@ -128,6 +128,11 @@ func (p *PodBuilder) WithNamespace(namespace string) *PodBuilder {
 	return p
 }
 
+func (p *PodBuilder) WithNodeName(nodeName string) *PodBuilder {
+	p.pod.Spec.NodeName = nodeName
+	return p
+}
+
 func (p *PodBuilder) Build() v1.Pod {
 	return p.pod
 }


### PR DESCRIPTION
…at creation

When a pod is created with Spec.Nodename set the following error was encountered. 
The Pod "example" is invalid: spec.nodeName: Forbidden: cannot be set until all schedulingGates have been cleared

Now we ignore the pod if Spec.Nodename is set
