### PR TITLE
WIP: MULTIARCH-4812: namespace exclusion based on ownerreference

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "true"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2024-06-21T16:16:42Z"
+    createdAt: "2024-08-05T21:49:14Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -175,6 +175,14 @@ spec:
           - events
           verbs:
           - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -82,6 +82,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -152,6 +152,12 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 							Name:            name,
 							Image:           utils.Image(),
 							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "NAMESPACE",
+									Value: utils.Namespace(), // Set the namespace name directly
+								},
+							},
 							Args: append([]string{
 								"--health-probe-bind-address=:8081",
 								"--metrics-bind-address=127.0.0.1:8080",

--- a/controllers/podplacement/namespaces.go
+++ b/controllers/podplacement/namespaces.go
@@ -69,7 +69,7 @@ func (s *NamespaceCache) onAdd() func(interface{}) {
 	return func(obj interface{}) {
 		ns := obj.(*v1.Namespace)
 		if len(ns.OwnerReferences) != 0 && (ns.Name != "openshift-marketplace" && ns.Name != "openshift-operators") {
-			// Print the kind of the first owner reference if available
+			// Exclude namespaces managed by CVO and networking operators
 			if ns.OwnerReferences[0].Kind == "ClusterVersion" || ns.OwnerReferences[0].Kind == "Network" {
 				s.namespaceMap.Insert(ns.Name)
 				s.log.V(5).Info("Added namespace ", ns.Name, " to map")

--- a/controllers/podplacement/namespaces.go
+++ b/controllers/podplacement/namespaces.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podplacement
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+)
+
+type NamespaceCache struct {
+	mgr          manager.Manager
+	namespaceMap sets.Set[string]
+	log          logr.Logger
+}
+
+func NewNamespaceCache(mgr manager.Manager) *NamespaceCache {
+	return &NamespaceCache{
+		mgr:          mgr,
+		namespaceMap: sets.New[string](),
+	}
+}
+
+func (s *NamespaceCache) Start(ctx context.Context) (err error) {
+	s.log = log.FromContext(ctx, "handler", "NamespaceCache", "kind", "Namespace")
+	s.log.Info("Starting Namespace informer")
+	// Setup an event handler for the informer
+	s.namespaceMap.Insert("openshift-route-controller-manager", "openshift-ingress-canary")
+	namespaceInformer, err := s.mgr.GetCache().GetInformer(ctx, &v1.Namespace{})
+	if err != nil {
+		s.log.Error(err, "Error getting the informer")
+		return err
+	}
+	_, err = namespaceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    s.onAdd(),
+		DeleteFunc: s.onDelete(),
+	})
+
+	if err != nil {
+		s.log.Error(err, "Error registering handler")
+		return err
+	}
+
+	return nil
+}
+
+func (s *NamespaceCache) onAdd() func(interface{}) {
+	return func(obj interface{}) {
+		ns := obj.(*v1.Namespace)
+		if len(ns.OwnerReferences) != 0 && (ns.Name != "openshift-marketplace" && ns.Name != "openshift-operators") {
+			// Print the kind of the first owner reference if available
+			if ns.OwnerReferences[0].Kind == "ClusterVersion" || ns.OwnerReferences[0].Kind == "Network" {
+				s.namespaceMap.Insert(ns.Name)
+				s.log.V(5).Info("Added namespace ", ns.Name, " to map")
+			}
+		}
+	}
+}
+
+func (s *NamespaceCache) onDelete() func(interface{}) {
+	return func(obj interface{}) {
+		ns := obj.(*v1.Namespace)
+		if s.namespaceMap.Has(ns.Name) {
+			s.namespaceMap.Delete(ns.Name)
+			s.log.V(5).Info("Deleted namespace ", ns.Name, " from map")
+		}
+	}
+}
+
+func (s *NamespaceCache) ShouldExcludeNamespace(namespaceName string) bool {
+	if s.namespaceMap.Has(namespaceName) {
+		return true
+	}
+	if (!strings.HasSuffix(namespaceName, "-operator")) && (namespaceName != "openshift-marketplace" && namespaceName != "openshift-operators") {
+		if s.namespaceMap.Has(namespaceName + "-operator") {
+			return true
+		}
+	}
+	return false
+}

--- a/controllers/podplacement/pod_reconciler.go
+++ b/controllers/podplacement/pod_reconciler.go
@@ -42,6 +42,7 @@ type PodReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -73,7 +73,7 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 		return a.patchedPodResponse(pod, req)
 	}
 
-	// For openshift namespaces, exclude accrodingly
+	// For openshift namespaces, exclude accordingly
 	//   - check for any namespace having ownerReference of ClusterVersion of Network
 	//   - exclude the namespace if it does. If it is a namespace starting with openshift* and does not have the "-operator" suffix, add the "-operator" suffix
 	//     and check if the parent operator is managed by CVO. If so ,exclude this operand namespace as well.

--- a/controllers/podplacement/suite_test.go
+++ b/controllers/podplacement/suite_test.go
@@ -229,10 +229,16 @@ func runManager() {
 		ClientSet: clientset,
 	}).SetupWithManager(mgr)).NotTo(HaveOccurred())
 
