### PR TITLE
OCPBUGS-38823: skip bundle images when computing the set of compatible architectures for a given pod

### DIFF
--- a/pkg/testing/framework/node_affinity_equivalence_matcher.go
+++ b/pkg/testing/framework/node_affinity_equivalence_matcher.go
@@ -37,15 +37,15 @@ func (matcher *equivalentNodeAffinityMatcher) Match(actual interface{}) (success
 		return true, nil
 	}
 	if actualNodeAffinity == nil || expectedNodeAffinity == nil {
-		return false, fmt.Errorf("expectedNodeAffinity: %v, actualNodeAffinity: %v", expectedNodeAffinity, actualNodeAffinity)
+		return false, fmt.Errorf("expectedNodeAffinity: %+v, actualNodeAffinity: %+v", expectedNodeAffinity, actualNodeAffinity)
 	}
 
 	if actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil && expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
 		return true, nil
 	}
 	if actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil || expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-		return false, fmt.Errorf("expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution: %v, "+
-			"actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution: %v",
+		return false, fmt.Errorf("expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution: %+v, "+
+			"actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution: %+v",
 			expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
 			actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
 	}
@@ -53,8 +53,8 @@ func (matcher *equivalentNodeAffinityMatcher) Match(actual interface{}) (success
 	actualTerms := actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 	expectedTerms := expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 	if len(actualTerms) != len(expectedTerms) {
-		return false, fmt.Errorf("expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms: %v, "+
-			"actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms: %v",
+		return false, fmt.Errorf("expectedNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms: %+v, "+
+			"actualNodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms: %+v",
 			expectedTerms, actualTerms)
 	}
 
@@ -66,7 +66,7 @@ func (matcher *equivalentNodeAffinityMatcher) Match(actual interface{}) (success
 }
 
 func (matcher *equivalentNodeAffinityMatcher) FailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nto have an equivalent node affinity with \n\t%#v", actual, matcher.expected)
+	return fmt.Sprintf("Expected\n\t%+v\nto have an equivalent node affinity with \n\t%+v", actual, matcher.expected)
 }
 
 func (matcher *equivalentNodeAffinityMatcher) NegatedFailureMessage(actual interface{}) (message string) {

--- a/pkg/testing/image/fake/registry/mock_image.go
+++ b/pkg/testing/image/fake/registry/mock_image.go
@@ -27,6 +27,7 @@ type MockImage struct {
 	Repository    string
 	Name          string
 	Tag           string
+	Labels        map[string]string
 	partial       bool
 	destination   *types.ImageDestination
 }
@@ -76,7 +77,8 @@ func (i *MockImage) prepareSingleArchImage(ctx context.Context, dst *types.Image
 	// Single architecture images or partial manifests for manifestObj lists
 	// We expect the architecture set to be a singleton
 	arch, _ := i.Architectures.PopAny()
-	configData := []byte(fmt.Sprintf(`{"architecture":"%s","os":"linux","config":{}}`, arch))
+	labelsJsonBytes, _ := json.Marshal(i.Labels)
+	configData := []byte(fmt.Sprintf(`{"architecture":"%s","os":"linux","config":{"Labels":%s}}`, arch, string(labelsJsonBytes)))
 	configDataDigest, err := manifest.Digest(configData)
 	if err != nil {
 		log.Error(err, "Error computing the digest of the image config data")

--- a/pkg/testing/image/fake/registry/seed.go
+++ b/pkg/testing/image/fake/registry/seed.go
@@ -73,6 +73,25 @@ func GetMockImages() []MockImage {
 			}
 		}
 	}
+	mockImages = append(mockImages, MockImage{
+		Architectures: sets.New[string](utils.ArchitecturePpc64le, utils.ArchitectureS390x),
+		MediaType:     imgspecv1.MediaTypeImageIndex,
+		Repository:    PublicRepo,
+		Name:          ComputeNameByMediaType(imgspecv1.MediaTypeImageIndex, "bundle"),
+		Tag:           "latest",
+	}, MockImage{
+		Architectures: sets.New[string](utils.ArchitecturePpc64le),
+		MediaType:     imgspecv1.MediaTypeImageManifest,
+		Repository:    PublicRepo,
+		Name:          ComputeNameByMediaType(imgspecv1.MediaTypeImageManifest, "bundle"),
+		Tag:           "latest",
+	}, MockImage{
+		Architectures: sets.New[string](utils.ArchitecturePpc64le, utils.ArchitectureS390x),
+		MediaType:     imgspecv1.MediaTypeImageIndex,
+		Repository:    PublicRepo,
+		Name:          ComputeNameByMediaType(imgspecv1.MediaTypeImageIndex, "ppc64le-s390x"),
+		Tag:           "latest",
+	})
 	return mockImages
 }
 
@@ -80,10 +99,13 @@ func GetMockImages() []MockImage {
 // The name of the image is given by the media type, replacing the "." with "-" and
 // removing the "+...." suffix and "application/" prefix.
 // The tag is given by the indices of the for loops.
-func ComputeNameByMediaType(mediaType string) string {
+func ComputeNameByMediaType(mediaType string, suffixes ...string) string {
 	name := strings.Split(mediaType, "+")[0]
 	name = strings.Split(name, "/")[1]
 	name = strings.ReplaceAll(name, ".", "-")
+	for _, suffix := range suffixes {
+		name = fmt.Sprintf("%s-%s", name, suffix)
+	}
 	return name
 }
 

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -1,5 +1,7 @@
 package utils
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 const (
 	ControllerNameKey = "controller"
 	OperandLabelKey   = "multiarch.openshift.io/operand"
@@ -45,3 +47,7 @@ const (
 	PodPlacementControllerName               = "pod-placement-controller"
 	PodPlacementWebhookName                  = "pod-placement-web-hook"
 )
+
+func AllSupportedArchitecturesSet() sets.Set[string] {
+	return sets.New(ArchitectureAmd64, ArchitectureArm64, ArchitecturePpc64le, ArchitectureS390x)
+}


### PR DESCRIPTION
This PR updates the registry inspector to handle bundle images correctly. Bundle images are intended to carry metadata-only information and not be multi-architecture.

It is possible for an operator bundle image to reference a valid operator supported by the cluster's architectures while the bundle image itself remains a single-architecture manifest image. Suppose the cluster (e.g., an arm64+ppc64le cluster) has no nodes supporting the bundle image's architecture (such as an amd64-built bundle). OLM may fail to run the job in that case because the node affinity settings could lead to an ImagePullBackOff error.

To address this, the GetCompatibleArchitectureSet function will now return the set of all the architectures supported by the operator (arm64, amd64, ppc64le, s390x) for OLM bundle images. If there are other container images specified in the pod (as in the OLM case), the node affinity will be set to the intersection of the architectures supported by the non-bundle images. As this fix is strictly related to the OLM bundles, we don't consider the case where a pod has only that bundle as a container image. In fact, the pod cannot run in such a case because no binaries are shipped in the image of a bundle to act as an entry point.

Testing: I added two integration tests for this. Having some e2e might be good (e.g., subscription-based operator installation, operator-sdk run, but I'd leave this choice to @lwan-wanglin and consider it a low-priority task for now as the scenarios we support consider mixarch amd64 + $second_arch today and this edge case would not be faced.

A manual test, though, could be done even before merging.