### PR TITLE
NO-JIRA: Update kustomization project to support 1.0 images built in Konflux

### DIFF
--- a/deploy/base/config.openshift.io/imagedistedmirrorsets/multiarch-tuning-operator-fbc-staging/imagedigestmirrorset.yaml
+++ b/deploy/base/config.openshift.io/imagedistedmirrorsets/multiarch-tuning-operator-fbc-staging/imagedigestmirrorset.yaml
@@ -6,7 +6,9 @@ spec:
   imageDigestMirrors:
     - source: registry.redhat.io/multiarch-tuning/multiarch-tuning-operator-bundle
       mirrors:
+        - quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator-1-0/multiarch-tuning-operator-bundle-1-0
         - quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator-bundle
     - source: registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator
       mirrors:
+        - quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator-1-0/multiarch-tuning-operator-1-0
         - quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator

--- a/deploy/base/operators.coreos.com/subscriptions/openshift-multiarch-tuning-operator/subscription.yaml
+++ b/deploy/base/operators.coreos.com/subscriptions/openshift-multiarch-tuning-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-multiarch-tuning-operator
   namespace: openshift-multiarch-tuning-operator
 spec:
-  channel: tech-preview
+  channel: stable
   name: multiarch-tuning-operator
   source: multiarch-tuning-operator-catalog
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The new default channel for the subscription should be `stable`. Also, now that we have branched and created builds from the v1.0 branch, the images mirror to test the non-released images built by Konflux, I'm adding a mirror to the ImageDigestMirrorSet we deploy via kustomize.

cc @AnnaZivkovic to report in #294 