### PR TITLE
MULTIARCH-4962: Label for pods set by the pod placement controller and minor fixes

### DIFF
--- a/controllers/podplacement/events.go
+++ b/controllers/podplacement/events.go
@@ -9,6 +9,7 @@ const (
 	ArchitectureAwareSchedulingGateAdded          = "ArchAwareSchedGateAdded"
 	ArchitectureAwareSchedulingGateRemovalFailure = "ArchAwareSchedGateRemovalFailed"
 	ArchitectureAwareSchedulingGateRemovalSuccess = "ArchAwareSchedGateRemovalSuccess"
+	NoSupportedArchitecturesFound                 = "NoSupportedArchitecturesFound"
 
 	SchedulingGateAddedMsg              = "Successfully gated with the " + utils.SchedulingGateName + " scheduling gate"
 	SchedulingGateRemovalSuccessMsg     = "Successfully removed the " + utils.SchedulingGateName + " scheduling gate"
@@ -16,4 +17,5 @@ const (
 	ArchitecturePredicatesConflictMsg   = "All the scheduling predicates already include architecture-specific constraints"
 	ArchitecturePredicateSetupMsg       = "Set the nodeAffinity for the architecture to "
 	ImageArchitectureInspectionErrorMsg = "Failed to retrieve the supported architectures: "
+	NoSupportedArchitecturesFoundMsg    = "Pod cannot be scheduled due to incompatible image architectures; container images have no supported architectures in common"
 )

--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -660,7 +660,7 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 				Pod: tt.pod,
 				ctx: ctx,
 			}
-			pod.SetNodeAffinityArchRequirement(tt.pullSecretDataList, nil)
+			pod.SetNodeAffinityArchRequirement(tt.pullSecretDataList)
 			g := NewGomegaWithT(t)
 			g.Expect(pod.Spec.Affinity).Should(Equal(tt.want.Spec.Affinity))
 			imageInspectionCache = mmoimage.FacadeSingleton()

--- a/controllers/podplacement/pod_reconciler.go
+++ b/controllers/podplacement/pod_reconciler.go
@@ -61,7 +61,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	log := ctrllog.FromContext(ctx)
 
 	pod := &Pod{
-		ctx: ctx,
+		ctx:      ctx,
+		recorder: r.Recorder,
 	}
 
 	if err := r.Get(ctx, req.NamespacedName, &pod.Pod); err != nil {
@@ -86,7 +87,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			"The nodeAffinity for this pod will not be set.")
 		// we still need to remove the scheduling gate. Therefore, we do not return here.
 	} else {
-		pod.SetNodeAffinityArchRequirement(psdl, r.Recorder)
+		pod.SetNodeAffinityArchRequirement(psdl)
 	}
 
 	// Remove the scheduling gate

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -83,6 +83,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity on privileged deployments", func() {
@@ -145,6 +152,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity when users node affinity do not conflict", func() {
@@ -177,6 +191,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&hostnameLabelNSR, &archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should not set the node affinity when users node affinity conflicts", func() {
@@ -238,6 +259,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedHostnameNST := NewNodeSelectorTerm().WithMatchExpressions(&hostnameLabelNSR, &expectedArchLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedHostnameNST, archLabelNSTs)
 		})
 		It("should not set the node affinity when nodeSelector exist", func() {
@@ -325,6 +353,10 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.SingleArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity when with a single container and a multiarch image", func() {
@@ -352,6 +384,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity when with more containers some with singlearch image some with multiarch image", func() {
@@ -431,6 +470,10 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.SingleArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 	})
@@ -458,6 +501,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
 				Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyDaemonSetPodNodeAffinity(ns, "app", "test", archLabelNSR)
 		})
 		It("should set the node affinity on Job owning pod", func() {
@@ -485,6 +535,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity on Build owning pod", func() {
@@ -507,6 +564,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "openshift.io/build.name", "test-build", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "openshift.io/build.name", "test-build",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "openshift.io/build.name", "test-build", expectedNSTs)
 		})
 		It("should set the node affinity on DeploymentConfig owning pod", func() {
@@ -534,6 +598,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 	})
@@ -584,6 +655,11 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity in pods with images requiring credentials set in pods imagePullSecrets", func() {
@@ -625,6 +701,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity in pods with images that require both global and local pull secrets", func() {
@@ -666,6 +749,10 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.SingleArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+			)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
 		})
 	})
@@ -725,6 +812,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 		})
 		It("should not set the node affinity when registry certificate is not in the trusted anchors", func() {
 			var (
@@ -822,6 +916,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 		})
 		It("should set the node affinity when registry certificate added in the trusted anchors and registry url added to allowed list", func() {
 			var (
@@ -888,6 +989,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 		})
 		It("should not set the node affinity when registry url added to blockedRegistries list", func() {
 			var err error
@@ -945,6 +1053,13 @@ var _ = Describe("The Pod Placement Operand", func() {
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
+			verifyPodLabelsAreSet(ns, "app", "test",
+				utils.MultiArchLabel, "",
+				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
+				utils.ArchLabelValue(utils.ArchitectureArm64), "",
+				utils.ArchLabelValue(utils.ArchitectureS390x), "",
+				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+			)
 		})
 	})
 })
@@ -1066,6 +1181,18 @@ func verifyPodLabels(ns *corev1.Namespace, labelKey string, labelInValue string,
 			}
 		}
 	}, e2e.WaitShort).Should(Succeed())
