### PR TITLE
Revert 8928d81e5d: Extract the single-arch manifest from the bundle to allow extraction on arm64 nodes

### DIFF
--- a/hack/deploy-and-e2e.sh
+++ b/hack/deploy-and-e2e.sh
@@ -34,28 +34,6 @@ if [ "${USE_OLM:-}" == "true" ]; then
   # The following is required for prow, we allow failures as in general we don't expect
   # this to be required in non-prow envs, for example dev environments.
   oc registry login || echo "[WARN] Unable to login the registry, this could be expected in non-Prow envs"
-  # Get the manifest from the manifest-list
-  # Prow produces a manifest-list image even for the bundle and that bundle image is not deployed on the multi-arch clusters
-  # Therefore, it can be a single-arch one and operator-sdk isn't able to extract the bundle as the bundle image is set in a
-  # pod's container image field and cri-o will fail to pull the image when the architecture of the node is different from the
-  # bundle image's architecture.
-  # However, the bundle image is FROM scratch and doesn't have any architecture-specific binaries. It doesn't need to be
-  # a manifest-list image. Therefore, we can extract the first single-arch manifest from the manifest-list image and use it
-  # as the bundle image in a multi-arch cluster, allowing the extraction pod to be scheduled on arm64 as well.
-  # The following is a workaround for this issue until https://issues.redhat.com/browse/DPTP-4143 is resolved.
-  set -x
-  oc image info --show-multiarch "${OO_BUNDLE}"
-  echo "Bundle: ${OO_BUNDLE}"
-  if oc image info --show-multiarch "${OO_BUNDLE}" | grep -q "Manifest List:"; then
-    echo "The bundle is a manifest-list image, extracting the first single-arch manifest."
-    MANIFEST_DIGEST=$(oc image info --show-multiarch "${OO_BUNDLE}" | grep "Digest: " | awk '{print $2}' | head -n1)
-    OO_BUNDLE=${OO_BUNDLE%%:*}
-    OO_BUNDLE=${OO_BUNDLE%%@*}@${MANIFEST_DIGEST}
-  else
-    echo "The bundle is not a manifest-list image."
-  fi
-  echo "The final bundle we will run: ${OO_BUNDLE}"
-  set +x
   export KUBECONFIG="${OLD_KUBECONFIG}"
   export JUNIT_SUFFIX="-olm"
   operator-sdk run bundle "${OO_BUNDLE}" -n "${NAMESPACE}" --security-context-config restricted --timeout=10m


### PR DESCRIPTION
Now that ci-operator doesn't trigger a manifest-list build for bundles, we can revert the workaround in 8928d81e5d.

Related to openshift/ci-tools#4307 
Related to [DPTP-4143](https://issues.redhat.com//browse/DPTP-4143)