### PR TITLE
MULTIARCH-4937: Implement Status of the ClusterPodPlacementConfig, conditions and improve reliability.

### DIFF
--- a/apis/multiarch/v1beta1/clusterpodplacementconfig_types.go
+++ b/apis/multiarch/v1beta1/clusterpodplacementconfig_types.go
@@ -17,8 +17,14 @@ limitations under the License.
 package v1beta1
 
 import (
-	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
+	"fmt"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
 )
 
 // ClusterPodPlacementConfigSpec defines the desired state of ClusterPodPlacementConfig
@@ -42,6 +48,144 @@ type ClusterPodPlacementConfigSpec struct {
 type ClusterPodPlacementConfigStatus struct {
 	// Conditions represents the latest available observations of a ClusterPodPlacementConfig's current state.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// The following fields are used to derive the conditions. They are not exposed to the user.
+	available                                bool `json:"-"`
+	progressing                              bool `json:"-"`
+	degraded                                 bool `json:"-"`
+	deprovisioning                           bool `json:"-"`
+	podPlacementControllerNotReady           bool `json:"-"`
+	podPlacementWebhookNotReady              bool `json:"-"`
+	mutatingWebhookConfigurationNotAvailable bool `json:"-"`
+	canDeployMutatingWebhook                 bool `json:"-"`
+}
+
+func (s *ClusterPodPlacementConfigStatus) IsReady() bool {
+	return s.available
+}
+
+func (s *ClusterPodPlacementConfigStatus) IsProgressing() bool {
+	return s.progressing
+}
+
+func (s *ClusterPodPlacementConfigStatus) IsDegraded() bool {
+	return s.degraded
+}
+
+func (s *ClusterPodPlacementConfigStatus) IsDeprovisioning() bool {
+	return s.deprovisioning
+}
+
+func (s *ClusterPodPlacementConfigStatus) IsPodPlacementControllerNotReady() bool {
+	return s.podPlacementControllerNotReady
+}
+
+func (s *ClusterPodPlacementConfigStatus) IsPodPlacementWebhookNotReady() bool {
+	return s.podPlacementWebhookNotReady
+}
+
+func (s *ClusterPodPlacementConfigStatus) IsMutatingWebhookConfigurationNotAvailable() bool {
+	return s.mutatingWebhookConfigurationNotAvailable
+}
+
+func (s *ClusterPodPlacementConfigStatus) CanDeployMutatingWebhook() bool {
+	return s.canDeployMutatingWebhook
+}
+
+// Build sets the conditions in the ClusterPodPlacementConfig object.
+// The build Conditions are:
+//   - Degraded: if some components are not available (no replicas) and the object is not deprovisioning
+//   - Deprovisioning: if the object is being deleted
+//   - MutatingWebhookConfigurationNotAvailable: if the mutating webhook configuration does not exist
+//   - PodPlacementControllerNotReady: if the pod placement controller is not available or up-to-date
+//   - PodPlacementWebhookNotReady: if the pod placement webhook is not available or up-to-date
+//   - Progressing: if the object is not deprovisioning and some of the components are not up-to-date.
+//   - Available: if all the components are available to serve the requests and reconcile node affinities (at least one replica).
+func (s *ClusterPodPlacementConfigStatus) Build(
+	podPlacementControllerAvailable, podPlacementWebhookAvailable,
+	podPlacementControllerUpToDate, podPlacementWebhookUpToDate,
+	mutatingWebhookConfigurationAvailable,
+	deprovisioning bool) {
+	s.deprovisioning = deprovisioning
+	// tracks existence of the mutating webhook configuration
+	s.mutatingWebhookConfigurationNotAvailable = !mutatingWebhookConfigurationAvailable
+	// tracks the availability of the pod placement controller and webhook and if they are up to date
+	s.podPlacementControllerNotReady = !podPlacementControllerAvailable || !podPlacementControllerUpToDate
+	s.podPlacementWebhookNotReady = !podPlacementWebhookAvailable || !podPlacementWebhookUpToDate
+	// if all the components exist and have at least one replica ready
+	s.available = mutatingWebhookConfigurationAvailable && podPlacementWebhookAvailable && podPlacementControllerAvailable
+	// if some components are not available (no replicas)
+	s.degraded = !s.available && !s.deprovisioning // degraded will not track deprovisioning
+	// allow the deployment of the mutating webhook configuration if the pod placement controller and webhook are available
+	// (at least one replica)
+	s.canDeployMutatingWebhook = podPlacementWebhookAvailable && podPlacementControllerAvailable && !s.deprovisioning
+	s.progressing = (!podPlacementControllerUpToDate || !podPlacementWebhookUpToDate || !mutatingWebhookConfigurationAvailable) && !s.deprovisioning
+	s.buildConditions()
+}
+
+func (s *ClusterPodPlacementConfigStatus) buildConditions() {
+	if s.Conditions == nil {
+		s.Conditions = []metav1.Condition{}
+	}
+	reason := ""
+	if s.podPlacementControllerNotReady {
+		reason += PodPlacementControllerNotRolledOutType
+	}
+	if s.podPlacementWebhookNotReady {
+		reason += PodPlacementWebhookNotRolledOutType
+	}
+	if s.mutatingWebhookConfigurationNotAvailable {
+		reason += MutatingWebhookConfigurationNotAvailable
+	}
+	if reason == "" {
+		reason = AllComponentsReady
+	}
+	v1helpers.SetCondition(&s.Conditions, metav1.Condition{
+		Type:    AvailableType,
+		Status:  conditionFromBool(s.available),
+		Reason:  reason,
+		Message: fmt.Sprintf(ReadyMsg, notFromBool(s.available), strings.TrimSpace(notFromBool(s.available))),
+	})
+	v1helpers.SetCondition(&s.Conditions, metav1.Condition{
+		Type:    ProgressingType,
+		Status:  conditionFromBool(s.progressing),
+		Reason:  reason,
+		Message: fmt.Sprintf(ProgressingMsg, notFromBool(s.progressing)),
+	})
+	v1helpers.SetCondition(&s.Conditions, metav1.Condition{
+		Type:    DegradedType,
+		Status:  conditionFromBool(s.degraded),
+		Reason:  fmt.Sprintf("%s%s", trimAndCapitalize(notFromBool(s.degraded)), DegradedType),
+		Message: fmt.Sprintf(DegradedMsg, notFromBool(s.degraded)),
+	})
+	deprovisinoingMessagePostfix := ""
+	if s.deprovisioning {
+		deprovisinoingMessagePostfix = PendingDeprovisioningMsg
+	}
+	v1helpers.SetCondition(&s.Conditions, metav1.Condition{
+		Type:    DeprovisioningType,
+		Status:  conditionFromBool(s.deprovisioning),
+		Reason:  fmt.Sprintf("%s%s", trimAndCapitalize(notFromBool(s.deprovisioning)), DeprovisioningType),
+		Message: fmt.Sprintf(DeprovisioningMsg, notFromBool(s.deprovisioning), deprovisinoingMessagePostfix),
+	})
+	v1helpers.SetCondition(&s.Conditions, metav1.Condition{
+		Type:    PodPlacementControllerNotRolledOutType,
+		Status:  conditionFromBool(s.podPlacementControllerNotReady),
+		Reason:  fmt.Sprintf("PodPlacementController%sReady", trimAndCapitalize(notFromBool(!s.podPlacementControllerNotReady))),
+		Message: fmt.Sprintf(PodPlacementControllerRolledOutMsg, notFromBool(!s.podPlacementControllerNotReady)),
+	})
+	v1helpers.SetCondition(&s.Conditions, metav1.Condition{
+		Type:    PodPlacementWebhookNotRolledOutType,
+		Status:  conditionFromBool(s.podPlacementWebhookNotReady),
+		Reason:  fmt.Sprintf("PodPlacementWebhook%sReady", trimAndCapitalize(notFromBool(!s.podPlacementWebhookNotReady))),
+		Message: fmt.Sprintf(PodPlacementWebhookRolledOutMsg, notFromBool(!s.podPlacementWebhookNotReady)),
+	})
+	v1helpers.SetCondition(&s.Conditions, metav1.Condition{
+		Type:    MutatingWebhookConfigurationNotAvailable,
+		Status:  conditionFromBool(s.mutatingWebhookConfigurationNotAvailable),
+		Reason:  reason,
+		Message: fmt.Sprintf(MutatingWebhookConfigurationReadyMsg, notFromBool(!s.mutatingWebhookConfigurationNotAvailable)),
+	})
 }
 
 // ClusterPodPlacementConfig defines the configuration for the architecture aware pod placement operand.
@@ -51,6 +195,11 @@ type ClusterPodPlacementConfigStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=clusterpodplacementconfigs,scope=Cluster
+// +kubebuilder:printcolumn:name=Available,JSONPath=.status.conditions[?(@.type=="Available")].status,type=string
+// +kubebuilder:printcolumn:name=Progressing,JSONPath=.status.conditions[?(@.type=="Progressing")].status,type=string
+// +kubebuilder:printcolumn:name=Degraded,JSONPath=.status.conditions[?(@.type=="Degraded")].status,type=string
+// +kubebuilder:printcolumn:name=Since,JSONPath=.status.conditions[?(@.type=="Progressing")].lastTransitionTime,type=date
+// +kubebuilder:printcolumn:name=Status,JSONPath=.status.conditions[?(@.type=="Available")].reason,type=string
 type ClusterPodPlacementConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -70,4 +219,26 @@ type ClusterPodPlacementConfigList struct {
 
 func init() {
 	SchemeBuilder.Register(&ClusterPodPlacementConfig{}, &ClusterPodPlacementConfigList{})
+}
+
+func conditionFromBool(b bool) metav1.ConditionStatus {
+	if b {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
+}
+
+func notFromBool(b bool) string {
+	if b {
+		return ""
+	}
+	return "not "
+}
+
+func trimAndCapitalize(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if len(trimmed) == 0 {
+		return trimmed
+	}
+	return strings.ToUpper(string(trimmed[0])) + trimmed[1:]
 }

--- a/apis/multiarch/v1beta1/clusterpodplacementconfig_types_test.go
+++ b/apis/multiarch/v1beta1/clusterpodplacementconfig_types_test.go
@@ -1,0 +1,249 @@
+package v1beta1
+
+import (
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_conditionFromBool(t *testing.T) {
+	type args struct {
+		b bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want v1.ConditionStatus
+	}{
+		{
+			name: "Test conditionFromBool with true",
+			args: args{b: true},
+			want: v1.ConditionTrue,
+		},
+		{
+			name: "Test conditionFromBool with false",
+			args: args{b: false},
+			want: v1.ConditionFalse,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := conditionFromBool(tt.args.b); got != tt.want {
+				t.Errorf("conditionFromBool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_notFromBool(t *testing.T) {
+	type args struct {
+		b bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test notFromBool with true",
+			args: args{b: true},
+			want: "",
+		},
+		{
+			name: "Test notFromBool with false",
+			args: args{b: false},
+			want: "not ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := notFromBool(tt.args.b); got != tt.want {
+				t.Errorf("notFromBool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_trimAndCapitalize(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test trimAndCapitalize with empty string",
+			args: args{s: ""},
+			want: "",
+		},
+		{
+			name: "Test trimAndCapitalize with single character",
+			args: args{s: "a"},
+			want: "A",
+		},
+		{
+			name: "Test trimAndCapitalize with multiple characters",
+			args: args{s: "abc"},
+			want: "Abc",
+		},
+		{
+			name: "Test trimAndCapitalize with multiple characters and spaces",
+			args: args{s: "  ab c  "},
+			want: "Ab c",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimAndCapitalize(tt.args.s); got != tt.want {
+				t.Errorf("trimAndCapitalize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterPodPlacementConfigStatus_Build(t *testing.T) {
+	tests := []struct {
+		name                                           string
+		podPlacementControllerAvailable                bool
+		podPlacementWebhookAvailable                   bool
+		podPlacementControllerUpToDate                 bool
+		podPlacementWebhookUpToDate                    bool
+		mutatingWebhookConfigurationAvailable          bool
+		deprovisioning                                 bool
+		expectDegraded                                 bool
+		expectDeprovisioning                           bool
+		expectMutatingWebhookConfigurationNotAvailable bool
+		expectPodPlacementControllerNotReady           bool
+		expectPodPlacementWebhookNotReady              bool
+		expectAvailable                                bool
+		expectProgressing                              bool
+		expectCanDeployMutatingWebhook                 bool
+	}{
+		{
+			name:                                           "Deprovisioning",
+			podPlacementControllerAvailable:                true,
+			podPlacementWebhookAvailable:                   true,
+			podPlacementControllerUpToDate:                 true,
+			podPlacementWebhookUpToDate:                    true,
+			mutatingWebhookConfigurationAvailable:          true,
+			deprovisioning:                                 true,
+			expectDegraded:                                 false,
+			expectDeprovisioning:                           true,
+			expectMutatingWebhookConfigurationNotAvailable: false,
+			expectPodPlacementControllerNotReady:           false,
+			expectPodPlacementWebhookNotReady:              false,
+			expectAvailable:                                true,
+			expectProgressing:                              false,
+			expectCanDeployMutatingWebhook:                 false,
+		},
+		{
+			name:                                           "AllAvailableAndUpToDate",
+			podPlacementControllerAvailable:                true,
+			podPlacementWebhookAvailable:                   true,
+			podPlacementControllerUpToDate:                 true,
+			podPlacementWebhookUpToDate:                    true,
+			mutatingWebhookConfigurationAvailable:          true,
+			deprovisioning:                                 false,
+			expectDegraded:                                 false,
+			expectDeprovisioning:                           false,
+			expectMutatingWebhookConfigurationNotAvailable: false,
+			expectPodPlacementControllerNotReady:           false,
+			expectPodPlacementWebhookNotReady:              false,
+			expectAvailable:                                true,
+			expectProgressing:                              false,
+			expectCanDeployMutatingWebhook:                 true,
+		},
+		{
+			name:                                           "MutatingWebhookConfigurationNotAvailable",
+			podPlacementControllerAvailable:                true,
+			podPlacementWebhookAvailable:                   true,
+			podPlacementControllerUpToDate:                 true,
+			podPlacementWebhookUpToDate:                    true,
+			mutatingWebhookConfigurationAvailable:          false,
+			deprovisioning:                                 false,
+			expectDegraded:                                 true,
+			expectDeprovisioning:                           false,
+			expectMutatingWebhookConfigurationNotAvailable: true,
+			expectPodPlacementControllerNotReady:           false,
+			expectPodPlacementWebhookNotReady:              false,
+			expectAvailable:                                false,
+			expectProgressing:                              true,
+			expectCanDeployMutatingWebhook:                 true,
+		},
+		{
+			name:                                           "PodPlacementControllerNotAvailable",
+			podPlacementControllerAvailable:                false,
+			podPlacementWebhookAvailable:                   true,
+			podPlacementControllerUpToDate:                 false,
+			podPlacementWebhookUpToDate:                    true,
+			mutatingWebhookConfigurationAvailable:          true,
+			deprovisioning:                                 false,
+			expectDegraded:                                 true,
+			expectDeprovisioning:                           false,
+			expectMutatingWebhookConfigurationNotAvailable: false,
+			expectPodPlacementControllerNotReady:           true,
+			expectPodPlacementWebhookNotReady:              false,
+			expectAvailable:                                false,
+			expectProgressing:                              true,
+			expectCanDeployMutatingWebhook:                 false,
+		},
+		{
+			name:                                           "PodPlacementWebhookNotUpToDate",
+			podPlacementControllerAvailable:                true,
+			podPlacementWebhookAvailable:                   true,
+			podPlacementControllerUpToDate:                 true,
+			podPlacementWebhookUpToDate:                    false,
+			mutatingWebhookConfigurationAvailable:          true,
+			deprovisioning:                                 false,
+			expectDegraded:                                 false,
+			expectDeprovisioning:                           false,
+			expectMutatingWebhookConfigurationNotAvailable: false,
+			expectPodPlacementControllerNotReady:           false,
+			expectPodPlacementWebhookNotReady:              true,
+			expectAvailable:                                true,
+			expectProgressing:                              true,
+			expectCanDeployMutatingWebhook:                 true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &ClusterPodPlacementConfigStatus{}
+			s.Build(
+				tt.podPlacementControllerAvailable,
+				tt.podPlacementWebhookAvailable,
+				tt.podPlacementControllerUpToDate,
+				tt.podPlacementWebhookUpToDate,
+				tt.mutatingWebhookConfigurationAvailable,
+				tt.deprovisioning,
+			)
+
+			if s.degraded != tt.expectDegraded {
+				t.Errorf("degraded = %v, expected %v", s.degraded, tt.expectDegraded)
+			}
+			if s.deprovisioning != tt.expectDeprovisioning {
+				t.Errorf("deprovisioning = %v, expected %v", s.deprovisioning, tt.expectDeprovisioning)
+			}
+			if s.mutatingWebhookConfigurationNotAvailable != tt.expectMutatingWebhookConfigurationNotAvailable {
+				t.Errorf("mutatingWebhookConfigurationNotAvailable = %v, expected %v", s.mutatingWebhookConfigurationNotAvailable, tt.expectMutatingWebhookConfigurationNotAvailable)
+			}
+			if s.podPlacementControllerNotReady != tt.expectPodPlacementControllerNotReady {
+				t.Errorf("podPlacementControllerNotReady = %v, expected %v", s.podPlacementControllerNotReady, tt.expectPodPlacementControllerNotReady)
+			}
+			if s.podPlacementWebhookNotReady != tt.expectPodPlacementWebhookNotReady {
+				t.Errorf("podPlacementWebhookNotReady = %v, expected %v", s.podPlacementWebhookNotReady, tt.expectPodPlacementWebhookNotReady)
+			}
+			if s.available != tt.expectAvailable {
+				t.Errorf("available = %v, expected %v", s.available, tt.expectAvailable)
+			}
+			if s.progressing != tt.expectProgressing {
+				t.Errorf("progressing = %v, expected %v", s.progressing, tt.expectProgressing)
+			}
+			if s.canDeployMutatingWebhook != tt.expectCanDeployMutatingWebhook {
+				t.Errorf("canDeployMutatingWebhook = %v, expected %v", s.canDeployMutatingWebhook, tt.expectCanDeployMutatingWebhook)
+			}
+		})
+	}
+}

--- a/apis/multiarch/v1beta1/clusterpodplacementconfig_webhook.go
+++ b/apis/multiarch/v1beta1/clusterpodplacementconfig_webhook.go
@@ -20,8 +20,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (r *ClusterPodPlacementConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (c *ClusterPodPlacementConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(c).
 		Complete()
 }

--- a/apis/multiarch/v1beta1/conditions.go
+++ b/apis/multiarch/v1beta1/conditions.go
@@ -1,0 +1,24 @@
+package v1beta1
+
+import "github.com/openshift/multiarch-tuning-operator/pkg/utils"
+
+const (
+	MutatingWebhookConfigurationNotAvailable = "MutatingWebhookConfigurationNotAvailable"
+	PodPlacementControllerNotRolledOutType   = "PodPlacementControllerNotRolledOut"
+	PodPlacementWebhookNotRolledOutType      = "PodPlacementWebhookNotRolledOut"
+	AvailableType                            = "Available"
+	DegradedType                             = "Degraded"
+	ProgressingType                          = "Progressing"
+	DeprovisioningType                       = "Deprovisioning"
+
+	MutatingWebhookConfigurationReadyMsg = "The mutating webhook configuration is %sready."
+	PodPlacementControllerRolledOutMsg   = "The pod placement controller is %sfully rolled out."
+	PodPlacementWebhookRolledOutMsg      = "The pod placement webhook is %sfully rolled out."
+	ReadyMsg                             = "The cluster pod placement config operand is %sready. We can%s gate and reconcile pods."
+	DegradedMsg                          = "The cluster pod placement config operand is %sdegraded."
+	ProgressingMsg                       = "The cluster pod placement config operand is %sprogressing."
+	DeprovisioningMsg                    = "The cluster pod placement config operand is %sbeing deprovisioned. %s"
+	PendingDeprovisioningMsg             = "Some pods may still have the " + utils.SchedulingGateName +
+		"scheduling gate. The pod placement controller is updating them and will terminate."
+	AllComponentsReady = "AllComponentsReady"
+)

--- a/bundle/manifests/multiarch.openshift.io_clusterpodplacementconfigs.yaml
+++ b/bundle/manifests/multiarch.openshift.io_clusterpodplacementconfigs.yaml
@@ -193,7 +193,23 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].lastTransitionTime
+      name: Since
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Status
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ClusterPodPlacementConfig defines the configuration for the architecture

--- a/config/crd/bases/multiarch.openshift.io_clusterpodplacementconfigs.yaml
+++ b/config/crd/bases/multiarch.openshift.io_clusterpodplacementconfigs.yaml
@@ -179,7 +179,23 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].lastTransitionTime
+      name: Since
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Status
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ClusterPodPlacementConfig defines the configuration for the architecture

--- a/controllers/operator/clusterpodplacementconfig_controller_test.go
+++ b/controllers/operator/clusterpodplacementconfig_controller_test.go
@@ -59,20 +59,20 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 			})
 			It("should reconcile the deployment pod-placement-controller", func() {
 				// get the deployment
-				By("getting the deployment " + PodPlacementControllerName)
+				By("getting the deployment " + utils.PodPlacementControllerName)
 				d := appsv1.Deployment{}
 				err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      PodPlacementControllerName,
+						Name:      utils.PodPlacementControllerName,
 						Namespace: utils.Namespace(),
 					},
 				}), &d)
-				Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+PodPlacementControllerName, err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+utils.PodPlacementControllerName, err)
 				// change the deployment's replicas
 				By("changing the deployment's replicas to 3")
 				d.Spec.Replicas = utils.NewPtr(int32(3))
 				err = k8sClient.Update(ctx, &d)
-				Expect(err).NotTo(HaveOccurred(), "failed to update deployment "+PodPlacementControllerName, err)
+				Expect(err).NotTo(HaveOccurred(), "failed to update deployment "+utils.PodPlacementControllerName, err)
 				By("verifying the conditions are correct")
 				Eventually(framework.VerifyConditions(ctx, k8sClient,
 					framework.NewConditionTypeStatusTuple(v1beta1.AvailableType, corev1.ConditionTrue),
@@ -88,14 +88,14 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 					d := appsv1.Deployment{}
 					err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      PodPlacementControllerName,
+							Name:      utils.PodPlacementControllerName,
 							Namespace: utils.Namespace(),
 						},
 					}), &d)
-					g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+PodPlacementControllerName, err)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+utils.PodPlacementControllerName, err)
 					g.Expect(d.Spec.Replicas).To(Equal(utils.NewPtr(int32(2))), "the deployment's replicas should be 2")
 				}).Should(Succeed(), "the deployment's replicas should be 2")
