### PR TITLE
MULTIARCH-4565: Run integration tests in Konflux

### DIFF
--- a/.tekton/multiarch-tuning-operator-integration-tests.yaml
+++ b/.tekton/multiarch-tuning-operator-integration-tests.yaml
@@ -1,0 +1,52 @@
+kind: Pipeline
+apiVersion: tekton.dev/v1
+metadata:
+  name: integration-and-unit-tests
+  namespace: multiarch-tuning-ope-tenant
+spec:
+  params: [ ]
+  tasks:
+    - name: clone-and-test
+      taskSpec:
+        volumes:
+          - name: source
+            emptyDir: { }
+        steps:
+          - image: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22
+            env:
+              - name: URL
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/source-repo-url']
+              - name: REVISION
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/sha']
+            computeResources:
+              limits:
+                cpu: 8
+                memory: 4Gi
+              requests:
+                cpu: 500m
+                memory: 1Gi
+            volumeMounts:
+              - name: source
+                mountPath: /workspace
+            script: |
+              #!/bin/bash
+              set -exuo pipefail
+              if [ -z "$URL" ] || [ -z "$REVISION" ]; then
+                echo "URL and REVISION must be set"
+                exit 1
+              fi
+              echo "Initializing the env vars"
+              echo "URL: $URL"
+              echo "REVISION: $REVISION"
+              mkdir /workspace/source
+              cd /workspace/source
+              git init
+              git remote add origin $URL
+              git fetch origin $REVISION
+              git checkout FETCH_HEAD
+              make unit NO_DOCKER=1
+              exit $? # exit with the status of the tests


### PR DESCRIPTION
This PR adds a Pipeline that we will bind to an IntegrationTestScenario for running the unit and integration tests as a gating job for the releases.

Passed test: https://github.com/openshift/multiarch-tuning-operator/pull/287/checks?check_run_id=30593240233