### PR TITLE
Fix tekton pipelines' step deprecated-image-check

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -489,12 +489,10 @@ spec:
             workspace: workspace
       - name: deprecated-base-image-check
         params:
-          - name: BASE_IMAGES_DIGESTS
-            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
           - name: IMAGE_URL
-            value: $(tasks.build-container-amd64.results.IMAGE_URL)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
         taskRef:
           params:
             - name: name

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -486,12 +486,10 @@ spec:
             workspace: workspace
       - name: deprecated-base-image-check
         params:
-          - name: BASE_IMAGES_DIGESTS
-            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
           - name: IMAGE_URL
-            value: $(tasks.build-container-amd64.results.IMAGE_URL)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
         taskRef:
           params:
             - name: name

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -491,12 +491,10 @@ spec:
             workspace: workspace
       - name: deprecated-base-image-check
         params:
-          - name: BASE_IMAGES_DIGESTS
-            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
           - name: IMAGE_URL
-            value: $(tasks.build-container-amd64.results.IMAGE_URL)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
         taskRef:
           params:
             - name: name

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -487,12 +487,10 @@ spec:
             workspace: workspace
       - name: deprecated-base-image-check
         params:
-          - name: BASE_IMAGES_DIGESTS
-            value: $(tasks.build-container-amd64.results.BASE_IMAGES_DIGESTS)
           - name: IMAGE_URL
-            value: $(tasks.build-container-amd64.results.IMAGE_URL)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container-amd64.results.IMAGE_DIGEST)
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
         taskRef:
           params:
             - name: name


### PR DESCRIPTION
The deprecated image check step doesn't process each single arch manifest when using multiarch builds
