### PR TITLE
MULTIARCH-4635: Re-enable hermetic builds

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -96,7 +96,7 @@ spec:
         description: Skip optional checks, set false if you want to run optional checks
         name: skip-optional
         type: string
-      - default: "false"
+      - default: "true"
         description: Execute the build with network isolation
         name: hermetic
         type: string

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -93,7 +93,7 @@ spec:
         description: Skip optional checks, set false if you want to run optional checks
         name: skip-optional
         type: string
-      - default: "false"
+      - default: "true"
         description: Execute the build with network isolation
         name: hermetic
         type: string

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -98,11 +98,11 @@ spec:
         description: Skip optional checks, set false if you want to run optional checks
         name: skip-optional
         type: string
-      - default: "false"
+      - default: "true"
         description: Execute the build with network isolation
         name: hermetic
         type: string
-      - default: "gomod"
+      - default: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -95,11 +95,11 @@ spec:
         description: Skip optional checks, set false if you want to run optional checks
         name: skip-optional
         type: string
-      - default: "false"
+      - default: "true"
         description: Execute the build with network isolation
         name: hermetic
         type: string
-      - default: "gomod"
+      - default: '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor-check"]}'
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string


### PR DESCRIPTION
This PR enables hermetic builds and fixes the prefetch-input parameters. 

As even the bundle will be built on a disconnected environment and since the Makefile `bundle` target generated by operator-sdk strongly relies on ephemeral binaries downloaded from the internet that cachi2 cannot address, this PR also changes the way we rebuild the image references in the bundle from the `bundle` Makefile target to a regex/sed statement.