### PR TITLE
MULTIARCH-4934: ordered removal of the operand and minor fixes 

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -133,6 +133,12 @@ spec:
         - apiGroups:
           - apps
           resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps
+          resources:
           - deployments/status
           verbs:
           - get

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -318,7 +318,6 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
-                - -zap-log-level=3
                 - --enable-operator
                 command:
                 - /manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -63,5 +63,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-        - "-zap-log-level=3"
         - "--enable-operator"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,12 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
   - deployments/status
   verbs:
   - get

--- a/controllers/operator/clusterpodplacementconfig_controller.go
+++ b/controllers/operator/clusterpodplacementconfig_controller.go
@@ -34,6 +34,8 @@ import (
 
 	"github.com/openshift/library-go/pkg/operator/events"
 
+	"go.uber.org/zap/zapcore"
+
 	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
@@ -134,6 +136,11 @@ func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context) 
 // reconcile reconciles the ClusterPodPlacementConfig operand's resources.
 func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clusterPodPlacementConfig *multiarchv1beta1.ClusterPodPlacementConfig) error {
 	log := ctrllog.FromContext(ctx)
+	if int8(utils.AtomicLevel.Level()) != int8(clusterPodPlacementConfig.Spec.LogVerbosity.ToZapLevelInt()) {
+		log.Info("Setting log level", "level", -clusterPodPlacementConfig.Spec.LogVerbosity.ToZapLevelInt())
+		utils.AtomicLevel.SetLevel(zapcore.Level(-clusterPodPlacementConfig.Spec.LogVerbosity.ToZapLevelInt()))
+	}
+
 	objects := []client.Object{
 		buildDeployment(clusterPodPlacementConfig, PodPlacementControllerName, 2,
 			"--leader-elect",

--- a/controllers/operator/clusterpodplacementconfig_controller.go
+++ b/controllers/operator/clusterpodplacementconfig_controller.go
@@ -18,11 +18,12 @@ package operator
 
 import (
 	"context"
+	"errors"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,6 +31,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -61,6 +63,8 @@ const (
 	serviceAccountName                       = "multiarch-tuning-operator-controller-manager"
 )
 
+const waitingForUngatingPodsError = "waiting for pods with the scheduling gate to be ungated"
+
 //+kubebuilder:rbac:groups=multiarch.openshift.io,resources=clusterpodplacementconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=multiarch.openshift.io,resources=clusterpodplacementconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=multiarch.openshift.io,resources=clusterpodplacementconfigs/finalizers,verbs=update
@@ -69,6 +73,7 @@ const (
 
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch;create;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
+//+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch;create;delete
 //+kubebuilder:rbac:groups=core,resources=services/status,verbs=get
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create
@@ -85,25 +90,28 @@ func (r *ClusterPodPlacementConfigReconciler) Reconcile(ctx context.Context, req
 
 	if err = r.Get(ctx, client.ObjectKey{
 		Name: req.NamespacedName.Name,
-	}, clusterPodPlacementConfig); client.IgnoreNotFound(err) != nil {
+	}, clusterPodPlacementConfig); err != nil {
 		log.Error(err, "Unable to fetch ClusterPodPlacementConfig")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	log.V(3).Info("ClusterPodPlacementConfig fetched...", "name", clusterPodPlacementConfig.Name)
-	if apierrors.IsNotFound(err) || !clusterPodPlacementConfig.DeletionTimestamp.IsZero() {
-		// Only execute deletion iff the name of the object is 'cluster' and the object is being deleted or not found
-		return ctrl.Result{}, r.handleDelete(ctx)
+	switch {
+	case !clusterPodPlacementConfig.DeletionTimestamp.IsZero() && !controllerutil.ContainsFinalizer(clusterPodPlacementConfig, utils.PodPlacementFinalizerName):
+		log.V(4).Info("the ClusterPodPlacementConfig object is being deleted, and the finalizer has already been removed successfully.")
+		return ctrl.Result{}, nil
+	case !clusterPodPlacementConfig.DeletionTimestamp.IsZero():
+		// Only execute deletion if the object is being deleted and the finalizer is present
+		return ctrl.Result{}, r.handleDelete(ctx, clusterPodPlacementConfig)
 	}
 	return ctrl.Result{}, r.reconcile(ctx, clusterPodPlacementConfig)
 }
 
 // handleDelete handles the deletion of the PodPlacement operand's resources.
-func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context) error {
+func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context,
+	clusterPodPlacementConfig *multiarchv1beta1.ClusterPodPlacementConfig) error {
 	// The ClusterPodPlacementConfig is being deleted, cleanup the resources
-	log := ctrllog.FromContext(ctx)
-	log.Info("Deleting the PodPlacement operand's resources")
-
+	log := ctrllog.FromContext(ctx).WithValues("operation", "handleDelete")
 	objsToDelete := []utils.ToDeleteRef{
 		{
 			NamespacedTypedClient: r.ClientSet.AppsV1().Deployments(utils.Namespace()),
@@ -130,7 +138,69 @@ func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context) 
 			ObjName:               podMutatingWebhookConfigurationName,
 		},
 	}
-	return utils.DeleteResources(ctx, objsToDelete)
+	log.Info("Deleting the PodPlacement operand's resources")
+	err := utils.DeleteResources(ctx, objsToDelete)
+	// NOTE: err aggregates non-nil errors, excluding NotFound errors
+	if err != nil {
+		log.Error(err, "Unable to delete resources")
+		return err
+	}
+	log.Info("Looking for pods with the scheduling gate")
+	// get pending pods as we cannot query for the scheduling gate
+	pods, err := r.ClientSet.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: "status.phase=Pending",
+	})
+	if err != nil {
+		log.Error(err, "Unable to list pods")
+		return err
+	}
+	if len(pods.Items) != 0 {
+		// Check if any pods really have our scheduling gate
+		found := false
+		for _, pod := range pods.Items {
+			for _, sg := range pod.Spec.SchedulingGates {
+				log.V(4).Info("Pod has scheduling gate", "pod", pod.Name, "gate", sg.Name)
+				if sg.Name == utils.SchedulingGateName {
+					log.Info("Found pod with the pod placement scheduling gate", "pod", pod.Name)
+					found = true
+				}
+			}
+		}
+		if found {
+			return errors.New(waitingForUngatingPodsError)
+		}
+	}
+
+	// The pods have been ungated and no other errors occurred, so we can remove the finalizer
+	log.Info("Pods have been ungated")
+	log = log.WithValues("finalizer", utils.PodPlacementFinalizerName)
+	dlog := log.WithValues("deployment", PodPlacementControllerName)
+	dlog.Info("Removing the finalizer from the deployment")
+	dlog.V(4).Info("Fetching the deployment", "Deployment", PodPlacementControllerName)
+	ppcDeployment := &appsv1.Deployment{}
+	err = r.Get(ctx, client.ObjectKey{
+		Name:      PodPlacementControllerName,
+		Namespace: utils.Namespace(),
+	}, ppcDeployment)
+	if client.IgnoreNotFound(err) != nil {
+		dlog.Error(err, "Unable to fetch the deployment")
+		return err
+	}
+	controllerutil.RemoveFinalizer(ppcDeployment, utils.PodPlacementFinalizerName)
+	dlog.V(4).Info("Updating the deployment")
+	if err = r.Update(ctx, ppcDeployment); err != nil {
+		dlog.Error(err, "Unable to remove the finalizer")
+		return err
+	}
+	// we can remove the finalizer in the ClusterPodPlacementConfig object now
+	log.Info("Removing the finalizer from the ClusterPodPlacementConfig")
+	controllerutil.RemoveFinalizer(clusterPodPlacementConfig, utils.PodPlacementFinalizerName)
+	if err = r.Update(ctx, clusterPodPlacementConfig); err != nil {
+		log.Error(err, "Unable to remove finalizers.",
+			clusterPodPlacementConfig.Kind, clusterPodPlacementConfig.Name)
+		return err
+	}
+	return err
 }
 
 // reconcile reconciles the ClusterPodPlacementConfig operand's resources.
@@ -142,11 +212,13 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 	}
 
 	objects := []client.Object{
+		// The finalizer will not affect the reconciliation of ReplicaSets and Pods
+		// when updates to the ClusterPodPlacementConfig are made.
 		buildDeployment(clusterPodPlacementConfig, PodPlacementControllerName, 2,
-			"--leader-elect",
+			utils.PodPlacementFinalizerName, "--leader-elect",
 			"--enable-ppc-controllers",
 		),
-		buildDeployment(clusterPodPlacementConfig, PodPlacementWebhookName, 3,
+		buildDeployment(clusterPodPlacementConfig, PodPlacementWebhookName, 3, "",
 			"--enable-ppc-webhook",
 		),
 		buildService(PodPlacementControllerName, PodPlacementControllerName,
@@ -179,9 +251,15 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 		return err
 	}
 
-	/* TODO: Updates to the ClusterPodPlacementConfig's status will probably be considered in the future to address the
-	 * ordered un-installation of the operator and operands.
-	 */
+	if !controllerutil.ContainsFinalizer(clusterPodPlacementConfig, utils.PodPlacementFinalizerName) {
+		// Add the finalizer to the object
+		log.Info("Adding finalizer to the ClusterPodPlacementConfig")
+		controllerutil.AddFinalizer(clusterPodPlacementConfig, utils.PodPlacementFinalizerName)
+		if err := r.Update(ctx, clusterPodPlacementConfig); err != nil {
+			log.Error(err, "Unable to update finalizers in the ClusterPodPlacementConfig")
+			return err
+		}
+	}
 	return nil
 }
 

--- a/controllers/operator/clusterpodplacementconfig_controller_test.go
+++ b/controllers/operator/clusterpodplacementconfig_controller_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
 
@@ -162,6 +163,15 @@ func validateDeletion() {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the mutating webhook configuration "+podMutatingWebhookConfigurationName, err)
 	}).Should(Succeed(), "the mutating webhook configuration "+podMutatingWebhookConfigurationName+" should be created")
+	Eventually(func(g Gomega) {
+		gppc := &v1beta1.ClusterPodPlacementConfig{}
+		err := k8sClient.Get(ctx, crclient.ObjectKey{
+			Name:      common.SingletonResourceObjectName,
+			Namespace: utils.Namespace(),
+		}, gppc)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the ClusterPodPlacementConfig", err)
+	}).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
 }
 
 var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfigReconciler", func() {
