### PR TITLE
fix path env variable in deploy-and-e2e.sh

### DIFF
--- a/hack/deploy-and-e2e.sh
+++ b/hack/deploy-and-e2e.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euxo pipefail
 
+mkdir -p /tmp/bin
+export PATH=/tmp/bin:${PATH}
 if ! which kubectl >/dev/null; then
-  mkdir -p /tmp/bin
-  export PATH=/tmp/bin:${PATH}
   ln -s "$(which oc)" "/tmp/bin/kubectl"
 fi
 

--- a/pkg/e2e/podplacement/e2e_test.go
+++ b/pkg/e2e/podplacement/e2e_test.go
@@ -98,6 +98,8 @@ var _ = AfterSuite(func() {
 	Eventually(framework.ValidateDeletion(client, ctx)).Should(Succeed())
 	By("Clean up registry config test data")
 	deleteRegistryConfigTestData()
+	By("Wait for machineconfig finishing updating")
+	framework.WaitForMCPComplete(ctx, client)
 })
 
 // updateGlobalPullSecret patches the global pull secret to onboard the


### PR DESCRIPTION
the pr fix below issues
- when deploy-and-e2e.sh is running twice, the symbolic link has been created to `/tmp/bin/kubectl` but the path is reset without `/tmp/bin`,  wich kubectl and` ln -s` command will fail
- add WaitForMCPComplete in AfterSuite, otherwise the step `*-gather-audit-logs` might fail