### PR TITLE
MULTIARCH-4296: Add more pre-checking logic in the webhook to skip pods that will not get a patched nodeAffinity

### DIFF
--- a/controllers/podplacement/events.go
+++ b/controllers/podplacement/events.go
@@ -6,6 +6,7 @@ const (
 	ArchitecturePredicatesConflict                = "ArchAwarePredicatesConflict"
 	ImageArchitectureInspectionError              = "ArchAwareInspectionError"
 	ArchitectureAwareNodeAffinitySet              = "ArchAwarePredicateSet"
+	ArchitectureAwareGatedPodIgnored              = "ArchAwareGatedPodIgnored"
 	ArchitectureAwareSchedulingGateAdded          = "ArchAwareSchedGateAdded"
 	ArchitectureAwareSchedulingGateRemovalFailure = "ArchAwareSchedGateRemovalFailed"
 	ArchitectureAwareSchedulingGateRemovalSuccess = "ArchAwareSchedGateRemovalSuccess"
@@ -18,4 +19,5 @@ const (
 	ArchitecturePredicateSetupMsg       = "Set the nodeAffinity for the architecture to "
 	ImageArchitectureInspectionErrorMsg = "Failed to retrieve the supported architectures: "
 	NoSupportedArchitecturesFoundMsg    = "Pod cannot be scheduled due to incompatible image architectures; container images have no supported architectures in common"
+	ArchitectureAwareGatedPodIgnoredMsg = "The gated pod has been modified and is no longer eligible for architecture-aware scheduling"
 )

--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -346,6 +346,6 @@ func (pod *Pod) isNodeSelectorConfiguredForArchitecture() bool {
 func (pod *Pod) publishIgnorePod() {
 	log := ctrllog.FromContext(pod.ctx)
 	log.V(3).Info("The pod has the nodeSelector or all the nodeAffinityTerms set for the kubernetes.io/arch label. Ignoring the pod...")
-	pod.ensureLabel(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueNotSet)
+	pod.ensureLabel(utils.NodeAffinityLabel, utils.LabelValueNotSet)
 	pod.publishEvent(corev1.EventTypeNormal, ArchitecturePredicatesConflict, ArchitecturePredicatesConflictMsg)
 }

--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -533,13 +533,14 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 					},
 				}).Build(),
 		},
