### PR TITLE
Mount the nodes' /etc/containers/ and /etc/docker/

### DIFF
--- a/controllers/operator/clusterpodplacementconfig_controller.go
+++ b/controllers/operator/clusterpodplacementconfig_controller.go
@@ -375,13 +375,8 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 				Namespace: utils.Namespace(),
 			},
 		}),
-		buildDeployment(clusterPodPlacementConfig, utils.PodPlacementControllerName, 2, utils.PodPlacementControllerName,
-			utils.PodPlacementFinalizerName, "--leader-elect",
-			"--enable-ppc-controllers",
-		),
-		buildDeployment(clusterPodPlacementConfig, utils.PodPlacementWebhookName, 3, utils.PodPlacementWebhookName, "",
-			"--enable-ppc-webhook",
-		),
+		buildControllerDeployment(clusterPodPlacementConfig),
+		buildWebhookDeployment(clusterPodPlacementConfig),
 	}
 	// We ensure the MutatingWebHookConfiguration is created and present only if the operand is ready to serve the admission request and add/remove the scheduling gate.
 	shouldEnsureMWC := clusterPodPlacementConfig.Status.CanDeployMutatingWebhook()

--- a/main.go
+++ b/main.go
@@ -44,8 +44,6 @@ import (
 
 	//+kubebuilder:scaffold:imports
 
-	ocpv1 "github.com/openshift/api/config/v1"
-	ocpv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/library-go/pkg/operator/events"
 
 	"github.com/panjf2000/ants/v2"
@@ -90,12 +88,6 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(multiarchv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(multiarchv1beta1.AddToScheme(scheme))
-
-	// TODO[OCP specific]
-	utilruntime.Must(ocpv1.Install(scheme))
-	utilruntime.Must(ocpv1alpha1.Install(scheme))
-
-	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -192,22 +184,8 @@ func RunClusterPodPlacementConfigOperandControllers(mgr ctrl.Manager) {
 	}).SetupWithManager(mgr),
 		unableToCreateController, controllerKey, "PodReconciler")
 
-	must(mgr.Add(podplacement.NewConfigSyncerRunnable()), unableToAddRunnable, runnableKey, "ConfigSyncerRunnable")
-	must(mgr.Add(podplacement.NewRegistryCertificatesSyncer(clientset, registryCertificatesConfigMapNamespace,
-		registryCertificatesConfigMapName)),
-		unableToAddRunnable, runnableKey, "RegistryCertificatesSyncer")
 	must(mgr.Add(podplacement.NewGlobalPullSecretSyncer(clientset, globalPullSecretNamespace, globalPullSecretName)),
 		unableToAddRunnable, runnableKey, "GlobalPullSecretSyncer")
-
-	// TODO[OCP specific]
-	must(mgr.Add(podplacement.NewICSPSyncer(mgr)),
-		unableToAddRunnable, runnableKey, "ICSPSyncer")
-	must(mgr.Add(podplacement.NewIDMSSyncer(mgr)),
-		unableToAddRunnable, runnableKey, "IDMSSyncer")
-	must(mgr.Add(podplacement.NewITMSSyncer(mgr)),
-		unableToAddRunnable, runnableKey, "ITMSSyncer")
-	must(mgr.Add(podplacement.NewImageRegistryConfigSyncer(mgr)),
-		unableToAddRunnable, runnableKey, "ImageRegistryConfigSyncer")
 }
 
 func RunClusterPodPlacementConfigOperandWebHook(mgr ctrl.Manager) {

--- a/pkg/systemconfig/types.go
+++ b/pkg/systemconfig/types.go
@@ -53,28 +53,28 @@ var (
 
 func DockerCertsDir() string {
 	if dockerCertsDir == "" {
-		dockerCertsDir = lookupEnvOr("DOCKER_CERTS_DIR", "/tmp/docker/certs.d")
+		dockerCertsDir = lookupEnvOr("DOCKER_CERTS_DIR", "/etc/docker/certs.d")
 	}
 	return dockerCertsDir
 }
 
 func RegistryCertsDir() string {
 	if registriesCertsDir == "" {
-		registriesCertsDir = lookupEnvOr("REGISTRIES_CERTS_DIR", "/tmp/containers/registries.d")
+		registriesCertsDir = lookupEnvOr("REGISTRIES_CERTS_DIR", "/etc/containers/registries.d")
 	}
 	return registriesCertsDir
 }
 
 func RegistriesConfPath() string {
 	if registriesConfPath == "" {
-		registriesConfPath = lookupEnvOr("REGISTRIES_CONF_PATH", "/tmp/containers/registries.conf")
+		registriesConfPath = lookupEnvOr("REGISTRIES_CONF_PATH", "/etc/containers/registries.conf")
 	}
 	return registriesConfPath
 }
 
 func PolicyConfPath() string {
 	if policyConfPath == "" {
-		policyConfPath = lookupEnvOr("POLICY_CONF_PATH", "/tmp/containers/policy.json")
+		policyConfPath = lookupEnvOr("POLICY_CONF_PATH", "/etc/containers/policy.json")
 	}
 	return policyConfPath
 }


### PR DESCRIPTION
Mount the nodes' /etc/containers/ and /etc/docker/ directories to the PodPlacementConfig. 

This setup enables direct access to the registry configuration files, certificates, and policies, eliminating the need for temporary storage in the /tmp/ directory. This also reduces the computational load associated with maintaining the registries