### PR TITLE
Update multiarch-tuning-operator to 98da044

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -1,5 +1,5 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as builder
-ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:6e7b485229dda16d01b7880b18bce1dc7c6def0eecdbb902bf4dd3d454024a09
+ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:36705668e673ee0105cb7453416a46430b24432e0a5d2c7e09a6c174098da044
 ARG ORIGINAL_IMG=registry.ci.openshift.org/origin/multiarch-tuning-operator:main
 WORKDIR /code
 COPY ./ ./


### PR DESCRIPTION
Updating the multiarch-tuning-operator to use the same image as the snapshot multiarch-tuning-operator-nr782

```
Spec:
  Application:  multiarch-tuning-operator
  Artifacts:
  Components:
    Container Image:  quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator@sha256:36705668e673ee0105cb7453416a46430b24432e0a5d2c7e09a6c174098da044
    Name:             multiarch-tuning-operator
    Source:
      Git:
        Revision:     d10efe3fddb1745931dfd9b8be8a3492ee12a7f8
        URL:          https://github.com/openshift/multiarch-tuning-operator
    Container Image:  quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator-bundle@sha256:fecc81362b2647971ab9661e8816ae10c7d777a476b1d3a6287d0173d3dcee22
    Name:             multiarch-tuning-operator-bundle
    Source:
      Git:
        Context:         ./
        Dockerfile URL:  bundle.Dockerfile
        Revision:        55d9dfef041e90bc9dff7cc97d387dc6d632477a
        URL:             https://github.com/openshift/multiarch-tuning-operator
```