+	By("Setting up Namespace Cache")
+	nscache := NewNamespaceCache(mgr)
+	err = mgr.Add(nscache)
+	Expect(err).NotTo(HaveOccurred())
+
 	mgr.GetWebhookServer().Register("/add-pod-scheduling-gate", &webhook.Admission{
 		Handler: &PodSchedulingGateMutatingWebHook{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
+			Client:  mgr.GetClient(),
+			Scheme:  mgr.GetScheme(),
+			NsCache: nscache,
 		}})
 	By("Setting up System Config Syncer")
 	err = mgr.Add(NewConfigSyncerRunnable())

--- a/main.go
+++ b/main.go
@@ -196,9 +196,12 @@ func RunClusterPodPlacementConfigOperandControllers(mgr ctrl.Manager) {
 }
 
 func RunClusterPodPlacementConfigOperandWebHook(mgr ctrl.Manager) {
+	nsCache := podplacement.NewNamespaceCache(mgr)
+	must(mgr.Add(nsCache), unableToAddRunnable, runnableKey, "NamespaceCache")
 	mgr.GetWebhookServer().Register("/add-pod-scheduling-gate", &webhook.Admission{Handler: &podplacement.PodSchedulingGateMutatingWebHook{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		NsCache: nsCache,
 	}})
 }
 

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -185,10 +185,12 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 			var err error
 			parentns, ns := framework.NewEphemeralOpenshiftOperatorNamespaceWithOwnerRef("ClusterVersion")
 			err = client.Create(ctx, parentns)
+			Expect(err).NotTo(HaveOccurred())
 			err = client.Create(ctx, ns)
 			Expect(err).NotTo(HaveOccurred())
 			//nolint:errcheck
 			defer client.Delete(ctx, ns)
+			//nolint:errcheck
 			defer client.Delete(ctx, parentns)
 			ps := NewPodSpec().
 				WithContainersImages(helloOpenshiftPublicMultiarchImage).

--- a/pkg/testing/framework/namespace.go
+++ b/pkg/testing/framework/namespace.go
@@ -16,6 +16,49 @@ func NewEphemeralNamespace() *corev1.Namespace {
 	return ns
 }
 
+func NewEphemeralNamespaceWithOwnerRef(ownerref string) *corev1.Namespace {
+	name := NormalizeNameString("t-" + uuid.NewString())
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "config.openshift.io/v1",
+					Kind:       ownerref,
+					Name:       "version",
+					UID:        "example-uid",
+				},
+			},
+		},
+	}
+	return ns
+}
+
+func NewEphemeralOpenshiftOperatorNamespaceWithOwnerRef(ownerref string) (*corev1.Namespace, *corev1.Namespace) {
+	uuidstring := uuid.NewString()
+	parentname := NormalizeNameString("openshift-" + uuidstring + "-operator")
+	name := NormalizeNameString("openshift-" + uuidstring)
+	parentns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: parentname,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "config.openshift.io/v1",
+					Kind:       ownerref,
+					Name:       "version",
+					UID:        "example-uid",
+				},
+			},
+		},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	return parentns, ns
+}
+
 func NormalizeNameString(name string) string {
 	if len(name) > 63 {
 		return name[:63]


### PR DESCRIPTION
For openshift namespaces, exclude accrodingly
  - check for any namespace having ownerReference of ClusterVersion of Network
  - exclude the namespace if it does. If it is a namespace starting with openshift* and does not have the "-operator" suffix, 
     add the "-operator" suffix and check if the parent operator is managed by CVO. If so ,exclude this operand namespace 
    as well.
  - exclude "openshift-route-controller-manager" and "openshift-ingress-canary"
  - include the "openshift-marketplace" and "openshift-operators" namespaces