-				setDeploymentReady(PodPlacementControllerName, NewGomegaWithT(GinkgoT()))
+				setDeploymentReady(utils.PodPlacementControllerName, NewGomegaWithT(GinkgoT()))
 				By("verifying the conditions are restored to normal")
 				Eventually(framework.VerifyConditions(ctx, k8sClient,
 					framework.NewConditionTypeStatusTuple(v1beta1.AvailableType, corev1.ConditionTrue),
@@ -108,14 +108,14 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				))
 			})
 			It("should reconcile the deployment pod-placement-webhook when deleted", func() {
-				By("deleting the deployment " + PodPlacementWebhookName)
+				By("deleting the deployment " + utils.PodPlacementWebhookName)
 				err := k8sClient.Delete(ctx, &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      PodPlacementWebhookName,
+						Name:      utils.PodPlacementWebhookName,
 						Namespace: utils.Namespace(),
 					},
 				})
-				Expect(err).NotTo(HaveOccurred(), "failed to delete deployment "+PodPlacementWebhookName, err)
+				Expect(err).NotTo(HaveOccurred(), "failed to delete deployment "+utils.PodPlacementWebhookName, err)
 				By("verifying the conditions are correct")
 				Eventually(framework.VerifyConditions(ctx, k8sClient,
 					framework.NewConditionTypeStatusTuple(v1beta1.AvailableType, corev1.ConditionFalse),
@@ -128,7 +128,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				)).Should(Succeed(), "the ClusterPodPlacementConfig should have the correct conditions")
 				By("Not mutating webhook configuration should be available")
 				err = k8sClient.Get(ctx, crclient.ObjectKey{
-					Name: podMutatingWebhookConfigurationName,
+					Name: utils.PodMutatingWebhookConfigurationName,
 				}, &admissionv1.MutatingWebhookConfiguration{})
 				Expect(err).To(HaveOccurred(), "the mutating webhook configuration should not be available", err)
 				Expect(errors.IsNotFound(err)).To(BeTrue(), "the mutating webhook configuration should not be available", err)