@@ -332,7 +342,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 					}), &d)
 					g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+PodPlacementWebhookName, err)
 					g.Expect(d.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
-						fmt.Sprintf("-zap-log-level=%d", common.LogVerbosityLevelTraceAll.ToZapLevelInt())))
+						fmt.Sprintf("--initial-log-level=%d", common.LogVerbosityLevelTraceAll.ToZapLevelInt())))
 				}).Should(Succeed(), "the deployment "+PodPlacementWebhookName+" should be updated")
 			})
 			It("Should sync the namespace selector", func() {
@@ -363,6 +373,77 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 					g.Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+podMutatingWebhookConfigurationName, err)
 					g.Expect(mw.Webhooks[0].NamespaceSelector).To(Equal(ppc.Spec.NamespaceSelector))
 				}).Should(Succeed(), "the deployment "+PodPlacementControllerName+" should be updated")
+			})
+			It("Should have finalizers", func() {
+				ppc := &v1beta1.ClusterPodPlacementConfig{}
+				err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      common.SingletonResourceObjectName,
+						Namespace: utils.Namespace(),
+					},
+				}), ppc)
+				Expect(err).NotTo(HaveOccurred(), "failed to get ClusterPodPlacementConfig", err)
+				Eventually(func(g Gomega) {
+					cppc := &v1beta1.ClusterPodPlacementConfig{}
+					err := k8sClient.Get(ctx, crclient.ObjectKey{
+						Name:      common.SingletonResourceObjectName,
+						Namespace: utils.Namespace(),
+					}, cppc)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get ClusterPodPlacementConfig", err)
+					g.Expect(cppc.Finalizers).To(ContainElement(utils.PodPlacementFinalizerName))
+				})
+			})
+		})
+		Context("is handling the cleanup lifecycle of the ClusterPodPlacementConfig", func() {
+			BeforeEach(func() {
+				err := k8sClient.Create(ctx, newClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
+				Expect(err).NotTo(HaveOccurred(), "failed to create ClusterPodPlacementConfig", err)
+				validateReconcile()
+			})
+			It("Should remove finalizers and allow the collection of ClusterPodPlcementConfig and Pod placement controller deployment if no pods with our scheduling gates are present", func() {
+				// add a pod with a different scheduling gate
+				pod := builder.NewPod().
+					WithContainersImages("nginx:latest").
+					WithGenerateName("test-pod-").
+					WithSchedulingGates("different-scheduling-gate").
+					WithNamespace("test-namespace").
+					Build()
+				err := k8sClient.Create(ctx, &pod)
+				Expect(err).NotTo(HaveOccurred(), "failed to create pod", err)
+				err = k8sClient.Delete(ctx, newClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
+				Expect(err).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
+				validateDeletion()
+				err = k8sClient.Delete(ctx, &pod)
+				Expect(err).NotTo(HaveOccurred(), "failed to delete pod", err)
+			})
+			It("Should not remove finalizers and not allow the collection of ClusterPodPlcementConfig and Pod placement controller deployment until pods with our scheduling gates are present", func() {
+				// add a pod with our scheduling gate
+				pod := builder.NewPod().
+					WithContainersImages("nginx:latest").
+					WithGenerateName("test-pod-").
+					WithSchedulingGates(utils.SchedulingGateName).
+					WithNamespace("test-namespace").
+					Build()
+				err := k8sClient.Create(ctx, &pod)
+				Expect(err).NotTo(HaveOccurred(), "failed to create pod", err)
+				By("The pod has been created with our scheduling gate (the pod reconciler is not running in the integration test, therefore the scheduling gate will not be removed)")
+				err = k8sClient.Delete(ctx, newClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
+				Expect(err).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
+				Consistently(func(g Gomega) {
+					cppc := &v1beta1.ClusterPodPlacementConfig{}
+					err := k8sClient.Get(ctx, crclient.ObjectKey{
+						Name:      common.SingletonResourceObjectName,
+						Namespace: utils.Namespace(),
+					}, cppc)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get ClusterPodPlacementConfig", err)
+					g.Expect(cppc.DeletionTimestamp.IsZero()).NotTo(BeTrue())
+					g.Expect(cppc.Finalizers).To(ContainElement(utils.PodPlacementFinalizerName))
+				})
+				By("Manually delete the gated pod")
+				err = k8sClient.Delete(ctx, &pod)
+				Expect(err).NotTo(HaveOccurred(), "failed to delete pod", err)
+				By("The pod has been deleted and the ClusterPodPlacementConfig should now be collected")
+				validateDeletion()
 			})
 		})
 	})

--- a/controllers/operator/clusterpodplacementconfig_controller_test.go
+++ b/controllers/operator/clusterpodplacementconfig_controller_test.go
@@ -320,7 +320,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 					}), &d)
 					g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+PodPlacementControllerName, err)
 					g.Expect(d.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
-						fmt.Sprintf("-zap-log-level=%d", common.LogVerbosityLevelTraceAll.ToZapLevelInt())))
+						fmt.Sprintf("--initial-log-level=%d", common.LogVerbosityLevelTraceAll.ToZapLevelInt())))
 				}).Should(Succeed(), "the deployment "+PodPlacementControllerName+" should be updated")
 				Eventually(func(g Gomega) {
 					d := appsv1.Deployment{}

--- a/controllers/operator/clusterpodplacementconfig_controller_test.go
+++ b/controllers/operator/clusterpodplacementconfig_controller_test.go
@@ -307,22 +307,23 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				}).Should(Succeed(), "the mutating webhook configuration's failure policy never reconciled to Ignore")
 			})
 			It("should sync the deployments' logLevel arguments", func() {
-				// get the clusterpodplacementconfig
-				ppc2 := &v1beta1.ClusterPodPlacementConfig{}
-				err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      common.SingletonResourceObjectName,
-						Namespace: utils.Namespace(),
-					},
-				}), ppc2)
-				Expect(err).NotTo(HaveOccurred(), "failed to get ClusterPodPlacementConfig", err)
-				// change the clusterpodplacementconfig's logLevel
-				ppc2.Spec.LogVerbosity = common.LogVerbosityLevelTraceAll
-				err = k8sClient.Update(ctx, ppc2)
-				Expect(err).NotTo(HaveOccurred(), "failed to update ClusterPodPlacementConfig", err)
+				Eventually(func(g Gomega) {
+					ppc2 := &v1beta1.ClusterPodPlacementConfig{}
+					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      common.SingletonResourceObjectName,
+							Namespace: utils.Namespace(),
+						},
+					}), ppc2)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get ClusterPodPlacementConfig", err)
+					// change the clusterpodplacementconfig's logLevel
+					ppc2.Spec.LogVerbosity = common.LogVerbosityLevelTraceAll
+					err = k8sClient.Update(ctx, ppc2)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to update ClusterPodPlacementConfig", err)
+				}).Should(Succeed(), "the ClusterPodPlacementConfig should be updated")
 				Eventually(func(g Gomega) {
 					d := appsv1.Deployment{}
-					err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
+					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      PodPlacementControllerName,
 							Namespace: utils.Namespace(),
@@ -334,7 +335,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				}).Should(Succeed(), "the deployment "+PodPlacementControllerName+" should be updated")
 				Eventually(func(g Gomega) {
 					d := appsv1.Deployment{}
-					err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
+					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      PodPlacementWebhookName,
 							Namespace: utils.Namespace(),
@@ -348,24 +349,26 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 			It("Should sync the namespace selector", func() {
 				// get the clusterpodplacementconfig
 				ppc := &v1beta1.ClusterPodPlacementConfig{}
-				err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      common.SingletonResourceObjectName,
-						Namespace: utils.Namespace(),
-					},
-				}), ppc)
-				Expect(err).NotTo(HaveOccurred(), "failed to get ClusterPodPlacementConfig", err)
-				// change the clusterpodplacementconfig's namespace selector
-				ppc.Spec.NamespaceSelector = &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"foo": "bar",
-					},
-				}
-				err = k8sClient.Update(ctx, ppc)
-				Expect(err).NotTo(HaveOccurred(), "failed to update ClusterPodPlacementConfig", err)
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      common.SingletonResourceObjectName,
+							Namespace: utils.Namespace(),
+						},
+					}), ppc)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get ClusterPodPlacementConfig", err)
+					// change the clusterpodplacementconfig's namespace selector
+					ppc.Spec.NamespaceSelector = &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"foo": "bar",
+						},
+					}
+					err = k8sClient.Update(ctx, ppc)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to update ClusterPodPlacementConfig", err)
+				}).Should(Succeed(), "the ClusterPodPlacementConfig should be updated")
 				Eventually(func(g Gomega) {
 					mw := &admissionv1.MutatingWebhookConfiguration{}
-					err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&admissionv1.MutatingWebhookConfiguration{
+					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&admissionv1.MutatingWebhookConfiguration{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: podMutatingWebhookConfigurationName,
 						},

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -155,7 +155,7 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 							Args: append([]string{
 								"--health-probe-bind-address=:8081",
 								"--metrics-bind-address=127.0.0.1:8080",
-								fmt.Sprintf("-zap-log-level=%d",
+								fmt.Sprintf("--initial-log-level=%d",
 									clusterPodPlacementConfig.Spec.LogVerbosity.ToZapLevelInt()),
 							}, args...),
 							Command: []string{

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -88,7 +88,11 @@ func buildService(name string, controllerName string, port int32, targetPort int
 }
 
 func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfig,
-	name string, replicas int32, args ...string) *appsv1.Deployment {
+	name string, replicas int32, finalizer string, args ...string) *appsv1.Deployment {
+	finalizers := make([]string, 0)
+	if finalizer != "" {
+		finalizers = append(finalizers, finalizer)
+	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -97,6 +101,7 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 				utils.OperandLabelKey:   operandName,
 				utils.ControllerNameKey: name,
 			},
+			Finalizers: finalizers,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: utils.NewPtr(replicas),

--- a/controllers/operator/suite_test.go
+++ b/controllers/operator/suite_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1alpha1"
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	testingutils "github.com/openshift/multiarch-tuning-operator/pkg/testing/framework"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 	//+kubebuilder:scaffold:imports
 )
@@ -84,6 +85,7 @@ var _ = BeforeSuite(func() {
 	SetDefaultEventuallyPollingInterval(5 * time.Millisecond)
 	SetDefaultEventuallyTimeout(5 * time.Second)
 	startTestEnv()
+	testingutils.EnsureNamespaces(ctx, k8sClient, "test-namespace")
 	runManager()
 })
 

--- a/controllers/podplacement/events.go
+++ b/controllers/podplacement/events.go
@@ -1,5 +1,7 @@
 package podplacement
 
+import "github.com/openshift/multiarch-tuning-operator/pkg/utils"
+
 const (
 	ArchitecturePredicatesConflict                = "ArchAwarePredicatesConflict"
 	ImageArchitectureInspectionError              = "ArchAwareInspectionError"
@@ -8,9 +10,9 @@ const (
 	ArchitectureAwareSchedulingGateRemovalFailure = "ArchAwareSchedGateRemovalFailed"
 	ArchitectureAwareSchedulingGateRemovalSuccess = "ArchAwareSchedGateRemovalSuccess"
 
-	SchedulingGateAddedMsg              = "Successfully gated with the " + schedulingGateName + " scheduling gate"
-	SchedulingGateRemovalSuccessMsg     = "Successfully removed the " + schedulingGateName + " scheduling gate"
-	SchedulingGateRemovalFailureMsg     = "Failed to remove the scheduling gate \"" + schedulingGateName + "\""
+	SchedulingGateAddedMsg              = "Successfully gated with the " + utils.SchedulingGateName + " scheduling gate"
+	SchedulingGateRemovalSuccessMsg     = "Successfully removed the " + utils.SchedulingGateName + " scheduling gate"
+	SchedulingGateRemovalFailureMsg     = "Failed to remove the scheduling gate \"" + utils.SchedulingGateName + "\""
 	ArchitecturePredicatesConflictMsg   = "All the scheduling predicates already include architecture-specific constraints"
 	ArchitecturePredicateSetupMsg       = "Set the nodeAffinity for the architecture to "
 	ImageArchitectureInspectionErrorMsg = "Failed to retrieve the supported architectures: "

--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -58,7 +58,7 @@ func (pod *Pod) HasSchedulingGate() bool {
 		return false
 	}
 	for _, condition := range pod.Spec.SchedulingGates {
-		if condition.Name == schedulingGateName {
+		if condition.Name == utils.SchedulingGateName {
 			return true
 		}
 	}
@@ -73,7 +73,7 @@ func (pod *Pod) RemoveSchedulingGate() {
 	}
 	filtered := make([]corev1.PodSchedulingGate, 0, len(pod.Spec.SchedulingGates))
 	for _, schedulingGate := range pod.Spec.SchedulingGates {
-		if schedulingGate.Name != schedulingGateName {
+		if schedulingGate.Name != utils.SchedulingGateName {
 			filtered = append(filtered, schedulingGate)
 		}
 	}

--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -75,7 +75,7 @@ func TestPod_HasSchedulingGate(t *testing.T) {
 		},
 		{
 			name: "pod with the multiarch-tuning-operator scheduling gate",
-			pod:  NewPod().WithSchedulingGates(schedulingGateName).Build(),
+			pod:  NewPod().WithSchedulingGates(utils.SchedulingGateName).Build(),
 			want: true,
 		},
 		{
@@ -86,7 +86,7 @@ func TestPod_HasSchedulingGate(t *testing.T) {
 		{
 			name: "pod with scheduling gates and the multiarch-tuning-operator scheduling gate",
 			pod: NewPod().WithSchedulingGates(
-				"some-other-scheduling-gate-bar", schedulingGateName, "some-other-scheduling-gate-foo").Build(),
+				"some-other-scheduling-gate-bar", utils.SchedulingGateName, "some-other-scheduling-gate-foo").Build(),
 			want: true,
 		},
 	}
@@ -120,7 +120,7 @@ func TestPod_RemoveSchedulingGate(t *testing.T) {
 		},
 		{
 			name: "pod with the multiarch-tuning-operator scheduling gate",
-			pod:  NewPod().WithSchedulingGates(schedulingGateName).Build(),
+			pod:  NewPod().WithSchedulingGates(utils.SchedulingGateName).Build(),
 			want: []v1.PodSchedulingGate{},
 		},
 		{
@@ -135,7 +135,7 @@ func TestPod_RemoveSchedulingGate(t *testing.T) {
 		{
 			name: "pod with scheduling gates and the multiarch-tuning-operator scheduling gate",
 			pod: NewPod().WithSchedulingGates(
-				"some-other-scheduling-gate-bar", schedulingGateName,
+				"some-other-scheduling-gate-bar", utils.SchedulingGateName,
 				"some-other-scheduling-gate-foo").Build(),
 			want: []v1.PodSchedulingGate{
 				{

--- a/controllers/podplacement/pod_reconciler.go
+++ b/controllers/podplacement/pod_reconciler.go
@@ -55,7 +55,7 @@ type PodReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
-// Reconcile has to watch the pod object if it has the scheduling gate with name schedulingGateName,
+// Reconcile has to watch the pod object if it has the scheduling gate with name SchedulingGateName,
 // inspect the images in the pod spec, update the nodeAffinity accordingly and remove the scheduling gate.
 func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)

--- a/controllers/podplacement/pod_reconciler_test.go
+++ b/controllers/podplacement/pod_reconciler_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&pod), &pod)
 					g.Expect(err).NotTo(HaveOccurred(), "failed to get pod", err)
 					g.Expect(pod.Spec.SchedulingGates).NotTo(ContainElement(corev1.PodSchedulingGate{
-						Name: schedulingGateName,
+						Name: utils.SchedulingGateName,
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -41,13 +41,8 @@ import (
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
 
-const (
-	// SchedulingGateName is the name of the Scheduling Gate
-	schedulingGateName = "multiarch.openshift.io/scheduling-gate"
-)
-
 var schedulingGate = corev1.PodSchedulingGate{
-	Name: schedulingGateName,
+	Name: utils.SchedulingGateName,
 }
 
 // [disabled:operator]kubebuilder:webhook:path=/add-pod-scheduling-gate,mutating=true,sideEffects=None,admissionReviewVersions=v1,failurePolicy=ignore,groups="",resources=pods,verbs=create,versions=v1,name=pod-placement-scheduling-gate.multiarch.openshift.io
@@ -96,7 +91,7 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 
 	// if the gate is already present, do not try to patch (it would fail)
 	for _, schedulingGate := range pod.Spec.SchedulingGates {
-		if schedulingGate.Name == schedulingGateName {
+		if schedulingGate.Name == utils.SchedulingGateName {
 			return a.patchedPodResponse(pod, req)
 		}
 	}

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -22,6 +22,7 @@ const (
 	SchedulingGateLabel             = "multiarch.openshift.io/scheduling-gate"
 	SchedulingGateLabelValueGated   = "gated"
 	SchedulingGateLabelValueRemoved = "removed"
+	PodPlacementFinalizerName       = "finalizers.multiarch.openshift.io/pod-placement"
 )
 
 const (

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -23,3 +23,8 @@ const (
 	SchedulingGateLabelValueGated   = "gated"
 	SchedulingGateLabelValueRemoved = "removed"
 )
+
+const (
+	// SchedulingGateName is the name of the Scheduling Gate
+	SchedulingGateName = "multiarch.openshift.io/scheduling-gate"
+)

--- a/pkg/utils/resource.go
+++ b/pkg/utils/resource.go
@@ -78,10 +78,7 @@ func ApplyResources(ctx context.Context, clientSet *kubernetes.Clientset, record
 // DeleteResource deletes the given object from the cluster. It returns an error if any.
 // TODO[integration-tests]: integration tests for this function in a suite dedicated to this package
 func DeleteResource(ctx context.Context, namespacedTypedClient DeleterInterface, objName string) error {
-	if err := namespacedTypedClient.Delete(ctx, objName, metav1.DeleteOptions{}); err != nil && client.IgnoreNotFound(err) != nil {
-		return err
-	}
-	return nil
+	return client.IgnoreNotFound(namespacedTypedClient.Delete(ctx, objName, metav1.DeleteOptions{}))
 }
 
 // DeleteResources deletes the given objects from the cluster. It returns an error if any.

--- a/pkg/utils/runtime.go
+++ b/pkg/utils/runtime.go
@@ -1,9 +1,14 @@
 package utils
 
-import "os"
+import (
+	"os"
+
+	"go.uber.org/zap"
+)
 
 var namespace string
 var image string
+var AtomicLevel zap.AtomicLevel = zap.NewAtomicLevelAt(-5)
 
 func init() {
 	// Get the namespace from the env variable


### PR DESCRIPTION
When the ClusterPodPlacementConfig is removed, the Pod placement controller should wait for the webhook to be deleted and should ungate all the pods.

This pr will let the operator add a finalizer to the ClusterPodPlacementConfig and the pod placement controller deployment such that when the user deletes the ClusterPodPlacementConfig, the deletion is marked for all the objects, with the webhook immediately collected to avoid new pods from being gated. The pod placement controller will continue running until all the pods are ungated. Then, the operator removes the finalizer in the deployment and the ClusterPodPlacementConfig, allowing the operand to be disabled without leaking any gated pod in the cluster.


This PR also includes changes in the logging system to synchronize the logging level set in the operator with the one requested by the ClusterPodPlacementConfig.
We reconcile the operands when a change to the ClusterPodPlacementConfig is detected. That reconciliation also included the setup of the log-level with the default zap command line flag.
However, the operator didn't change the level of logging.
I'm changing this behavior by leveraging a custom command line flag and the zap.AtomicLevel object that can be changed at runtime.

When a `CusterPodPlacementConfig` is reconciled, the controllers continue to be reconciled as they have always been, but the operator can now change the log level at runtime.
Moreover, the dev mode is now disabled so that the logs output uses the default non-dev JSON encoder, which allows the collection of logs through structured log collectors.

In the future, we may completely deprecate that command line flag and let the ClusterPodPlacementConfig drive the log level and other settings through informers in the operands' components.