-		{
+		/*{ // This test is not valid anymore after 300e719608271b5c9baa6ecfd845c24c2a71eec8:
+		    // We now check the predicates are set earlier in the process.
 			name: "pod with node selector and architecture requirement",
 			pod: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectors("foo", "bar",
 				utils.ArchLabel, utils.ArchitectureArm64).Build(),
 			want: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectors("foo", "bar",
 				utils.ArchLabel, utils.ArchitectureArm64).Build(),
-		},
+		},*/
 		{
 			name: "pod with no affinity",
 			pod:  NewPod().WithContainersImages(fake.MultiArchImage).Build(),

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -78,7 +78,8 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	}
 	log := ctrllog.FromContext(ctx).WithValues("namespace", pod.Namespace, "name", pod.Name)
 
-	pod.ensureLabel(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueNotSet)
+	pod.ensureLabel(utils.NodeAffinityLabel, utils.LabelValueNotSet)
+	pod.ensureLabel(utils.SchedulingGateLabel, utils.LabelValueNotSet)
 
 	if pod.shouldIgnorePod() {
 		log.V(5).Info("Ignoring the pod")

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -88,7 +88,7 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	// ignore the kube-* namespace as those are infra components, and ignore the namespace where the operand is running too
 	// Also ignore any pods which are deployed on control plane nodes
 	if utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "kube-") ||
-		pod.Spec.NodeName != "" || pod.Spec.NodeSelector != nil && utils.HasControlPlaneNodeSelector(pod.Spec.NodeSelector) {
+		pod.Spec.NodeName != "" || utils.HasControlPlaneNodeSelector(pod.Spec.NodeSelector) {
 		log.V(5).Info("Ignoring the pod")
 		return a.patchedPodResponse(pod, req)
 	}

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -85,11 +85,10 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	}
 	pod.Labels[utils.NodeAffinityLabel] = utils.NodeAffinityLabelValueNotSet
 
-	// ignore the kube-* and hypershift-* namespace as those are infra components, and ignore the namespace where the operand is running too
+	// ignore the kube-* namespace as those are infra components, and ignore the namespace where the operand is running too
 	// Also ignore any pods which are deployed on control plane nodes
-	if utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "hypershift-") ||
-		strings.HasPrefix(pod.Namespace, "kube-") || pod.Spec.NodeName != "" ||
-		pod.Spec.NodeSelector != nil && utils.HasControlPlaneNodeSelector(pod.Spec.NodeSelector) {
+	if utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "kube-") ||
+		pod.Spec.NodeName != "" || pod.Spec.NodeSelector != nil && utils.HasControlPlaneNodeSelector(pod.Spec.NodeSelector) {
 		log.V(5).Info("Ignoring the pod")
 		return a.patchedPodResponse(pod, req)
 	}

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -70,7 +70,7 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	}
 	pod := &Pod{
 		ctx:      ctx,
-		recorder: a.Recorder,
+		recorder: nil, // do we want to publish events if the pod is ignored?
 	}
 	err := a.decoder.Decode(req, &pod.Pod)
 	if err != nil {

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -18,7 +18,6 @@ package podplacement
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"net/http"
@@ -41,10 +40,6 @@ import (
 	"github.com/openshift/multiarch-tuning-operator/controllers/podplacement/metrics"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
-
-var schedulingGate = corev1.PodSchedulingGate{
-	Name: utils.SchedulingGateName,
-}
 
 // [disabled:operator]kubebuilder:webhook:path=/add-pod-scheduling-gate,mutating=true,sideEffects=None,admissionReviewVersions=v1,failurePolicy=ignore,groups="",resources=pods,verbs=create,versions=v1,name=pod-placement-scheduling-gate.multiarch.openshift.io
 
@@ -73,40 +68,24 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	if a.decoder == nil {
 		a.decoder = admission.NewDecoder(a.scheme)
 	}
-	pod := &corev1.Pod{}
-	err := a.decoder.Decode(req, pod)
+	pod := &Pod{
+		ctx:      ctx,
+		recorder: a.Recorder,
+	}
+	err := a.decoder.Decode(req, &pod.Pod)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	log := ctrllog.FromContext(ctx).WithValues("namespace", pod.Namespace, "name", pod.Name)
 
-	if pod.Labels == nil {
-		pod.Labels = make(map[string]string)
-	}
-	pod.Labels[utils.NodeAffinityLabel] = utils.NodeAffinityLabelValueNotSet
+	pod.ensureLabel(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueNotSet)
 
-	// ignore the kube-* namespace as those are infra components, and ignore the namespace where the operand is running too
-	// Also ignore any pods which are deployed on control plane nodes
-	if utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "kube-") ||
-		pod.Spec.NodeName != "" || utils.HasControlPlaneNodeSelector(pod.Spec.NodeSelector) {
+	if pod.shouldIgnorePod() {
 		log.V(5).Info("Ignoring the pod")
-		return a.patchedPodResponse(pod, req)
+		return a.patchedPodResponse(&pod.Pod, req)
 	}
 
-	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3521-pod-scheduling-readiness
-	if pod.Spec.SchedulingGates == nil {
-		pod.Spec.SchedulingGates = []corev1.PodSchedulingGate{}
-	}
-
-	// if the gate is already present, do not try to patch (it would fail)
-	for _, schedulingGate := range pod.Spec.SchedulingGates {
-		if schedulingGate.Name == utils.SchedulingGateName {
-			return a.patchedPodResponse(pod, req)
-		}
-	}
-
-	pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, schedulingGate)
-
+	pod.ensureSchedulingGate()
 	// We also add a label to the pod to indicate that the scheduling gate was added
 	// and this pod expects processing by the operator. That's useful for testing and debugging, but also gives the user
 	// an indication that the pod is waiting for processing and can support kubectl queries to find out which pods are
@@ -116,11 +95,11 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	// we know it will finish eventually by design, and we don't need to block the response as we
 	// are right in the admission pipeline, before the pod is persisted.
 	log.V(5).Info("Scheduling gate added to the pod, launching the event creation goroutine")
-	a.delayedSchedulingGatedEvent(ctx, pod)
+	a.delayedSchedulingGatedEvent(ctx, pod.DeepCopy())
 	metrics.GatedPods.Inc()
 	metrics.GatedPodsGauge.Inc()
 	log.V(4).Info("Accepting pod")
-	return a.patchedPodResponse(pod, req)
+	return a.patchedPodResponse(&pod.Pod, req)
 }
 
 func (a *PodSchedulingGateMutatingWebHook) delayedSchedulingGatedEvent(ctx context.Context, pod *corev1.Pod) {

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -26,8 +26,9 @@ const (
 
 var _ = Describe("The Multiarch Tuning Operator", func() {
 	var (
-		podLabel            = map[string]string{"app": "test"}
-		schedulingGateLabel = map[string]string{utils.SchedulingGateLabel: utils.SchedulingGateLabelValueRemoved}
+		podLabel                  = map[string]string{"app": "test"}
+		schedulingGateLabel       = map[string]string{utils.SchedulingGateLabel: utils.SchedulingGateLabelValueRemoved}
+		schedulingGateNotSetLabel = map[string]string{utils.SchedulingGateLabel: utils.LabelValueNotSet}
 	)
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
@@ -256,7 +257,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			//should exclude the namespace
-			verifyPodLabels(ns, "app", "test", e2e.Absent, schedulingGateLabel)
+			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateNotSetLabel)
 			verifyPodNodeAffinity(ns, "app", "test")
 		},
 			Entry(utils.ControlPlaneNodeSelectorLabel, utils.ControlPlaneNodeSelectorLabel),

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -321,7 +321,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
 			By("The pod should not have been processed by the webhook and the scheduling gate label should not be added")
-			verifyPodLabels(ns, "app", "test", e2e.Absent, schedulingGateLabel)
+			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateNotSetLabel)
 			By("The pod should keep the same node affinity provided by the users. No node affinity is added by the controller.")
 			verifyPodNodeAffinity(ns, "app", "test")
 			By("The pod should be running and not gated")

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -38,8 +38,9 @@ const (
 
 var _ = Describe("The Pod Placement Operand", func() {
 	var (
-		podLabel            = map[string]string{"app": "test"}
-		schedulingGateLabel = map[string]string{utils.SchedulingGateLabel: utils.SchedulingGateLabelValueRemoved}
+		podLabel                  = map[string]string{"app": "test"}
+		schedulingGateLabel       = map[string]string{utils.SchedulingGateLabel: utils.SchedulingGateLabelValueRemoved}
+		schedulingGateNotSetLabel = map[string]string{utils.SchedulingGateLabel: utils.LabelValueNotSet}
 	)
 	BeforeEach(func() {
 		By("Verifying the operand is ready")
@@ -224,7 +225,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
-			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateNotSetLabel)
 			verifyPodNodeAffinity(ns, "app", "test", archLabelNSTs)
 		})
 		It("should check each matchExpressions when users node affinity has multiple matchExpressions", func() {
@@ -269,7 +270,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			)
 			verifyPodNodeAffinity(ns, "app", "test", expectedHostnameNST, archLabelNSTs)
 		})
-		It("should not set the node affinity when nodeSelector exist", func() {
+		It("should neither set the node affinity nor gate pods when nodeSelector exist", func() {
 			var err error
 			var nodeSelectors = map[string]string{utils.ArchLabel: utils.ArchitectureAmd64}
 			ns := framework.NewEphemeralNamespace()
@@ -290,10 +291,10 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			err = client.Create(ctx, d)
 			Expect(err).NotTo(HaveOccurred())
-			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateNotSetLabel)
 			verifyPodNodeAffinity(ns, "app", "test")
 		})
-		It("should not set the node affinity when nodeName exist", func() {
+		It("should neither set the node affinity not gate pods when nodeName exist", func() {
 			var err error
 			By("Create an ephemeral namespace")
 			ns := framework.NewEphemeralNamespace()
@@ -420,7 +421,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
-		It("should not set the node affinity when with more containers all with multiarch image but users node affinity conflicts", func() {
+		It("should not set the node affinity when more multiarch image-based containers and users set node affinity", func() {
 			var err error
 			ns := framework.NewEphemeralNamespace()
 			err = client.Create(ctx, ns)
@@ -444,7 +445,7 @@ var _ = Describe("The Pod Placement Operand", func() {
 			err = client.Create(ctx, &s)
 			Expect(err).NotTo(HaveOccurred())
 			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(&archLabelNSR).Build()
-			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateLabel)
+			verifyPodLabels(ns, "app", "test", e2e.Present, schedulingGateNotSetLabel)
 			verifyPodNodeAffinity(ns, "app", "test", expectedNSTs)
 		})
 		It("should set the node affinity when with more containers all with multiarch image", func() {

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -19,7 +19,7 @@ const (
 	ArchLabel                       = "kubernetes.io/arch"
 	NodeAffinityLabel               = "multiarch.openshift.io/node-affinity"
 	NodeAffinityLabelValueSet       = "set"
-	NodeAffinityLabelValueNotSet    = "not-set"
+	LabelValueNotSet                = "not-set"
 	HostnameLabel                   = "kubernetes.io/hostname"
 	SchedulingGateLabel             = "multiarch.openshift.io/scheduling-gate"
 	SchedulingGateLabelValueGated   = "gated"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,22 +1,11 @@
 package utils
 
-import "path"
+import (
+	"path"
+)
 
 func NewPtr[T any](a T) *T {
 	return &a
-}
-
-func HasControlPlaneNodeSelector(nodeSelector map[string]string) bool {
-	if nodeSelector == nil {
-		return false
-	}
-	requiredSelectors := []string{MasterNodeSelectorLabel, ControlPlaneNodeSelectorLabel}
-	for _, value := range requiredSelectors {
-		if _, ok := nodeSelector[value]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 func ArchLabelValue(arch string) string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,8 +7,10 @@ func NewPtr[T any](a T) *T {
 }
 
 func HasControlPlaneNodeSelector(nodeSelector map[string]string) bool {
+	if nodeSelector == nil {
+		return false
+	}
 	requiredSelectors := []string{MasterNodeSelectorLabel, ControlPlaneNodeSelectorLabel}
-
 	for _, value := range requiredSelectors {
 		if _, ok := nodeSelector[value]; ok {
 			return true


### PR DESCRIPTION
Changes proposed in this PR:

- Improve the code of the webhook by using the Pod model embedding v1.Pod so that we can share further methods among the controller and the webhook
- Ensure the pod placement controller also runs the shouldIgnore verification: We remove the scheduling gate for pods that no longer meet the criteria for architecture-aware scheduling due to changes between the webhook patch at creation time and the pod's processing by the pod placement controller.
   - A pod may be gated but unprocessed when the operator's configuration changes, making the pod ineligible for architecture-aware scheduling based on the new rules.
   - Alternatively, the pod may have been modified by another webhook in the admission chain (e.g., setting the `nodeAffinity` for the `kubernetes.io/arch` label), rendering it unsuitable for further processing by the operator.
   In both scenarios, we must not set the nodeAffinity, and the gate should be removed.
- Ignore pods that have nodeSelectors/affinity set earlier in the webhook and before even catching pull secrets
- Finally, we stop ignoring hypershift—* namespaces. At this stage, it should mostly be a testing effort to validate that hyper shift works. Also, namespaces with hypershift—* are not a constraint for hypershift management clusters.
