### PR TITLE
Remove sbom-json-check

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -304,7 +304,7 @@ spec:
             - name: name
               value: buildah
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:60cd734b48cf6c62cc5931fd4dfd159cc7aeba2d89c8f7f0352341480ccc8f2c
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:d47b0b67109940b264cff6995941aa56c0517562b4939b85d6ac3ed750bf59f1
             - name: kind
               value: task
           resolver: bundles
@@ -341,7 +341,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles
@@ -378,7 +378,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles
@@ -415,7 +415,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -599,28 +599,6 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
-      - name: sbom-json-check
-        params:
-          - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
-          - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
-        runAfter:
-          - build-container
-        taskRef:
-          params:
-            - name: name
-              value: sbom-json-check
-            - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-sbom-json-check:0.2@sha256:94af54db1f8aeef7dddaf410e4584e505ea71ab06ae7cc6ae9d0a2d6ddcb3d1b
-            - name: kind
-              value: task
-          resolver: bundles
-        when:
-          - input: $(params.skip-checks)
-            operator: in
-            values:
-              - "false"
     workspaces:
       - name: workspace
       - name: git-auth

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -301,7 +301,7 @@ spec:
             - name: name
               value: buildah
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:60cd734b48cf6c62cc5931fd4dfd159cc7aeba2d89c8f7f0352341480ccc8f2c
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:d47b0b67109940b264cff6995941aa56c0517562b4939b85d6ac3ed750bf59f1
             - name: kind
               value: task
           resolver: bundles
@@ -338,7 +338,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles
@@ -375,7 +375,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles
@@ -412,7 +412,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -596,28 +596,6 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
-      - name: sbom-json-check
-        params:
-          - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
-          - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
-        runAfter:
-          - build-container
-        taskRef:
-          params:
-            - name: name
-              value: sbom-json-check
-            - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-sbom-json-check:0.2@sha256:94af54db1f8aeef7dddaf410e4584e505ea71ab06ae7cc6ae9d0a2d6ddcb3d1b
-            - name: kind
-              value: task
-          resolver: bundles
-        when:
-          - input: $(params.skip-checks)
-            operator: in
-            values:
-              - "false"
     workspaces:
       - name: workspace
       - name: git-auth

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -306,7 +306,7 @@ spec:
             - name: name
               value: buildah
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:60cd734b48cf6c62cc5931fd4dfd159cc7aeba2d89c8f7f0352341480ccc8f2c
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:d47b0b67109940b264cff6995941aa56c0517562b4939b85d6ac3ed750bf59f1
             - name: kind
               value: task
           resolver: bundles
@@ -343,7 +343,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles
@@ -380,7 +380,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles
@@ -417,7 +417,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -601,28 +601,6 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
-      - name: sbom-json-check
-        params:
-          - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
-          - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
-        runAfter:
-          - build-container
-        taskRef:
-          params:
-            - name: name
-              value: sbom-json-check
-            - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-sbom-json-check:0.2@sha256:94af54db1f8aeef7dddaf410e4584e505ea71ab06ae7cc6ae9d0a2d6ddcb3d1b
-            - name: kind
-              value: task
-          resolver: bundles
-        when:
-          - input: $(params.skip-checks)
-            operator: in
-            values:
-              - "false"
     workspaces:
       - name: workspace
       - name: git-auth

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -597,28 +597,6 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
-      - name: sbom-json-check
-        params:
-          - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
-          - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
-        runAfter:
-          - build-container
-        taskRef:
-          params:
-            - name: name
-              value: sbom-json-check
-            - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-sbom-json-check:0.2@sha256:94af54db1f8aeef7dddaf410e4584e505ea71ab06ae7cc6ae9d0a2d6ddcb3d1b
-            - name: kind
-              value: task
-          resolver: bundles
-        when:
-          - input: $(params.skip-checks)
-            operator: in
-            values:
-              - "false"
     workspaces:
       - name: workspace
       - name: git-auth

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -302,7 +302,7 @@ spec:
             - name: name
               value: buildah
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:60cd734b48cf6c62cc5931fd4dfd159cc7aeba2d89c8f7f0352341480ccc8f2c
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:d47b0b67109940b264cff6995941aa56c0517562b4939b85d6ac3ed750bf59f1
             - name: kind
               value: task
           resolver: bundles
@@ -339,7 +339,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles
@@ -376,7 +376,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles
@@ -413,7 +413,7 @@ spec:
             - name: name
               value: buildah-remote
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:0ba9132a5d04b8e5d33b6305d1b1e79512e21212041f90c81c6a755564671e49
+              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:54cd5f36c116c1f25a820f4e7a46c9e614d7bba95a16c7c38b91853e723eb9b5
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
Remove sbom-json-check definition from pipeline. This is part of the migration from 0.1 to 0.2
[https://github.com/konflux-ci/build-definitions/blob/main/task/sbom-json-check/0.2/MIGRATION.md](https://github.com/konflux-ci/build-definitions/blob/main/task/sbom-json-check/0.2/MIGRATION.md )