@@ -137,13 +137,13 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 					d := appsv1.Deployment{}
 					err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      PodPlacementWebhookName,
+							Name:      utils.PodPlacementWebhookName,
 							Namespace: utils.Namespace(),
 						},
 					}), &d)
-					g.Expect(err).NotTo(HaveOccurred(), "Unable to get deployment "+PodPlacementWebhookName, err)
-				}).Should(Succeed(), "the deployment "+PodPlacementWebhookName+" should be recreated")
-				setDeploymentReady(PodPlacementWebhookName, NewGomegaWithT(GinkgoT()))
+					g.Expect(err).NotTo(HaveOccurred(), "Unable to get deployment "+utils.PodPlacementWebhookName, err)
+				}).Should(Succeed(), "the deployment "+utils.PodPlacementWebhookName+" should be recreated")
+				setDeploymentReady(utils.PodPlacementWebhookName, NewGomegaWithT(GinkgoT()))
 				By("Verify the conditions are restored when the deployment gets available replicas")
 				Eventually(framework.VerifyConditions(ctx, k8sClient,
 					framework.NewConditionTypeStatusTuple(v1beta1.AvailableType, corev1.ConditionTrue),
@@ -158,46 +158,46 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 			It("should reconcile a service if deleted", func() {
 				err := k8sClient.Delete(ctx, &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      PodPlacementWebhookName,
+						Name:      utils.PodPlacementWebhookName,
 						Namespace: utils.Namespace(),
 					},
 				}, crclient.PropagationPolicy(metav1.DeletePropagationBackground))
-				Expect(err).NotTo(HaveOccurred(), "failed to delete service "+PodPlacementWebhookName, err)
+				Expect(err).NotTo(HaveOccurred(), "failed to delete service "+utils.PodPlacementWebhookName, err)
 				Eventually(func(g Gomega) {
 					s := &corev1.Service{}
 					err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      PodPlacementWebhookName,
+							Name:      utils.PodPlacementWebhookName,
 							Namespace: utils.Namespace(),
 						},
 					}), s)
-					g.Expect(err).NotTo(HaveOccurred(), "failed to get service "+PodPlacementWebhookName, err)
-				}).Should(Succeed(), "the service "+PodPlacementWebhookName+" should be recreated")
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get service "+utils.PodPlacementWebhookName, err)
+				}).Should(Succeed(), "the service "+utils.PodPlacementWebhookName+" should be recreated")
 			})
 			It("should reconcile a service if changed", func() {
 				s := &corev1.Service{}
 				err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      PodPlacementWebhookName,
+						Name:      utils.PodPlacementWebhookName,
 						Namespace: utils.Namespace(),
 					},
 				}), s)
-				Expect(err).NotTo(HaveOccurred(), "failed to get service "+PodPlacementWebhookName, err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get service "+utils.PodPlacementWebhookName, err)
 				By("changing the service's port")
 				// change the service's port
 				s.Spec.Ports[0].Port = 8080
 				err = k8sClient.Update(ctx, s)
-				Expect(err).NotTo(HaveOccurred(), "failed to update service "+PodPlacementWebhookName, err)
+				Expect(err).NotTo(HaveOccurred(), "failed to update service "+utils.PodPlacementWebhookName, err)
 				By("waiting for the service's port to be reconciled")
 				Eventually(func(g Gomega) {
 					s := &corev1.Service{}
 					err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      PodPlacementWebhookName,
+							Name:      utils.PodPlacementWebhookName,
 							Namespace: utils.Namespace(),
 						},
 					}), s)
-					g.Expect(err).NotTo(HaveOccurred(), "failed to get service "+PodPlacementWebhookName, err)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get service "+utils.PodPlacementWebhookName, err)
 					g.Expect(s.Spec.Ports[0].Port).To(Equal(int32(443)), "the service's port should be 443")
 				}).Should(Succeed(), "the service's port never reconciled to 443")
 			})
