### PR TITLE
MULTIARCH-5000: Refine log levels

### DIFF
--- a/apis/multiarch/common/verbositylevel.go
+++ b/apis/multiarch/common/verbositylevel.go
@@ -13,10 +13,10 @@ const (
 
 func (verbosity LogVerbosityLevel) ToZapLevelInt() int {
 	logVerbosityToZapLevelMap := map[LogVerbosityLevel]int{
-		LogVerbosityLevelNormal:   3,
-		LogVerbosityLevelDebug:    4,
-		LogVerbosityLevelTrace:    5,
-		LogVerbosityLevelTraceAll: 6,
+		LogVerbosityLevelNormal:   0,
+		LogVerbosityLevelDebug:    1,
+		LogVerbosityLevelTrace:    2,
+		LogVerbosityLevelTraceAll: 3,
 	}
 
 	if level, ok := logVerbosityToZapLevelMap[verbosity]; ok {

--- a/controllers/podplacement/image_config.go
+++ b/controllers/podplacement/image_config.go
@@ -116,7 +116,7 @@ func (s *ImageRegistryConfigSyncer) onAddOrUpdate(ic systemconfig.IConfigSyncer,
 		return
 	}
 	if image.Name != "cluster" {
-		s.log.V(3).Info("Ignoring unexpected object", "name", image.Name)
+		s.log.V(1).Info("Ignoring unexpected object", "name", image.Name)
 		return
 	}
 	s.log.Info("The object has been updated")

--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -194,21 +194,21 @@ func (pod *Pod) imagesNamesSet() sets.Set[string] {
 func (pod *Pod) intersectImagesArchitecture(pullSecretDataList [][]byte) (supportedArchitectures []string, err error) {
 	log := ctrllog.FromContext(pod.ctx)
 	imageNamesSet := pod.imagesNamesSet()
-	log.V(3).Info("Images list for pod", "imageNamesSet", fmt.Sprintf("%+v", imageNamesSet))
+	log.V(1).Info("Images list for pod", "imageNamesSet", fmt.Sprintf("%+v", imageNamesSet))
 	// https://github.com/containers/skopeo/blob/v1.11.1/cmd/skopeo/inspect.go#L72
 	// Iterate over the images, get their architectures and intersect (as in set intersection) them each other
 	var supportedArchitecturesSet sets.Set[string]
 	nowExternal := time.Now()
 	defer metrics.HistogramObserve(nowExternal, metrics.TimeToInspectPodImages)
 	for imageName := range imageNamesSet {
-		log.V(5).Info("Checking image", "imageName", imageName)
+		log.V(3).Info("Checking image", "imageName", imageName)
 		// We are collecting the time to inspect the image here to avoid implementing a metric in each of the
 		// cache implementations.
 		now := time.Now()
 		currentImageSupportedArchitectures, err := imageInspectionCache.GetCompatibleArchitecturesSet(pod.ctx, imageName, pullSecretDataList)
 		metrics.HistogramObserve(now, metrics.TimeToInspectImage)
 		if err != nil {
-			log.V(3).Error(err, "Error inspecting the image", "imageName", imageName)
+			log.V(1).Error(err, "Error inspecting the image", "imageName", imageName)
 			return nil, err
 		}
 		if supportedArchitecturesSet == nil {
@@ -345,7 +345,7 @@ func (pod *Pod) isNodeSelectorConfiguredForArchitecture() bool {
 
 func (pod *Pod) publishIgnorePod() {
 	log := ctrllog.FromContext(pod.ctx)
-	log.V(3).Info("The pod has the nodeSelector or all the nodeAffinityTerms set for the kubernetes.io/arch label. Ignoring the pod...")
+	log.V(1).Info("The pod has the nodeSelector or all the nodeAffinityTerms set for the kubernetes.io/arch label. Ignoring the pod...")
 	pod.ensureLabel(utils.NodeAffinityLabel, utils.LabelValueNotSet)
 	pod.publishEvent(corev1.EventTypeNormal, ArchitecturePredicatesConflict, ArchitecturePredicatesConflictMsg)
 }

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"flag"
@@ -145,6 +146,7 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       leaderId,
 		Cache:                  cacheOpts,
+		Logger:                 ctrllog.FromContext(context.Background()).WithName("manager"),
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -268,11 +270,11 @@ func bindFlags() {
 	// and the log level will be set in the ClusterPodPlacementConfig at runtime (with no need for reconciliation)
 	flag.IntVar(&initialLogLevel, "initial-log-level", common.LogVerbosityLevelNormal.ToZapLevelInt(), "Initial log level. Converted to zap")
 	klog.InitFlags(nil)
-	_ = flag.Set("alsologtostderr", "true")
 	flag.Parse()
 	// Set the Log Level as AtomicLevel to allow runtime changes
 	utils.AtomicLevel = zapuber.NewAtomicLevelAt(zapcore.Level(-initialLogLevel))
 	zapLogger := zap.New(zap.Level(utils.AtomicLevel), zap.UseDevMode(false))
+	klog.SetLogger(zapLogger)
 	ctrllog.SetLogger(zapLogger)
 }
 

--- a/pkg/image/inspector.go
+++ b/pkg/image/inspector.go
@@ -119,7 +119,7 @@ func (i *registryInspector) GetCompatibleArchitecturesSet(ctx context.Context, i
 		var e *signature.PolicyRequirementError
 		if errors.As(err, &e) {
 			// false and valid error
-			log.V(5).Info("The signature policy JSON file configuration does not allow inspecting this image",
+			log.V(3).Info("The signature policy JSON file configuration does not allow inspecting this image",
 				"validationError", e)
 			return nil, e
 		}
@@ -160,7 +160,7 @@ func (i *registryInspector) GetCompatibleArchitecturesSet(ctx context.Context, i
 		return nil, err
 	}
 	if _, ok := config.Config.Labels[operatorSDKBuilderBundleAnnotation]; ok {
-		log.V(5).Info("The image is an operator bundle image")
+		log.V(3).Info("The image is an operator bundle image")
 		// Operator bundle images are not tied to a specific architecture, so we should not set any constraints
 		// based on the architecture they report.
 		// We return the full set of supported architectures so that the intersection with the node architecture set
@@ -170,7 +170,7 @@ func (i *registryInspector) GetCompatibleArchitecturesSet(ctx context.Context, i
 	}
 
 	if !manifest.MIMETypeIsMultiImage(manifest.GuessMIMEType(rawManifest)) {
-		log.V(5).Info("The image is not a manifest list... getting the supported architecture")
+		log.V(3).Info("The image is not a manifest list... getting the supported architecture")
 		return sets.New[string](config.Architecture), nil
 	}
 	return supportedArchitectures, nil


### PR DESCRIPTION
Updated log verbosity levels to range from 0 (Normal) to 3 (TraceAll). Default verbosity is now set to 0 to suppress excessive logging, including debug-level logs from the event recorder. Info and Error logs remain intact. This change ensures that only Error and Info level logs are printed by the Pod placement controller and webhook, reducing log output for non-error conditions and minimizing ephemeral storage usage. As a result, reconciled pods no longer produce logs under normal conditions, leading to slight performance improvements. Users can adjust the log level via the ClusterPodPlacementConfig to increase verbosity as needed.