+}
+
+func verifyPodLabelsAreSet(ns *corev1.Namespace, labelKey string, labelInValue string, labelsKeyValuePair ...string) {
+	if len(labelsKeyValuePair)%2 != 0 {
+		// It's ok to panic as this is only used in unit tests.
+		panic("the number of arguments must be even")
+	}
+	entries := make(map[string]string)
+	for i := 0; i < len(labelsKeyValuePair); i += 2 {
+		entries[labelsKeyValuePair[i]] = labelsKeyValuePair[i+1]
+	}
+	verifyPodLabels(ns, labelKey, labelInValue, true, entries)
 }
 
 func waitForMCPComplete() {

--- a/pkg/testing/builder/pod_builder.go
+++ b/pkg/testing/builder/pod_builder.go
@@ -133,6 +133,20 @@ func (p *PodBuilder) WithNodeName(nodeName string) *PodBuilder {
 	return p
 }
 
+func (p *PodBuilder) WithLabels(labelsKeyValuesPair ...string) *PodBuilder {
+	if p.pod.Labels == nil {
+		p.pod.Labels = make(map[string]string)
+	}
+	if len(labelsKeyValuesPair)%2 != 0 {
+		// It's ok to panic as this is only used in unit tests.
+		panic("the number of arguments must be even")
+	}
+	for i := 0; i < len(labelsKeyValuesPair); i += 2 {
+		p.pod.Labels[labelsKeyValuesPair[i]] = labelsKeyValuesPair[i+1]
+	}
+	return p
+}
+
 func (p *PodBuilder) Build() v1.Pod {
 	return p.pod
 }

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -23,6 +23,11 @@ const (
 	SchedulingGateLabelValueGated   = "gated"
 	SchedulingGateLabelValueRemoved = "removed"
 	PodPlacementFinalizerName       = "finalizers.multiarch.openshift.io/pod-placement"
+	SingleArchLabel                 = "multiarch.openshift.io/single-arch"
+	MultiArchLabel                  = "multiarch.openshift.io/multi-arch"
+	NoSupportedArchLabel            = "multiarch.openshift.io/no-supported-arch"
+	ImageInspectionErrorLabel       = "multiarch.openshift.io/image-inspect-error"
+	LabelGroup                      = "multiarch.openshift.io"
 )
 
 const (

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,5 +1,7 @@
 package utils
 
+import "path"
+
 func NewPtr[T any](a T) *T {
 	return &a
 }
@@ -13,4 +15,8 @@ func HasControlPlaneNodeSelector(nodeSelector map[string]string) bool {
 		}
 	}
 	return false
+}
+
+func ArchLabelValue(arch string) string {
+	return path.Join(LabelGroup, arch)
 }


### PR DESCRIPTION
This PR lets the pod placement controller set the following labels in the patched pods:
- `multiarch.openshift.io/multi-arch: ""` -> Indicate a pod that supports more than 1 architecture. As a consequence, all the images are manifest-list.
- `multiarch.openshift.io/single-arch: ""` -> Indicate a pod that supports only 1 architecture. We can't argue anything about the nature of the images: for example, all can be manifest-list but have disjoint sets of supported architectures.
- `multiarch.openshift.io/arm64: ""` -> the pod supports arm64
- `multiarch.openshift.io/amd64: ""` -> the pod supports amd64
- `multiarch.openshift.io/ppc64le: ""` -> the pod supports ppc64le
- `multiarch.openshift.io/s390x: ""` -> the pod supports s390x.
- `multirach.openshift.io/node-affinity: (set|not-set)` indicates whether we patched the node 
affinity or not (in the case another node selector or all the affinity terms were previously set by a user or other actor)
- `multiarch.openshift.io/scheduling-gate: (gated|removed)`: whether the pod was gated (and whether we removed the gate)
- multiarch.openshift.io/inspection-error: "" indicates whether an error occurred when inspecting the images
- 

Labels are set separately so that we can index pods by supported architecture or by the fact they support multi-arch or not via simple client requests.

Examples:

Request the pods that support arm64:
```
oc get -A pods -l 'multiarch.openshift.io/arm64='
```

Request the pods that support a single architecture only:
```
oc get -A pods -l 'multiarch.openshift.io/single-arch='
```
Request the pods that support a single architecture only and that do NOT support amd64:
```
oc get -A pods -l 'multiarch.openshift.io/single-arch=' -l '!multiarch.openshift.io/amd64'
```

Request non-processed pods:

```
oc get -A pods -l 'multiarch.openshift.io/node-affinity=not-set' -l '!multiarch.openshift.io/scheduling-gate'
```

Request processed pods that didn't get a node affinity because already set by the user:

```
oc get -A pods -l 'multiarch.openshift.io/node-affinity=not-set' -l '!multiarch.openshift.io/inspection-error'
```

I think we should dedicate a paragraph in the doc to these labels.


:warning: We have a bug that arises when the images of a pod do not have a commonly supported architecture. This PR also fixes that by adding a dummy node selector requirement that will let the pod to hold in the Unschedulable status. 
Till now, the pod placement controller will face an error when updating the pod because the matchSelector we compute is not valid. It cannot have an empty list of values (`kubernetes.io/arch IN []` is not valid). As we just remove the scheduling gate in case of errors, the pods entered the scheduling cycle without modifications. If we prefer the current behavior, I'll just fix the bug by just skipping the patch of the node selector terms.
Events will be visible to the users for understanding the reason why it's a non-schedulable pod. 