@@ -205,22 +205,22 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				mwc := &admissionv1.MutatingWebhookConfiguration{}
 				err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&admissionv1.MutatingWebhookConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: podMutatingWebhookConfigurationName,
+						Name: utils.PodMutatingWebhookConfigurationName,
 					},
 				}), mwc)
-				Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+podMutatingWebhookConfigurationName, err)
+				Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+utils.PodMutatingWebhookConfigurationName, err)
 				// change the mutating webhook configuration's failure policy
 				mwc.Webhooks[0].FailurePolicy = utils.NewPtr(admissionv1.Fail)
 				err = k8sClient.Update(ctx, mwc)
-				Expect(err).NotTo(HaveOccurred(), "failed to update mutating webhook configuration "+podMutatingWebhookConfigurationName, err)
+				Expect(err).NotTo(HaveOccurred(), "failed to update mutating webhook configuration "+utils.PodMutatingWebhookConfigurationName, err)
 				Eventually(func(g Gomega) {
 					mwc := &admissionv1.MutatingWebhookConfiguration{}
 					err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&admissionv1.MutatingWebhookConfiguration{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: podMutatingWebhookConfigurationName,
+							Name: utils.PodMutatingWebhookConfigurationName,
 						},
 					}), mwc)
-					g.Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+podMutatingWebhookConfigurationName, err)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+utils.PodMutatingWebhookConfigurationName, err)
 					g.Expect(mwc.Webhooks[0].FailurePolicy).To(Equal(utils.NewPtr(admissionv1.Ignore)), "the mutating webhook configuration's failure policy should be Ignore")
 				}).Should(Succeed(), "the mutating webhook configuration's failure policy never reconciled to Ignore")
 			})
@@ -255,28 +255,28 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 					d := appsv1.Deployment{}
 					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      PodPlacementControllerName,
+							Name:      utils.PodPlacementControllerName,
 							Namespace: utils.Namespace(),
 						},
 					}), &d)
-					g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+PodPlacementControllerName, err)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+utils.PodPlacementControllerName, err)
 					g.Expect(d.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						fmt.Sprintf("--initial-log-level=%d", common.LogVerbosityLevelTraceAll.ToZapLevelInt())))
-				}).Should(Succeed(), "the deployment "+PodPlacementControllerName+" should be updated")
+				}).Should(Succeed(), "the deployment "+utils.PodPlacementControllerName+" should be updated")
 				Eventually(func(g Gomega) {
 					d := appsv1.Deployment{}
 					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      PodPlacementWebhookName,
+							Name:      utils.PodPlacementWebhookName,
 							Namespace: utils.Namespace(),
 						},
 					}), &d)
-					g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+PodPlacementWebhookName, err)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+utils.PodPlacementWebhookName, err)
 					g.Expect(d.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						fmt.Sprintf("--initial-log-level=%d", common.LogVerbosityLevelTraceAll.ToZapLevelInt())))
-				}).Should(Succeed(), "the deployment "+PodPlacementWebhookName+" should be updated")
-				setDeploymentReady(PodPlacementControllerName, NewGomegaWithT(GinkgoT()))
-				setDeploymentReady(PodPlacementWebhookName, NewGomegaWithT(GinkgoT()))
+				}).Should(Succeed(), "the deployment "+utils.PodPlacementWebhookName+" should be updated")
+				setDeploymentReady(utils.PodPlacementControllerName, NewGomegaWithT(GinkgoT()))
+				setDeploymentReady(utils.PodPlacementWebhookName, NewGomegaWithT(GinkgoT()))
 				By("Verifying the conditions are restored to normal")
 				Eventually(framework.VerifyConditions(ctx, k8sClient,
 					framework.NewConditionTypeStatusTuple(v1beta1.AvailableType, corev1.ConditionTrue),
@@ -310,12 +310,12 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 					mw := &admissionv1.MutatingWebhookConfiguration{}
 					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&admissionv1.MutatingWebhookConfiguration{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: podMutatingWebhookConfigurationName,
+							Name: utils.PodMutatingWebhookConfigurationName,
 						},
 					}), mw)
-					g.Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+podMutatingWebhookConfigurationName, err)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+utils.PodMutatingWebhookConfigurationName, err)
 					g.Expect(mw.Webhooks[0].NamespaceSelector).To(Equal(ppc.Spec.NamespaceSelector))
