### PR TITLE
MULTIARCH-4311: add more e2e cases for registry configuration

### DIFF
--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -23,7 +23,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
-GINKGO_ARGS=${GINKGO_ARGS:-"-vv --randomize-all --randomize-suites -race -trace --keep-going --timeout=30m "}
+GINKGO_ARGS=${GINKGO_ARGS:-"-vv --randomize-all --randomize-suites -race -trace --keep-going --timeout=60m "}
 TEST_LABEL=${TEST_LABEL:-"integration"}
 GINKGO_ARGS="${GINKGO_ARGS} --label-filter ${TEST_LABEL}"
 GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}

--- a/pkg/testing/registry/registry.go
+++ b/pkg/testing/registry/registry.go
@@ -187,6 +187,9 @@ func AddCertificateToConfigmap(ctx context.Context, client runtimeclient.Client,
 			return err
 		}
 	}
+	if c.Data == nil {
+		c.Data = map[string]string{}
+	}
 	c.Data[r.RegistryHost] = string(caData)
 	err = client.Update(ctx, &c)
 	if err != nil {


### PR DESCRIPTION
Adding more e2e cases for registry configuration:
- Add case for registry url added in allowedRegistry
- Add case for registry url added in blockedRegistry

Blocked by #111 