### PR TITLE
MULTIARCH-4307: Add fix for e2e running in cluster-wide proxy based cluster

### DIFF
--- a/pkg/testing/builder/configmap_builder.go
+++ b/pkg/testing/builder/configmap_builder.go
@@ -44,6 +44,17 @@ func (s *ConfigMapBuilder) WithBinaryData(entries map[string][]byte) *ConfigMapB
 	return s
 }
 
+func (s *ConfigMapBuilder) WithLabels(entries map[string]string) *ConfigMapBuilder {
+	if s.configmap.Labels == nil && len(entries) > 0 {
+		s.configmap.Labels = make(map[string]string, len(entries))
+	}
+	for k, v := range entries {
+		s.configmap.Labels[k] = v
+	}
+
+	return s
+}
+
 func (s *ConfigMapBuilder) Build() v1.ConfigMap {
 	return s.configmap
 }

--- a/pkg/testing/builder/volume_builder.go
+++ b/pkg/testing/builder/volume_builder.go
@@ -28,6 +28,17 @@ func (v *VolumeBuilder) WithVolumeSourceHostPath(path string, pathType *v1.HostP
 	return v
 }
 
+func (v *VolumeBuilder) WithVolumeSourceConfigmap(name string, values ...v1.KeyToPath) *VolumeBuilder {
+	if v.volume.VolumeSource.ConfigMap == nil {
+		v.volume.VolumeSource.ConfigMap = &v1.ConfigMapVolumeSource{}
+	}
+	v.volume.VolumeSource.ConfigMap.LocalObjectReference = v1.LocalObjectReference{
+		Name: name,
+	}
+	v.volume.VolumeSource.ConfigMap.Items = values
+	return v
+}
+
 func (v *VolumeBuilder) WithVolumeEmptyDir(value *v1.EmptyDirVolumeSource) *VolumeBuilder {
 	if v.volume.EmptyDir == nil {
 		v.volume.EmptyDir = &v1.EmptyDirVolumeSource{}

--- a/pkg/testing/builder/volume_mount_builder.go
+++ b/pkg/testing/builder/volume_mount_builder.go
@@ -24,6 +24,11 @@ func (v *VolumeMountBuilder) WithMountPath(path string) *VolumeMountBuilder {
 	return v
 }
 
+func (v *VolumeMountBuilder) WithReadOnly() *VolumeMountBuilder {
+	v.volumeMount.ReadOnly = true
+	return v
+}
+
 func (v *VolumeMountBuilder) Build() v1.VolumeMount {
 	return v.volumeMount
 }


### PR DESCRIPTION
Add proxy info for e2e test cases which need connection to network in the container for running e2e on cluster-wide proxy based cluster.