### PR TITLE
OCPBUGS-36244: Cluster wide proxy

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator-trusted-ca_v1_configmap.yaml
+++ b/bundle/manifests/multiarch-tuning-operator-trusted-ca_v1_configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    multiarch.openshift.io/image: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: multiarch-tuning-operator-trusted-ca

--- a/config/manager/custom_ca_certificate.yaml
+++ b/config/manager/custom_ca_certificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  namespace: openshift-multiarch-tuning-operator
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- custom_ca_certificate.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -233,6 +233,7 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 									Name:  "HTTPS_PROXY",
 									Value: os.Getenv("HTTPS_PROXY"),
 								},
+
 								{
 									Name:  "NO_PROXY",
 									Value: os.Getenv("NO_PROXY"),
@@ -303,6 +304,11 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 								{
 									Name:      "ca-projected-volume",
 									MountPath: "/etc/ssl/certs",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "trusted-ca",
+									MountPath: "/etc/pki/ca-trust/extracted/pem",
 									ReadOnly:  true,
 								},
 							},
@@ -402,6 +408,22 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 													},
 												},
 											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "trusted-ca",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "multiarch-tuning-operator-trusted-ca",
+									},
+									Items: []corev1.KeyToPath{
+										{
+											Key:  "ca-bundle.crt",
+											Path: "tls-ca-bundle.pem",
 										},
 									},
 								},

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"fmt"
+	"os"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -223,6 +224,18 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 								{
 									Name:  "NAMESPACE",
 									Value: utils.Namespace(),
+								},
+								{
+									Name:  "HTTP_PROXY",
+									Value: os.Getenv("HTTP_PROXY"),
+								},
+								{
+									Name:  "HTTPS_PROXY",
+									Value: os.Getenv("HTTPS_PROXY"),
+								},
+								{
+									Name:  "NO_PROXY",
+									Value: os.Getenv("NO_PROXY"),
 								},
 							},
 							Args: append([]string{


### PR DESCRIPTION
To ensure the operator works with a cluster-wide proxy, the Pod placement needs the proxy environment variables propagated to it. If a customer adds a custom CA certificate, the Pod placement configuration needs access to it. This is achieved by adding an empty ConfigMap with the label config.openshift.io/inject-trusted-cabundle: "true", which will inject a bundle of CA certificates.
[](https://docs.okd.io/4.16/operators/admin/olm-configuring-proxy-support.html)