-				}).Should(Succeed(), "the deployment "+PodPlacementControllerName+" should be updated")
+				}).Should(Succeed(), "the deployment "+utils.PodPlacementControllerName+" should be updated")
 			})
 			It("Should have finalizers", func() {
 				ppc := &v1beta1.ClusterPodPlacementConfig{}
@@ -407,8 +407,8 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 		})
 		AfterEach(func() {
 			By("Restoring the status of the deployments")
-			setDeploymentReady(PodPlacementControllerName, NewGomegaWithT(GinkgoT()))
-			setDeploymentReady(PodPlacementWebhookName, NewGomegaWithT(GinkgoT()))
+			setDeploymentReady(utils.PodPlacementControllerName, NewGomegaWithT(GinkgoT()))
+			setDeploymentReady(utils.PodPlacementWebhookName, NewGomegaWithT(GinkgoT()))
 		})
 		When("all components are available", func() {
 			It("should be available", func() {
@@ -426,7 +426,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 		})
 		When("the pod placement controller is not available", func() {
 			It("should be degraded, progressing and no mutating webhook should be present", func() {
-				patchDeploymentStatus(PodPlacementControllerName, func(d *appsv1.Deployment) {
+				patchDeploymentStatus(utils.PodPlacementControllerName, func(d *appsv1.Deployment) {
 					d.Status.AvailableReplicas = 0
 					d.Status.UpdatedReplicas = 0
 					d.Status.ReadyReplicas = 0
@@ -443,7 +443,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				)).Should(Succeed(), "the ClusterPodPlacementConfig should have the correct conditions")
 				By("Verify no mutating webhook configuration is not available")
 				err := k8sClient.Get(ctx, crclient.ObjectKey{
-					Name: podMutatingWebhookConfigurationName,
+					Name: utils.PodMutatingWebhookConfigurationName,
 				}, &admissionv1.MutatingWebhookConfiguration{})
 				Expect(err).To(HaveOccurred(), "the mutating webhook configuration should not be available", err)
 				Expect(errors.IsNotFound(err)).To(BeTrue(), "the mutating webhook configuration should not be available", err)
@@ -452,7 +452,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 		When("the pod placement webhook is not available", func() {
 			It("should be unavailable and degraded", func() {
 				By("Setting the deployment's available replicas to 0")
-				patchDeploymentStatus(PodPlacementWebhookName, func(d *appsv1.Deployment) {
+				patchDeploymentStatus(utils.PodPlacementWebhookName, func(d *appsv1.Deployment) {
 					d.Status.AvailableReplicas = 0
 					d.Status.UpdatedReplicas = 0
 					d.Status.ReadyReplicas = 0
@@ -470,7 +470,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				)).Should(Succeed(), "the ClusterPodPlacementConfig should have the correct conditions")
 				By("Verify no mutating webhook configuration is available")
 				err := k8sClient.Get(ctx, crclient.ObjectKey{
-					Name: podMutatingWebhookConfigurationName,
+					Name: utils.PodMutatingWebhookConfigurationName,
 				}, &admissionv1.MutatingWebhookConfiguration{})
 				Expect(err).To(HaveOccurred(), "the mutating webhook configuration should not be available", err)
 				Expect(errors.IsNotFound(err)).To(BeTrue(), "the mutating webhook configuration should not be available", err)
@@ -479,13 +479,13 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 		When("at least one replica is available for all components", func() {
 			It("should be available, progressing", func() {
 				By("Setting the deployment's available replicas to 1, minimum")
-				patchDeploymentStatus(PodPlacementControllerName, func(d *appsv1.Deployment) {
+				patchDeploymentStatus(utils.PodPlacementControllerName, func(d *appsv1.Deployment) {
 					d.Status.AvailableReplicas = 1
 					d.Status.UpdatedReplicas = 1
 					d.Status.ReadyReplicas = 1
 					d.Status.Replicas = 1
 				})
-				patchDeploymentStatus(PodPlacementWebhookName, func(d *appsv1.Deployment) {
+				patchDeploymentStatus(utils.PodPlacementWebhookName, func(d *appsv1.Deployment) {
 					d.Status.AvailableReplicas = 1
 					d.Status.UpdatedReplicas = 1
 					d.Status.ReadyReplicas = 1
@@ -502,7 +502,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				)).Should(Succeed(), "the ClusterPodPlacementConfig should have the correct conditions")
 				By("Verify the mutating webhook configuration is available")
 				err := k8sClient.Get(ctx, crclient.ObjectKey{
-					Name: podMutatingWebhookConfigurationName,
+					Name: utils.PodMutatingWebhookConfigurationName,
 				}, &admissionv1.MutatingWebhookConfiguration{})
 				Expect(err).NotTo(HaveOccurred(), "the mutating webhook configuration should be available", err)
 			})
@@ -519,7 +519,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				err = k8sClient.Update(ctx, ppc)
 				Expect(err).NotTo(HaveOccurred(), "failed to update ClusterPodPlacementConfig", err)
 				By("Verifying the deployments generation is different than the observed generation")
-				for _, name := range []string{PodPlacementControllerName, PodPlacementWebhookName} {
+				for _, name := range []string{utils.PodPlacementControllerName, utils.PodPlacementWebhookName} {
 					Eventually(func(g Gomega) {
 						d := appsv1.Deployment{}
 						err := k8sClient.Get(ctx, crclient.ObjectKey{
@@ -582,7 +582,7 @@ func setDeploymentReady(name string, g Gomega) {
 			Namespace: utils.Namespace(),
 		},
 	}), deployment)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+PodPlacementControllerName, err)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+utils.PodPlacementControllerName, err)
 	// This will simulate the deployment being available for the integration tests, letting the
 	// deployment controller to reconcile the deployment
 	deployment.Status.AvailableReplicas = *deployment.Spec.Replicas
@@ -591,7 +591,7 @@ func setDeploymentReady(name string, g Gomega) {
 	deployment.Status.Replicas = *deployment.Spec.Replicas
 	deployment.Status.ObservedGeneration = deployment.Generation
 	err = k8sClient.Status().Update(ctx, deployment)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to update deployment "+PodPlacementControllerName, err)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to update deployment "+utils.PodPlacementControllerName, err)
 }
 
 func reconcileDeployment(name string) func(g Gomega) {
@@ -614,29 +614,29 @@ func reconcileService(name string) func(g Gomega) {
 }
 
 func validateReconcile() {
-	By("Verifying the deployment " + PodPlacementControllerName + " is created")
-	Eventually(reconcileDeployment(PodPlacementControllerName)).Should(
-		Succeed(), "the deployment "+PodPlacementControllerName+" should be created")
-	By("Verifying the deployment " + PodPlacementWebhookName + " is created")
-	Eventually(reconcileDeployment(PodPlacementWebhookName)).Should(
-		Succeed(), "the deployment "+PodPlacementWebhookName+" should be created")
+	By("Verifying the deployment " + utils.PodPlacementControllerName + " is created")
+	Eventually(reconcileDeployment(utils.PodPlacementControllerName)).Should(
+		Succeed(), "the deployment "+utils.PodPlacementControllerName+" should be created")
+	By("Verifying the deployment " + utils.PodPlacementWebhookName + " is created")
+	Eventually(reconcileDeployment(utils.PodPlacementWebhookName)).Should(
+		Succeed(), "the deployment "+utils.PodPlacementWebhookName+" should be created")
 	By("Verifying the services are created")
-	Eventually(reconcileService(PodPlacementWebhookName)).Should(
-		Succeed(), "the service "+PodPlacementWebhookName+" should be created")
-	Eventually(reconcileService(podPlacementControllerMetricsServiceName)).Should(
-		Succeed(), "the service "+podPlacementControllerMetricsServiceName+" should be created")
-	Eventually(reconcileService(podPlacementWebhookMetricsServiceName)).Should(
-		Succeed(), "the service "+podPlacementWebhookMetricsServiceName+" should be created")
+	Eventually(reconcileService(utils.PodPlacementWebhookName)).Should(
+		Succeed(), "the service "+utils.PodPlacementWebhookName+" should be created")
+	Eventually(reconcileService(utils.PodPlacementControllerMetricsServiceName)).Should(
+		Succeed(), "the service "+utils.PodPlacementControllerMetricsServiceName+" should be created")
+	Eventually(reconcileService(utils.PodPlacementWebhookMetricsServiceName)).Should(
+		Succeed(), "the service "+utils.PodPlacementWebhookMetricsServiceName+" should be created")
 	By("Verifying the mutating webhook configuration is created")
 	Eventually(func(g Gomega) {
 		mutatingWebhookConf := &admissionv1.MutatingWebhookConfiguration{}
 		err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&admissionv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: podMutatingWebhookConfigurationName,
+				Name: utils.PodMutatingWebhookConfigurationName,
 			},
 		}), mutatingWebhookConf)
-		g.Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+podMutatingWebhookConfigurationName, err)
-	}).Should(Succeed(), "the mutating webhook configuration "+podMutatingWebhookConfigurationName+" should be created")
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get mutating webhook configuration "+utils.PodMutatingWebhookConfigurationName, err)
+	}).Should(Succeed(), "the mutating webhook configuration "+utils.PodMutatingWebhookConfigurationName+" should be created")
 	By("Verifying the ClusterPodPlacementConfig conditions")
 	Eventually(framework.VerifyConditions(ctx, k8sClient,
 		framework.NewConditionTypeStatusTuple(v1beta1.AvailableType, corev1.ConditionTrue),
@@ -655,67 +655,67 @@ func validateDeletion() {
 		deployment := &appsv1.Deployment{}
 		err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      PodPlacementControllerName,
+				Name:      utils.PodPlacementControllerName,
 				Namespace: utils.Namespace(),
 			},
 		}), deployment)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the deployment "+PodPlacementControllerName, err)
-	}).Should(Succeed(), "the deployment "+PodPlacementControllerName+" should be deleted")
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the deployment "+utils.PodPlacementControllerName, err)
+	}).Should(Succeed(), "the deployment "+utils.PodPlacementControllerName+" should be deleted")
 	Eventually(func(g Gomega) {
 		deployment := &appsv1.Deployment{}
 		err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      PodPlacementWebhookName,
+				Name:      utils.PodPlacementWebhookName,
 				Namespace: utils.Namespace(),
 			},
 		}), deployment)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the deployment "+PodPlacementWebhookName, err)
-	}).Should(Succeed(), "the deployment "+PodPlacementWebhookName+" should be created")
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the deployment "+utils.PodPlacementWebhookName, err)
+	}).Should(Succeed(), "the deployment "+utils.PodPlacementWebhookName+" should be created")
 	Eventually(func(g Gomega) {
 		service := &corev1.Service{}
 		err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      PodPlacementWebhookName,
+				Name:      utils.PodPlacementWebhookName,
 				Namespace: utils.Namespace(),
 			},
 		}), service)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the service "+PodPlacementWebhookName, err)
-	}).Should(Succeed(), "the service "+PodPlacementWebhookName+" should be created")
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the service "+utils.PodPlacementWebhookName, err)
+	}).Should(Succeed(), "the service "+utils.PodPlacementWebhookName+" should be created")
 	Eventually(func(g Gomega) {
 		service := &corev1.Service{}
 		err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      podPlacementControllerMetricsServiceName,
+				Name:      utils.PodPlacementControllerMetricsServiceName,
 				Namespace: utils.Namespace(),
 			},
 		}), service)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the service "+podPlacementControllerMetricsServiceName, err)
-	}).Should(Succeed(), "the service "+podPlacementControllerMetricsServiceName+" should be created")
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the service "+utils.PodPlacementControllerMetricsServiceName, err)
+	}).Should(Succeed(), "the service "+utils.PodPlacementControllerMetricsServiceName+" should be created")
 	Eventually(func(g Gomega) {
 		service := &corev1.Service{}
 		err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      podPlacementWebhookMetricsServiceName,
+				Name:      utils.PodPlacementWebhookMetricsServiceName,
 				Namespace: utils.Namespace(),
 			},
 		}), service)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the service "+podPlacementWebhookMetricsServiceName, err)
