### PR TITLE
NO-JIRA: Add securityContext to kube-rbac-proxy containers

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2024-08-21T22:08:50Z"
+    createdAt: "2024-08-27T22:08:50Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -168,6 +168,13 @@ spec:
           verbs:
           - create
           - patch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - update
         - apiGroups:
           - ""
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -75,6 +75,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -310,6 +310,19 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 									Name:          "https",
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: utils.NewPtr(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
+								Privileged:   utils.NewPtr(false),
+								RunAsNonRoot: utils.NewPtr(true),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/hack/deploy-and-e2e.sh
+++ b/hack/deploy-and-e2e.sh
@@ -10,8 +10,6 @@ fi
 export NO_DOCKER=1
 export NAMESPACE=openshift-multiarch-tuning-operator
 oc create namespace ${NAMESPACE}
-oc annotate namespace ${NAMESPACE} \
-  workload.openshift.io/allowed="management"
 
 if [ "${USE_OLM:-}" == "true" ]; then
   # Get the manifest from the manifest-list


### PR DESCRIPTION
#228 introduced using a hostPath volume to feed the content of the `/etc/containers` folder. The pod security admission controller does not allow this. 
The minimum level for the pod security admission that allows using an host path volume is privileged. See https://kubernetes.io/docs/concepts/security/pod-security-standards/

The OLM test for #228 succeeded because the `operator-sdk run bundle` command changed the namespace labels.

This PR adds the security context for the deployments' kube-rbac-proxy container and a method to reconcile the namespace labels in the cluster pod placement config controller to set the privileged pod admission security policy.

Finally, as we couldn't do that before when the operator is installed via the OperatorHub, I'm exploiting this fix requiring updates permissions to the namespace for adding the 
`"workload.openshift.io/allowed": "management"` label too (see https://github.com/openshift/enhancements/blob/c5b9aea25e/enhancements/workload-partitioning/management-workload-partitioning.md)

```
  Warning  FailedCreate  25s (x6 over 105s)  replicaset-controller  (combined from similar events): Error creating: pods "pod-placement-controller-6b448c5d6-pp6nt" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "kube-rbac-proxy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "kube-rbac-proxy" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volumes "docker-conf", "containers-conf" use restricted volume type "hostPath"), runAsNonRoot != true (pod or container "kube-rbac-proxy" must set securityContext.runAsNonRoot=true)
```

```
  Warning  FailedCreate  1s (x4 over 19s)  replicaset-controller  (combined from similar events): Error creating: pods "pod-placement-controller-7cb6978477-fsccr" is forbidden: violates PodSecurity "restricted:latest": restricted volume types (volumes "docker-conf", "containers-conf" use restricted volume type "hostPath")
```

It worked on the OLM version as `operator-sdk run bundle` . However, this should not happen when we deploy from the OperatorHub.


namespace patched by operator-sdk run bundle:

```
        {
            "apiVersion": "v1",
            "kind": "Namespace",
            "metadata": {
                "annotations": {
                    "openshift.io/sa.scc.mcs": "s0:c26,c25",
                    "openshift.io/sa.scc.supplemental-groups": "1000700000/10000",
                    "openshift.io/sa.scc.uid-range": "1000700000/10000",
                    "workload.openshift.io/allowed": "management"
                },
                "creationTimestamp": "2024-08-26T18:40:05Z",
                "labels": {
                    "kubernetes.io/metadata.name": "openshift-multiarch-tuning-operator",
                    "pod-security.kubernetes.io/audit": "privileged",
                    "pod-security.kubernetes.io/audit-version": "v1.24",
                    "pod-security.kubernetes.io/enforce": "privileged",
                    "pod-security.kubernetes.io/enforce-version": "v1.24",
                    "pod-security.kubernetes.io/warn": "privileged",
                    "pod-security.kubernetes.io/warn-version": "v1.24",
                    "security.openshift.io/scc.podSecurityLabelSync": "true"
                },
                "name": "openshift-multiarch-tuning-operator",
                "resourceVersion": "32163",
                "uid": "65ac6b40-7515-4c7a-8869-fc22cf34eed3"
            },
            "spec": {
                "finalizers": [
                    "kubernetes"
                ]
            },
            "status": {
                "phase": "Active"
            }
        },
```