### PR TITLE
MULTIARCH-4933: Do not disable operands deletion

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -25,9 +25,9 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Other
-    console.openshift.io/disable-operand-delete: "true"
+    console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2024-06-21T16:16:42Z"
+    createdAt: "2024-08-09T14:50:21Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -38,9 +38,8 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operator.openshift.io/uninstall-message: This action won't automatically delete
-      managed resources (operands). To prevent data loss or disruption, you'll need
-      to manually delete them.
+    operator.openshift.io/uninstall-message: You must remove all Operands before uninstalling
+      the operator.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-multiarch-tuning-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift

--- a/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Other
-    console.openshift.io/disable-operand-delete: "true"
+    console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -17,9 +17,8 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operator.openshift.io/uninstall-message: This action won't automatically delete
-      managed resources (operands). To prevent data loss or disruption, you'll need
-      to manually delete them.
+    operator.openshift.io/uninstall-message: You must remove all Operands before uninstalling
+      the operator.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-multiarch-tuning-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift


### PR DESCRIPTION
This will change the UI uninstallation modal to be like the following:

![image](https://github.com/user-attachments/assets/ba673bd1-a0ac-47b9-b921-f3ce8313279d)


We will hopefully have `https://issues.redhat.com/browse/RFE-6144` done and be able to force the deletion of the operands when users uninstall the operator.