### PR TITLE
OCPBUGS-42240: Refine security context

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2024-09-19T17:30:48Z"
+    createdAt: "2024-09-20T14:41:35Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -403,6 +403,11 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
                 volumeMounts:
                 - mountPath: /var/run/manager/tls
                   name: multiarch-tuning-operator-controller-manager-service-cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -94,6 +94,11 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -297,8 +297,9 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 										"ALL",
 									},
 								},
-								Privileged:   utils.NewPtr(false),
-								RunAsNonRoot: utils.NewPtr(true),
+								Privileged:             utils.NewPtr(false),
+								ReadOnlyRootFilesystem: utils.NewPtr(true),
+								RunAsNonRoot:           utils.NewPtr(true),
 								SeccompProfile: &corev1.SeccompProfile{
 									Type: corev1.SeccompProfileTypeRuntimeDefault,
 								},
@@ -324,6 +325,12 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 					},
 					PriorityClassName:  priorityClassName,
 					ServiceAccountName: serviceAccount,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: utils.NewPtr(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 						{
 							MaxSkew:           1,


### PR DESCRIPTION
This PR makes the security contexts of the workloads managed by the MTO and the MTO deployment explicit so that DAST is happy.