-	}).Should(Succeed(), "the service "+podPlacementWebhookMetricsServiceName+" should be created")
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the service "+utils.PodPlacementWebhookMetricsServiceName, err)
+	}).Should(Succeed(), "the service "+utils.PodPlacementWebhookMetricsServiceName+" should be created")
 	Eventually(func(g Gomega) {
 		mutatingWebhookConf := &admissionv1.MutatingWebhookConfiguration{}
 		err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&admissionv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: podMutatingWebhookConfigurationName,
+				Name: utils.PodMutatingWebhookConfigurationName,
 			},
 		}), mutatingWebhookConf)
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the mutating webhook configuration "+podMutatingWebhookConfigurationName, err)
-	}).Should(Succeed(), "the mutating webhook configuration "+podMutatingWebhookConfigurationName+" should be created")
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "still getting the mutating webhook configuration "+utils.PodMutatingWebhookConfigurationName, err)
+	}).Should(Succeed(), "the mutating webhook configuration "+utils.PodMutatingWebhookConfigurationName+" should be created")
 	Eventually(func(g Gomega) {
 		gppc := &v1beta1.ClusterPodPlacementConfig{}
 		err := k8sClient.Get(ctx, crclient.ObjectKey{

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -17,10 +17,10 @@ import (
 func buildMutatingWebhookConfiguration(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfig) *admissionv1.MutatingWebhookConfiguration {
 	return &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: podMutatingWebhookConfigurationName,
+			Name: utils.PodMutatingWebhookConfigurationName,
 			Labels: map[string]string{
 				utils.OperandLabelKey:   operandName,
-				utils.ControllerNameKey: PodPlacementWebhookName,
+				utils.ControllerNameKey: utils.PodPlacementWebhookName,
 			},
 			Annotations: map[string]string{
 				"service.beta.openshift.io/inject-cabundle": "true",
@@ -31,7 +31,7 @@ func buildMutatingWebhookConfiguration(clusterPodPlacementConfig *v1beta1.Cluste
 				AdmissionReviewVersions: []string{"v1"},
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{
-						Name:      PodPlacementWebhookName,
+						Name:      utils.PodPlacementWebhookName,
 						Namespace: utils.Namespace(),
 						Path:      utils.NewPtr("/add-pod-scheduling-gate"),
 					},
@@ -39,7 +39,7 @@ func buildMutatingWebhookConfiguration(clusterPodPlacementConfig *v1beta1.Cluste
 				NamespaceSelector: clusterPodPlacementConfig.Spec.NamespaceSelector,
 				FailurePolicy:     utils.NewPtr(admissionv1.Ignore),
 				SideEffects:       utils.NewPtr(admissionv1.SideEffectClassNone),
-				Name:              podMutatingWebhookName,
+				Name:              utils.PodMutatingWebhookName,
 				Rules: []admissionv1.RuleWithOperations{
 					{
 						Operations: []admissionv1.OperationType{

--- a/pkg/e2e/operator/e2e_test.go
+++ b/pkg/e2e/operator/e2e_test.go
@@ -4,17 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
-	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
 )
 
 var (
@@ -36,27 +33,3 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	client, clientset, ctx, suiteLog = e2e.CommonBeforeSuite()
 })
-
-func deploymentsAreRunning(g Gomega) {
-	d, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementControllerName,
-		metav1.GetOptions{})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(d.Status.AvailableReplicas).To(Equal(*d.Spec.Replicas),
-		"at least one pod placement controller replicas is not available yet")
-	d, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementWebhookName,
-		metav1.GetOptions{})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(d.Status.AvailableReplicas).To(Equal(*d.Spec.Replicas),
-		"at least one pod placement webhook replicas is not available yet")
-}
-
-func deploymentsAreDeleted(g Gomega) {
-	_, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementControllerName,
-		metav1.GetOptions{})
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	_, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementWebhookName,
-		metav1.GetOptions{})
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-}

--- a/pkg/e2e/operator/e2e_test.go
+++ b/pkg/e2e/operator/e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/openshift/multiarch-tuning-operator/controllers/operator"
 	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 
@@ -39,12 +38,12 @@ var _ = BeforeSuite(func() {
 })
 
 func deploymentsAreRunning(g Gomega) {
-	d, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementControllerName,
+	d, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementControllerName,
 		metav1.GetOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(d.Status.AvailableReplicas).To(Equal(*d.Spec.Replicas),
 		"at least one pod placement controller replicas is not available yet")
-	d, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementWebhookName,
+	d, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementWebhookName,
 		metav1.GetOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(d.Status.AvailableReplicas).To(Equal(*d.Spec.Replicas),
@@ -52,11 +51,11 @@ func deploymentsAreRunning(g Gomega) {
 }
 
 func deploymentsAreDeleted(g Gomega) {
-	_, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementControllerName,
+	_, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementControllerName,
 		metav1.GetOptions{})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	_, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementWebhookName,
+	_, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementWebhookName,
 		metav1.GetOptions{})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -34,7 +34,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
-		Eventually(deploymentsAreDeleted).Should(Succeed())
+		Eventually(framework.ValidateDeletion(client, ctx)).Should(Succeed())
 	})
 	Context("When the operator is running and a pod placement config is created", func() {
 		It("should deploy the operands with v1beta1 API", func() {
@@ -44,7 +44,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(deploymentsAreRunning).Should(Succeed())
+			Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed())
 			By("convert the v1beta1 CR to v1alpha1 should succeed")
 			c := &v1alpha1.ClusterPodPlacementConfig{}
 			err = client.Get(ctx, runtimeclient.ObjectKey{Name: "cluster"}, c)
@@ -57,7 +57,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(deploymentsAreRunning).Should(Succeed())
+			Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed())
 			By("convert the v1alpha1 CR to v1beta1 should succeed")
 			c := &v1beta1.ClusterPodPlacementConfig{}
 			err = client.Get(ctx, runtimeclient.ObjectKey{Name: "cluster"}, c)
@@ -79,7 +79,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 							},
 						}}}})
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(deploymentsAreRunning).Should(Succeed())
+			Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed())
 		})
 		It("should exclude namespaces that have the opt-out label", func() {
 			var err error
@@ -151,7 +151,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 							},
 						}}}})
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(deploymentsAreRunning).Should(Succeed())
+			Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed())
 		})
 		It("should exclude namespaces that do not match the opt-in configuration", func() {
 			var err error
@@ -223,7 +223,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 							},
 						}}}})
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(deploymentsAreRunning).Should(Succeed())
+			Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed())
 		})
 		DescribeTable("should not gate pods to schedule in control plane nodes", func(selector string) {
 			var err error

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -101,7 +101,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			//should exclude the namespace
 			verifyPodNodeAffinity(ns, "app", "test")
@@ -124,7 +124,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -170,7 +170,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			//should exclude the namespace
 			verifyPodNodeAffinity(ns, "app", "test")
@@ -196,7 +196,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -244,7 +244,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			//should exclude the namespace
 			verifyPodNodeAffinity(ns, "app", "test")

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -104,8 +104,8 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			//should exclude the namespace
-			verifyPodNodeAffinity(ns, "app", "test")
 			verifyPodLabels(ns, "app", "test", e2e.Absent, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test")
 		})
 		It("should handle namespaces that do not have the opt-out label", func() {
 			var err error
@@ -132,8 +132,8 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			//should handle the namespace
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 	})
 	Context("The operator should respect to an opt-in namespaceSelector in ClusterPodPlacementConfig CR", func() {
@@ -173,8 +173,8 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			//should exclude the namespace
-			verifyPodNodeAffinity(ns, "app", "test")
 			verifyPodLabels(ns, "app", "test", e2e.Absent, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test")
 		})
 		It("should handle namespaces that match the opt-in configuration", func() {
 			var err error
@@ -204,8 +204,8 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			//should handle the namespace
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 	})
 	Context("The webhook should not gate pods with node selectors that pin them to the control plane", func() {
@@ -247,8 +247,8 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			//should exclude the namespace
-			verifyPodNodeAffinity(ns, "app", "test")
 			verifyPodLabels(ns, "app", "test", e2e.Absent, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test")
 		},
 			Entry(utils.ControlPlaneNodeSelectorLabel, utils.ControlPlaneNodeSelectorLabel),
 			Entry(utils.MasterNodeSelectorLabel, utils.MasterNodeSelectorLabel),

--- a/pkg/e2e/podplacement/e2e_test.go
+++ b/pkg/e2e/podplacement/e2e_test.go
@@ -26,7 +26,6 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
-	"github.com/openshift/multiarch-tuning-operator/controllers/operator"
 	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
 	"github.com/openshift/multiarch-tuning-operator/pkg/testing/framework"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
@@ -102,12 +101,12 @@ var _ = AfterSuite(func() {
 })
 
 func deploymentsAreRunning(g Gomega) {
-	d, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementControllerName,
+	d, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementControllerName,
 		metav1.GetOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(d.Status.AvailableReplicas).To(Equal(*d.Spec.Replicas),
 		"at least one pod placement controller replicas is not available yet")
-	d, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementWebhookName,
+	d, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementWebhookName,
 		metav1.GetOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(d.Status.AvailableReplicas).To(Equal(*d.Spec.Replicas),
@@ -115,11 +114,11 @@ func deploymentsAreRunning(g Gomega) {
 }
 
 func deploymentsAreDeleted(g Gomega) {
-	_, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementControllerName,
+	_, err := clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementControllerName,
 		metav1.GetOptions{})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	_, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, operator.PodPlacementWebhookName,
+	_, err = clientset.AppsV1().Deployments(utils.Namespace()).Get(ctx, utils.PodPlacementWebhookName,
 		metav1.GetOptions{})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -65,7 +65,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -97,10 +97,10 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithSubjects(s).
 				WithName(ephemeralCRBName).
 				Build()
-			err = client.Create(ctx, &crb)
+			err = client.Create(ctx, crb)
 			Expect(err).NotTo(HaveOccurred())
 			//nolint:errcheck
-			defer client.Delete(ctx, &crb)
+			defer client.Delete(ctx, crb)
 			sc := NewSecurityContext().WithPrivileged(utils.NewPtr(true)).
 				WithRunAsGroup(utils.NewPtr(int64(0))).
 				WithRunAsUSer(utils.NewPtr(int64(0))).
@@ -124,7 +124,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			// TODO: verify the pod has some scc label
 			sccAnnotation := map[string]string{"openshift.io/scc": "privileged"}
@@ -159,7 +159,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -190,7 +190,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			verifyPodNodeAffinity(ns, "app", "test", archLabelNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
@@ -220,7 +220,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			expectedArchLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -249,7 +249,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			verifyPodNodeAffinity(ns, "app", "test")
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
@@ -278,7 +278,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			By("The pod should not have been processed by the webhook and the scheduling gate label should not be added")
 			verifyPodLabels(ns, "app", "test", e2e.Absent, schedulingGateLabel)
@@ -545,7 +545,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			verifyPodNodeAffinity(ns, "app", "test")
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
@@ -567,7 +567,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureArm64, utils.ArchitecturePpc64le).
@@ -607,7 +607,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -649,7 +649,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureArm64).
@@ -706,7 +706,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -745,7 +745,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			verifyPodNodeAffinity(ns, "app", "test")
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
@@ -803,7 +803,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -869,7 +869,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
@@ -912,7 +912,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment-blocked").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			verifyPodNodeAffinity(ns, "app", "test-block")
 			verifyPodLabels(ns, "app", "test-block", e2e.Present, schedulingGateLabel)
@@ -926,7 +926,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithName("test-deployment").
 				WithNamespace(ns.Name).
 				Build()
-			err = client.Create(ctx, &d)
+			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			archLabelNSR := NewNodeSelectorRequirement().
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -47,6 +47,16 @@ var _ = Describe("The Pod Placement Operand", func() {
 		podLabel            = map[string]string{"app": "test"}
 		schedulingGateLabel = map[string]string{utils.SchedulingGateLabel: utils.SchedulingGateLabelValueRemoved}
 	)
+	BeforeEach(func() {
+		By("Verifying the operand is ready")
+		Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed(), "operand not ready before the test case execution")
+		By("Operand ready. Executing the case")
+	})
+	AfterEach(func() {
+		By("Verify the operand is ready after the case ran")
+		Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed(), "operand not ready after the test case execution")
+		By("Operand ready after the case execution. Continuing")
+	})
 	Context("When a deployment is deployed with a single container and a public image", func() {
 		It("should set the node affinity", func() {
 			var err error

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -53,7 +53,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 		By("Operand ready. Executing the case")
 	})
 	AfterEach(func() {
-		By("Verify the operand is ready after the case ran")
+		By("Verify the operand is still ready after the case ran")
 		Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed(), "operand not ready after the test case execution")
 		By("Operand ready after the case execution. Continuing")
 	})
@@ -82,8 +82,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity on privileged deployments", func() {
 			var err error
@@ -144,8 +144,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity when users node affinity do not conflict", func() {
 			var err error
@@ -176,8 +176,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&hostnameLabelNSR, &archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should not set the node affinity when users node affinity conflicts", func() {
 			var err error
@@ -202,8 +202,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
-			verifyPodNodeAffinity(ns, "app", "test", archLabelNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", archLabelNSTs)
 		})
 		It("should check each matchExpressions when users node affinity has multiple matchExpressions", func() {
 			var err error
@@ -237,8 +237,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedHostnameNST := NewNodeSelectorTerm().WithMatchExpressions(&hostnameLabelNSR, &expectedArchLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedHostnameNST, archLabelNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedHostnameNST, archLabelNSTs)
 		})
 		It("should not set the node affinity when nodeSelector exist", func() {
 			var err error
@@ -261,8 +261,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
-			verifyPodNodeAffinity(ns, "app", "test")
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test")
 		})
 		It("should not set the node affinity when nodeName exist", func() {
 			var err error
@@ -324,8 +324,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureArm64).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity when with a single container and a multiarch image", func() {
 			var err error
@@ -351,8 +351,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity when with more containers some with singlearch image some with multiarch image", func() {
 			var err error
@@ -377,8 +377,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureArm64).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should not set the node affinity when with more containers all with multiarch image but users node affinity conflicts", func() {
 			var err error
@@ -404,8 +404,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 			err = client.Create(ctx, &s)
 			Expect(err).NotTo(HaveOccurred())
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity when with more containers all with multiarch image", func() {
 			var err error
@@ -430,8 +430,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureArm64).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 	})
 	Context("PodPlacementOperand works with several high-level resources owning pods", func() {
@@ -457,8 +457,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
-			verifyDaemonSetPodNodeAffinity(ns, "app", "test", archLabelNSR)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyDaemonSetPodNodeAffinity(ns, "app", "test", archLabelNSR)
 		})
 		It("should set the node affinity on Job owning pod", func() {
 			var err error
@@ -484,8 +484,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity on Build owning pod", func() {
 			var err error
@@ -506,8 +506,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "openshift.io/build.name", "test-build", expectedNSTs)
 			verifyPodLabels(ns, "openshift.io/build.name", "test-build", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "openshift.io/build.name", "test-build", expectedNSTs)
 		})
 		It("should set the node affinity on DeploymentConfig owning pod", func() {
 			var err error
@@ -533,8 +533,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 	})
 	Context("When deploying workloads with public and private images", func() {
@@ -557,8 +557,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
-			verifyPodNodeAffinity(ns, "app", "test")
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test")
 		})
 		It("should set the node affinity in pods with images requiring credentials set in the global pull secret", func() {
 			var err error
@@ -583,8 +583,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureArm64, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity in pods with images requiring credentials set in pods imagePullSecrets", func() {
 			var err error
@@ -624,8 +624,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity in pods with images that require both global and local pull secrets", func() {
 			var err error
@@ -924,8 +924,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
-			verifyPodNodeAffinity(ns, "app", "test-block")
 			verifyPodLabels(ns, "app", "test-block", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test-block")
 			// Check ppo will allow image from registry not in blocked registry list
 			d = NewDeployment().
 				WithSelectorAndPodLabels(podLabel).
@@ -943,8 +943,8 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 	})
 })

