### PR TITLE
OCPBUGS-38601: The operand should not fail when the operator is uninstalled without prior deletion of the operator

### DIFF
--- a/apis/multiarch/v1beta1/groupversion_info.go
+++ b/apis/multiarch/v1beta1/groupversion_info.go
@@ -34,3 +34,5 @@ var (
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+const ClusterPodPlacementConfigResource = "clusterpodplacementconfigs"

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2024-08-09T14:50:21Z"
+    createdAt: "2024-08-16T17:21:28Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -180,6 +180,7 @@ spec:
           - events
           verbs:
           - create
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -206,6 +207,30 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts/status
+          verbs:
+          - get
         - apiGroups:
           - ""
           resources:
@@ -258,6 +283,102 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings/status
+          verbs:
+          - get
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles/status
+          verbs:
+          - get
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings/status
+          verbs:
+          - get
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles/status
+          verbs:
+          - get
         - apiGroups:
           - security.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,6 +85,7 @@ rules:
   - events
   verbs:
   - create
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -111,6 +112,30 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/status
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -163,6 +188,102 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings/status
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles/status
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings/status
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles/status
+  verbs:
+  - get
 - apiGroups:
   - security.openshift.io
   resources:

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -274,6 +274,20 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 					},
 					PriorityClassName:  priorityClassName,
 					ServiceAccountName: serviceAccount,
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.ScheduleAnyway,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									utils.OperandLabelKey:   operandName,
+									utils.ControllerNameKey: name,
+								},
+							},
+							MatchLabelKeys: []string{"pod-template-hash"},
+						},
+					},
 					Volumes: []corev1.Volume{
 						{
 							Name: "webhook-server-cert",

--- a/pkg/testing/builder/cluster_role_builder.go
+++ b/pkg/testing/builder/cluster_role_builder.go
@@ -1,0 +1,24 @@
+package builder
+
+import rbacv1 "k8s.io/api/rbac/v1"
+
+// ClusterRoleBuilder is a builder for rbacv1.ClusterRole objects to be used only in unit tests.
+type ClusterRoleBuilder struct {
+	clusterRoleBinding *rbacv1.ClusterRole
+}
+
+// NewClusterRole returns a new ClusterRoleBuilder to build rbacv1.ClusterRole objects. It is meant to be used only in unit tests.
+func NewClusterRole() *ClusterRoleBuilder {
+	return &ClusterRoleBuilder{
+		clusterRoleBinding: &rbacv1.ClusterRole{},
+	}
+}
+
+func (c *ClusterRoleBuilder) Build() *rbacv1.ClusterRole {
+	return c.clusterRoleBinding
+}
+
+func (c *ClusterRoleBuilder) WithName(name string) *ClusterRoleBuilder {
+	c.clusterRoleBinding.Name = name
+	return c
+}

--- a/pkg/testing/builder/role_binding_builder.go
+++ b/pkg/testing/builder/role_binding_builder.go
@@ -1,0 +1,28 @@
+package builder
+
+import rbacv1 "k8s.io/api/rbac/v1"
+
+type RoleBindingBuilder struct {
+	roleBinding *rbacv1.RoleBinding
+}
+
+// NewRoleBinding returns a new RoleBindingBuilder to build rbacv1.RoleBinding objects. It is meant to be used only in unit tests.
+func NewRoleBinding() *RoleBindingBuilder {
+	return &RoleBindingBuilder{
+		roleBinding: &rbacv1.RoleBinding{},
+	}
+}
+
+func (c *RoleBindingBuilder) Build() *rbacv1.RoleBinding {
+	return c.roleBinding
+}
+
+func (c *RoleBindingBuilder) WithName(name string) *RoleBindingBuilder {
+	c.roleBinding.Name = name
+	return c
+}
+
+func (c *RoleBindingBuilder) WithNamespace(namespace string) *RoleBindingBuilder {
+	c.roleBinding.Namespace = namespace
+	return c
+}

--- a/pkg/testing/builder/role_builder.go
+++ b/pkg/testing/builder/role_builder.go
@@ -1,0 +1,29 @@
+package builder
+
+import rbacv1 "k8s.io/api/rbac/v1"
+
+// RoleBuilder is a builder for rbacv1.ClusterRole objects to be used only in unit tests.
+type RoleBuilder struct {
+	role *rbacv1.Role
+}
+
+// NewRole returns a new ClusterRoleBuilder to build rbacv1.ClusterRole objects. It is meant to be used only in unit tests.
+func NewRole() *RoleBuilder {
+	return &RoleBuilder{
+		role: &rbacv1.Role{},
+	}
+}
+
+func (c *RoleBuilder) Build() *rbacv1.Role {
+	return c.role
+}
+
+func (c *RoleBuilder) WithName(name string) *RoleBuilder {
+	c.role.Name = name
+	return c
+}
+
+func (c *RoleBuilder) WithNamespace(namespace string) *RoleBuilder {
+	c.role.Namespace = namespace
+	return c
+}

--- a/pkg/testing/builder/service_account_builder.go
+++ b/pkg/testing/builder/service_account_builder.go
@@ -1,0 +1,28 @@
+package builder
+
+import v1 "k8s.io/api/core/v1"
+
+type ServiceAccountBuilder struct {
+	serviceAccount *v1.ServiceAccount
+}
+
+// NewServiceAccount returns a new ServiceAccountBuilder to build v1.ServiceAccount objects. It is meant to be used only in unit tests.
+func NewServiceAccount() *ServiceAccountBuilder {
+	return &ServiceAccountBuilder{
+		serviceAccount: &v1.ServiceAccount{},
+	}
+}
+
+func (c *ServiceAccountBuilder) Build() *v1.ServiceAccount {
+	return c.serviceAccount
+}
+
+func (c *ServiceAccountBuilder) WithName(name string) *ServiceAccountBuilder {
+	c.serviceAccount.Name = name
+	return c
+}
+
+func (c *ServiceAccountBuilder) WithNamespace(namespace string) *ServiceAccountBuilder {
+	c.serviceAccount.Namespace = namespace
+	return c
+}

--- a/pkg/testing/framework/cluster_pod_placement_config.go
+++ b/pkg/testing/framework/cluster_pod_placement_config.go
@@ -55,6 +55,14 @@ func getObjects() []client.Object {
 		builder.NewService().WithName(utils.PodPlacementControllerMetricsServiceName).WithNamespace(utils.Namespace()).Build(),
 		builder.NewService().WithName(utils.PodPlacementWebhookMetricsServiceName).WithNamespace(utils.Namespace()).Build(),
 		builder.NewMutatingWebhookConfiguration().WithName(utils.PodMutatingWebhookConfigurationName).Build(),
+		builder.NewClusterRole().WithName(utils.PodPlacementControllerName).Build(),
+		builder.NewClusterRole().WithName(utils.PodPlacementWebhookName).Build(),
+		builder.NewClusterRoleBinding().WithName(utils.PodPlacementControllerName).Build(),
+		builder.NewClusterRoleBinding().WithName(utils.PodPlacementWebhookName).Build(),
+		builder.NewRole().WithName(utils.PodPlacementControllerName).WithNamespace(utils.Namespace()).Build(),
+		builder.NewRoleBinding().WithName(utils.PodPlacementControllerName).WithNamespace(utils.Namespace()).Build(),
+		builder.NewServiceAccount().WithName(utils.PodPlacementControllerName).WithNamespace(utils.Namespace()).Build(),
+		builder.NewServiceAccount().WithName(utils.PodPlacementWebhookName).WithNamespace(utils.Namespace()).Build(),
 		builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName),
 	}
 }

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -33,10 +33,10 @@ const (
 )
 
 const (
-	PodMutatingWebhookName                   = "pod-placement-scheduling-gate.multiarch.openshift.io"
 	PodMutatingWebhookConfigurationName      = "pod-placement-mutating-webhook-configuration"
-	PodPlacementControllerName               = "pod-placement-controller"
-	PodPlacementControllerMetricsServiceName = "pod-placement-controller-metrics-service"
-	PodPlacementWebhookName                  = "pod-placement-web-hook"
 	PodPlacementWebhookMetricsServiceName    = "pod-placement-web-hook-metrics-service"
+	PodMutatingWebhookName                   = "pod-placement-scheduling-gate.multiarch.openshift.io"
+	PodPlacementControllerMetricsServiceName = "pod-placement-controller-metrics-service"
+	PodPlacementControllerName               = "pod-placement-controller"
+	PodPlacementWebhookName                  = "pod-placement-web-hook"
 )

