### PR TITLE
MULTIARCH-4812: exclude pods in namespaces that are pinned to the control plane

### DIFF
--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -157,6 +157,12 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 							Name:            name,
 							Image:           utils.Image(),
 							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "NAMESPACE",
+									Value: utils.Namespace(),
+								},
+							},
 							Args: append([]string{
 								"--health-probe-bind-address=:8081",
 								"--metrics-bind-address=127.0.0.1:8080",

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -27,5 +27,7 @@ const (
 
 const (
 	// SchedulingGateName is the name of the Scheduling Gate
-	SchedulingGateName = "multiarch.openshift.io/scheduling-gate"
+	SchedulingGateName            = "multiarch.openshift.io/scheduling-gate"
+	MasterNodeSelectorLabel       = "node-role.kubernetes.io/master"
+	ControlPlaneNodeSelectorLabel = "node-role.kubernetes.io/control-plane"
 )

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,3 +3,14 @@ package utils
 func NewPtr[T any](a T) *T {
 	return &a
 }
+
+func HasControlPlaneNodeSelector(nodeSelector map[string]string) bool {
+	requiredSelectors := []string{MasterNodeSelectorLabel, ControlPlaneNodeSelectorLabel}
+
+	for _, value := range requiredSelectors {
+		if _, ok := nodeSelector[value]; ok {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
#198 is not a foolproof way to determine and exclude pods which belong to openshift infra.  Instead exclude pods which are scheduled on the control plane as they may be mission critical and part of the core infra. There is no harm in the other pods going through the tuning operator and the gating process.