--- a/pkg/testing/builder/cluster_role_binding_builder.go
+++ b/pkg/testing/builder/cluster_role_binding_builder.go
@@ -6,13 +6,13 @@ import (
 
 // ClusterRoleBindingBuilder is a builder for v1.ClusterRoleBinding objects to be used only in unit tests.
 type ClusterRoleBindingBuilder struct {
-	clusterRoleBinding v1.ClusterRoleBinding
+	clusterRoleBinding *v1.ClusterRoleBinding
 }
 
 // NewClusterRoleBinding returns a new ClusterRoleBindingBuilder to build v1.ClusterRoleBinding objects. It is meant to be used only in unit tests.
 func NewClusterRoleBinding() *ClusterRoleBindingBuilder {
 	return &ClusterRoleBindingBuilder{
-		clusterRoleBinding: v1.ClusterRoleBinding{},
+		clusterRoleBinding: &v1.ClusterRoleBinding{},
 	}
 }
 
@@ -35,6 +35,6 @@ func (c *ClusterRoleBindingBuilder) WithSubjects(subjects ...v1.Subject) *Cluste
 	return c
 }
 
-func (c *ClusterRoleBindingBuilder) Build() v1.ClusterRoleBinding {
+func (c *ClusterRoleBindingBuilder) Build() *v1.ClusterRoleBinding {
 	return c.clusterRoleBinding
 }

--- a/pkg/testing/builder/clusterpodplacementconfig_builder.go
+++ b/pkg/testing/builder/clusterpodplacementconfig_builder.go
@@ -1,0 +1,36 @@
+package builder
+
+import (
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ClusterPodPlacementConfigBuilder struct {
+	*v1beta1.ClusterPodPlacementConfig
+}
+
+func NewClusterPodPlacementConfig() *ClusterPodPlacementConfigBuilder {
+	return &ClusterPodPlacementConfigBuilder{
+		ClusterPodPlacementConfig: &v1beta1.ClusterPodPlacementConfig{},
+	}
+}
+
+func (p *ClusterPodPlacementConfigBuilder) WithName(name string) *ClusterPodPlacementConfigBuilder {
+	p.Name = name
+	return p
+}
+
+func (p *ClusterPodPlacementConfigBuilder) WithNamespaceSelector(labelSelector *v1.LabelSelector) *ClusterPodPlacementConfigBuilder {
+	p.Spec.NamespaceSelector = labelSelector
+	return p
+}
+
+func (p *ClusterPodPlacementConfigBuilder) WithLogVerbosity(logVerbosity common.LogVerbosityLevel) *ClusterPodPlacementConfigBuilder {
+	p.Spec.LogVerbosity = logVerbosity
+	return p
+}
+
+func (p *ClusterPodPlacementConfigBuilder) Build() *v1beta1.ClusterPodPlacementConfig {
+	return p.ClusterPodPlacementConfig
+}

--- a/pkg/testing/builder/deployment_builder.go
+++ b/pkg/testing/builder/deployment_builder.go
@@ -8,13 +8,13 @@ import (
 
 // DeploymentBuilder is a builder for appsv1.Deployment objects to be used only in unit tests.
 type DeploymentBuilder struct {
-	deployment appsv1.Deployment
+	deployment *appsv1.Deployment
 }
 
 // NewDeployment returns a new DeploymentBuilder to build appsv1.Deployment objects. It is meant to be used only in unit tests.
 func NewDeployment() *DeploymentBuilder {
 	return &DeploymentBuilder{
-		deployment: appsv1.Deployment{},
+		deployment: &appsv1.Deployment{},
 	}
 }
 
@@ -55,6 +55,6 @@ func (d *DeploymentBuilder) WithNamespace(namespace string) *DeploymentBuilder {
 	return d
 }
 
-func (d *DeploymentBuilder) Build() appsv1.Deployment {
+func (d *DeploymentBuilder) Build() *appsv1.Deployment {
 	return d.deployment
 }

--- a/pkg/testing/builder/mutating_webhook_configuration_builder.go
+++ b/pkg/testing/builder/mutating_webhook_configuration_builder.go
@@ -1,0 +1,22 @@
+package builder
+
+import v1 "k8s.io/api/admissionregistration/v1"
+
+type MutatingWebhookConfigurationBuilder struct {
+	mutatingWebhookConfiguration v1.MutatingWebhookConfiguration
+}
+
+func NewMutatingWebhookConfiguration() *MutatingWebhookConfigurationBuilder {
+	return &MutatingWebhookConfigurationBuilder{
+		mutatingWebhookConfiguration: v1.MutatingWebhookConfiguration{},
+	}
+}
+
+func (m *MutatingWebhookConfigurationBuilder) WithName(name string) *MutatingWebhookConfigurationBuilder {
+	m.mutatingWebhookConfiguration.Name = name
+	return m
+}
+
+func (m *MutatingWebhookConfigurationBuilder) Build() *v1.MutatingWebhookConfiguration {
+	return &m.mutatingWebhookConfiguration
+}

--- a/pkg/testing/builder/service_builder.go
+++ b/pkg/testing/builder/service_builder.go
@@ -4,13 +4,13 @@ import v1 "k8s.io/api/core/v1"
 
 // ServiceBuilder is a builder for v1.Service objects to be used only in unit tests.
 type ServiceBuilder struct {
-	service v1.Service
+	service *v1.Service
 }
 
 // Newservice returns a new ServiceBuilder to build v1.Service objects. It is meant to be used only in unit tests.
 func NewService() *ServiceBuilder {
 	return &ServiceBuilder{
-		service: v1.Service{},
+		service: &v1.Service{},
 	}
 }
 
@@ -39,6 +39,6 @@ func (s *ServiceBuilder) WithSelector(entries map[string]string) *ServiceBuilder
 	return s
 }
 
-func (s *ServiceBuilder) Build() v1.Service {
+func (s *ServiceBuilder) Build() *v1.Service {
 	return s.service
 }

--- a/pkg/testing/framework/cluster_pod_placement_config.go
+++ b/pkg/testing/framework/cluster_pod_placement_config.go
@@ -3,20 +3,28 @@ package framework
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
-	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
+	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
 
 type ConditionTypeStatusTuple struct {
 	ConditionType   string
-	ConditionStatus v1.ConditionStatus
+	ConditionStatus corev1.ConditionStatus
 }
 
-func NewConditionTypeStatusTuple(conditionType string, conditionStatus v1.ConditionStatus) ConditionTypeStatusTuple {
+func NewConditionTypeStatusTuple(conditionType string, conditionStatus corev1.ConditionStatus) ConditionTypeStatusTuple {
 	return ConditionTypeStatusTuple{
 		ConditionType:   conditionType,
 		ConditionStatus: conditionStatus,
@@ -36,5 +44,51 @@ func VerifyConditions(ctx context.Context, c client.Client, conditionTypeStatusT
 			g.Expect(v1helpers.FindCondition(ppc.Status.Conditions, conditionType)).NotTo(gomega.BeNil(), "the condition "+conditionType+" should be set")
 			g.Expect(v1helpers.FindCondition(ppc.Status.Conditions, conditionType).Status).To(gomega.BeEquivalentTo(conditionStatus), "the condition"+conditionType+" should be "+string(conditionStatus))
 		}
+	}
+}
+
+func getObjects() []client.Object {
+	return []client.Object{
+		builder.NewDeployment().WithName(utils.PodPlacementControllerName).WithNamespace(utils.Namespace()).Build(),
+		builder.NewDeployment().WithName(utils.PodPlacementWebhookName).WithNamespace(utils.Namespace()).Build(),
+		builder.NewService().WithName(utils.PodPlacementWebhookName).WithNamespace(utils.Namespace()).Build(),
+		builder.NewService().WithName(utils.PodPlacementControllerMetricsServiceName).WithNamespace(utils.Namespace()).Build(),
+		builder.NewService().WithName(utils.PodPlacementWebhookMetricsServiceName).WithNamespace(utils.Namespace()).Build(),
+		builder.NewMutatingWebhookConfiguration().WithName(utils.PodMutatingWebhookConfigurationName).Build(),
+		builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName),
+	}
+}
+
+func ValidateDeletion(cl client.Client, ctx context.Context) func(gomega.Gomega) {
+	return func(g gomega.Gomega) {
+		for _, obj := range getObjects() {
+			newObj := obj.DeepCopyObject().(client.Object)
+			err := cl.Get(ctx, client.ObjectKeyFromObject(obj), newObj)
+			g.Expect(err).To(gomega.HaveOccurred(), "the object should be deleted", err)
+			g.Expect(errors.IsNotFound(err)).To(gomega.BeTrue(), "the error should be \"Not found\"", err)
+		}
+	}
+}
+
+func ValidateCreation(cl client.Client, ctx context.Context) func(gomega.Gomega) {
+	return func(g gomega.Gomega) {
+		ginkgo.By("Verify all objects exist")
+		for _, obj := range getObjects() {
+			newObj := obj.DeepCopyObject().(client.Object)
+			err := cl.Get(ctx, client.ObjectKeyFromObject(obj), newObj)
+			g.Expect(err).NotTo(gomega.HaveOccurred(), "the object should be created", err)
+			g.Expect(newObj).NotTo(gomega.BeNil(), "the object should not be nil")
+			g.Expect(newObj.GetDeletionTimestamp().IsZero()).To(gomega.BeTrue(), "the object should not be marked for deletion")
+		}
+		ginkgo.By("Verify the ClusterPodPlacementConfig conditions")
+		VerifyConditions(ctx, cl,
+			NewConditionTypeStatusTuple(v1beta1.AvailableType, corev1.ConditionTrue),
+			NewConditionTypeStatusTuple(v1beta1.ProgressingType, corev1.ConditionFalse),
+			NewConditionTypeStatusTuple(v1beta1.DegradedType, corev1.ConditionFalse),
+			NewConditionTypeStatusTuple(v1beta1.PodPlacementControllerNotRolledOutType, corev1.ConditionFalse),
+			NewConditionTypeStatusTuple(v1beta1.PodPlacementWebhookNotRolledOutType, corev1.ConditionFalse),
+			NewConditionTypeStatusTuple(v1beta1.MutatingWebhookConfigurationNotAvailable, corev1.ConditionFalse),
+			NewConditionTypeStatusTuple(v1beta1.DeprovisioningType, corev1.ConditionFalse),
+		)
 	}
 }

--- a/pkg/testing/framework/cluster_pod_placement_config.go
+++ b/pkg/testing/framework/cluster_pod_placement_config.go
@@ -1,0 +1,40 @@
+package framework
+
+import (
+	"context"
+
+	"github.com/onsi/gomega"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ConditionTypeStatusTuple struct {
+	ConditionType   string
+	ConditionStatus v1.ConditionStatus
+}
+
+func NewConditionTypeStatusTuple(conditionType string, conditionStatus v1.ConditionStatus) ConditionTypeStatusTuple {
+	return ConditionTypeStatusTuple{
+		ConditionType:   conditionType,
+		ConditionStatus: conditionStatus,
+	}
+}
+
+func VerifyConditions(ctx context.Context, c client.Client, conditionTypeStatusTuples ...ConditionTypeStatusTuple) func(g gomega.Gomega) {
+	return func(g gomega.Gomega) {
+		ppc := &v1beta1.ClusterPodPlacementConfig{}
+		err := c.Get(ctx, client.ObjectKey{
+			Name: common.SingletonResourceObjectName,
+		}, ppc)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get ClusterPodPlacementConfig", err)
+		for _, condStatusPairs := range conditionTypeStatusTuples {
+			conditionType := condStatusPairs.ConditionType
+			conditionStatus := condStatusPairs.ConditionStatus
+			g.Expect(v1helpers.FindCondition(ppc.Status.Conditions, conditionType)).NotTo(gomega.BeNil(), "the condition "+conditionType+" should be set")
+			g.Expect(v1helpers.FindCondition(ppc.Status.Conditions, conditionType).Status).To(gomega.BeEquivalentTo(conditionStatus), "the condition"+conditionType+" should be "+string(conditionStatus))
+		}
+	}
+}

--- a/pkg/testing/registry/registry.go
+++ b/pkg/testing/registry/registry.go
@@ -73,7 +73,7 @@ func Deploy(ctx context.Context, client runtimeclient.Client, r *RegistryConfig)
 				Build()).
 		WithSelector(registryLabel).
 		Build()
-	err := client.Create(ctx, &service)
+	err := client.Create(ctx, service)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func Deploy(ctx context.Context, client runtimeclient.Client, r *RegistryConfig)
 		WithName(r.Name).
 		WithNamespace(r.Namespace.Name).
 		Build()
-	err = client.Create(ctx, &registryD)
+	err = client.Create(ctx, registryD)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -31,3 +31,12 @@ const (
 	MasterNodeSelectorLabel       = "node-role.kubernetes.io/master"
 	ControlPlaneNodeSelectorLabel = "node-role.kubernetes.io/control-plane"
 )
+
+const (
+	PodMutatingWebhookName                   = "pod-placement-scheduling-gate.multiarch.openshift.io"
+	PodMutatingWebhookConfigurationName      = "pod-placement-mutating-webhook-configuration"
+	PodPlacementControllerName               = "pod-placement-controller"
+	PodPlacementControllerMetricsServiceName = "pod-placement-controller-metrics-service"
+	PodPlacementWebhookName                  = "pod-placement-web-hook"
+	PodPlacementWebhookMetricsServiceName    = "pod-placement-web-hook-metrics-service"
+)


### PR DESCRIPTION
This commit implements the handling of the following conditions for the ClusterPodPlacementConfig:
   - Degraded: if some components are not available (no replicas) and the object is not deprovisioning
   - Deprovisioning: if the object is being deleted
   - MutatingWebhookConfigurationNotAvailable: if the mutating webhook configuration does not exist
   - PodPlacementControllerNotReady: if the pod placement controller is not available or up-to-date
   - PodPlacementWebhookNotReady: if the pod placement webhook is not available or up-to-date
   - Progressing: if the object is not deprovisioning and some of the components are not up-to-date.
   - Available: if all the components are available to serve the requests and reconcile node affinities (at least one replica).

This allows the users to be informed about the status of the operand.
When the operand is available and all the components are up-to-date, the only condition shown/set is "Available."

When the ClusterPodPlacementConfig is updated, or some components are being rolled out, the "Progressing" condition is set.

When progressing, if at least one replica is available for both the controller and webhook, the operand is considered available.
In this case, we also allow the deployment of the mutating webhook configuration.

Despite the current FailurePolicy of the MutatingWebhookConfiguration is set to None, if some components lack at least one replica's availability, we forcibly delete the MutatingWebhookConfiguration, and the Degraded condition is set. Similarly, we now deploy the MutatingWebhookConfiguration only if at least one replica of the MutatingWebhook and Controller deployments are available (such that we can ensure both the admission patching and the removal of gates through the controller).

When removing the object, the deprovisioning condition is set and the users are informed about the controller pending deletion if there exists at least one pod that is still gated.

This depends on #207

Only consider the last commit for review.

Evolution of the object (creation + pod pending with scheduling gate + deprovisioning): https://gist.github.com/aleskandro/1297d346f6749fa6c0a0fa5db69d764f


Also added columns to print out when using CLI:
```
└ $ oc get clusterpodplacementconfigs.multiarch.openshift.io
NAME      AVAILABLE   PROGRESSING   DEGRADED   SINCE   STATUS
cluster   True        False         False      13h     AllComponentsReady
```