--- a/pkg/utils/resource.go
+++ b/pkg/utils/resource.go
@@ -7,6 +7,7 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -51,6 +52,16 @@ func ApplyResource(ctx context.Context, clientSet *kubernetes.Clientset, recorde
 	case *admissionv1.MutatingWebhookConfiguration:
 		return resourceapply.ApplyMutatingWebhookConfigurationImproved(ctx, clientSet.AdmissionregistrationV1(),
 			recorder, t, resourceCache)
+	case *rbacv1.Role:
+		return resourceapply.ApplyRole(ctx, clientSet.RbacV1(), recorder, t)
+	case *rbacv1.RoleBinding:
+		return resourceapply.ApplyRoleBinding(ctx, clientSet.RbacV1(), recorder, t)
+	case *corev1.ServiceAccount:
+		return resourceapply.ApplyServiceAccount(ctx, clientSet.CoreV1(), recorder, t)
+	case *rbacv1.ClusterRole:
+		return resourceapply.ApplyClusterRole(ctx, clientSet.RbacV1(), recorder, t)
+	case *rbacv1.ClusterRoleBinding:
+		return resourceapply.ApplyClusterRoleBinding(ctx, clientSet.RbacV1(), recorder, t)
 	default:
 		return nil, false, fmt.Errorf("unhandled type %T", obj)
 	}


### PR DESCRIPTION
When the operator is uninstalled without prior deletion of the operand, we should not let the operand fail. This is due to the removal of the service account and other RBAC objects. This commit will let the operator create the RBAC objects and additional service accounts detached from the OLM ones.
The first commit also includes an edge-case fix: when a deployment is deleted outside of the operand's lifecycle, the operator must be able to reconcile it, so we need to remove the finalizer.

This PR also adds TopologySpreadConstraints to handle scenarios of nodes maintenance.

~Depends on https://github.com/openshift/multiarch-tuning-operator/pull/214~
