### PR TITLE
OCPBUGS-42165: Do not cache images from containers with image pull policy 'Always'

### DIFF
--- a/controllers/podplacement/pod_reconciler_test.go
+++ b/controllers/podplacement/pod_reconciler_test.go
@@ -201,10 +201,11 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 		Context("with different image types", func() {
 			DescribeTable("handles correctly", func(bundleImageType string, secondImageType string, supportedArchitectures ...string) {
 				pod := NewPod().
-					WithContainersImages(fmt.Sprintf("%s/%s/%s:latest", registryAddress,
-						registry.PublicRepo, registry.ComputeNameByMediaType(bundleImageType, "bundle"))).
-					WithContainersImages(fmt.Sprintf("%s/%s/%s:latest", registryAddress,
-						registry.PublicRepo, registry.ComputeNameByMediaType(secondImageType, "ppc64le-s390x"))).
+					WithContainersImages(
+						fmt.Sprintf("%s/%s/%s:latest", registryAddress,
+							registry.PublicRepo, registry.ComputeNameByMediaType(bundleImageType, "bundle")),
+						fmt.Sprintf("%s/%s/%s:latest", registryAddress,
+							registry.PublicRepo, registry.ComputeNameByMediaType(secondImageType, "ppc64le-s390x"))).
 					WithGenerateName("test-pod-").
 					WithNamespace("test-namespace").Build()
 				err := k8sClient.Create(ctx, &pod)

--- a/controllers/podplacement/pod_reconciler_test.go
+++ b/controllers/podplacement/pod_reconciler_test.go
@@ -182,6 +182,105 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 						},
 					}), "unexpected node affinity")
 			})
+			It("always queries the remote registry when the container uses imagePullPolicy 'Always'", func() {
+				imageName := registry.ComputeNameByMediaType(imgspecv1.MediaTypeImageIndex, "custom-image-that-will-change-supported-architectures-2")
+				By("Pushing a custom image to the registry")
+				supportedArchitectures := sets.New[string](utils.ArchitectureArm64, utils.ArchitectureAmd64)
+				err := registry.PushMockImage(ctx,
+					&registry.MockImage{
+						Architectures: supportedArchitectures,
+						Repository:    registry.PublicRepo,
+						Name:          imageName,
+						MediaType:     imgspecv1.MediaTypeImageIndex,
+						Tag:           "latest",
+					})
+				Expect(err).NotTo(HaveOccurred(), "failed push custom image to registry, err")
+				By("Creating a pod with the custom image [the cache will be populated with info about that image and its supported architectures]")
+				pod := NewPod().
+					WithContainerImagePullAlways(fmt.Sprintf("%s/%s/%s:latest", registryAddress,
+						registry.PublicRepo, imageName)).
+					WithGenerateName("test-pod-").
+					WithNamespace("test-namespace").
+					Build()
+				err = k8sClient.Create(ctx, &pod)
+				Expect(err).NotTo(HaveOccurred(), "failed to create pod", err)
+				By("Waiting for the pod to be mutated and the scheduling gate to be removed")
+				Eventually(func(g Gomega) {
+					// Get pod from the API server
+					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&pod), &pod)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get pod", err)
+					g.Expect(pod.Spec.SchedulingGates).NotTo(ContainElement(corev1.PodSchedulingGate{
+						Name: utils.SchedulingGateName,
+					}), "scheduling gate not removed")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
+						"scheduling gate annotation not found")
+				}).Should(Succeed(), "failed to remove scheduling gate from pod")
+				By("Checking that the pod has the correct node affinity")
+				Expect(pod).To(HaveEquivalentNodeAffinity(
+					&corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      utils.ArchLabel,
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   sets.List(supportedArchitectures),
+										},
+									},
+								},
+							},
+						},
+					}), "unexpected node affinity")
+				By("Replace the image with a new one having a different set of supported architectures")
+				supportedArchitectures = sets.New[string](utils.ArchitectureArm64, utils.ArchitectureAmd64, utils.ArchitecturePpc64le)
+				err = registry.PushMockImage(ctx,
+					&registry.MockImage{
+						Repository:    registry.PublicRepo,
+						Name:          imageName,
+						Architectures: supportedArchitectures,
+						MediaType:     imgspecv1.MediaTypeImageIndex,
+						Tag:           "latest",
+					})
+				Expect(err).NotTo(HaveOccurred(), "failed push custom image to registry, err")
+				By("Creating a new pod with the custom image")
+				pod = NewPod().
+					WithContainerImagePullAlways(fmt.Sprintf("%s/%s/%s:latest", registryAddress,
+						registry.PublicRepo, imageName)).
+					WithGenerateName("test-pod-").
+					WithNamespace("test-namespace").
+					Build()
+				err = k8sClient.Create(ctx, &pod)
+				Expect(err).NotTo(HaveOccurred(), "failed to create pod", err)
+				By("Waiting for the pod to be mutated and the scheduling gate to be removed")
+				Eventually(func(g Gomega) {
+					// Get pod from the API server
+					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&pod), &pod)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get pod", err)
+					g.Expect(pod.Spec.SchedulingGates).NotTo(ContainElement(corev1.PodSchedulingGate{
+						Name: utils.SchedulingGateName,
+					}), "scheduling gate not removed")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
+						"scheduling gate annotation not found")
+				}).Should(Succeed(), "failed to remove scheduling gate from pod")
+				By("Checking that the pod has the wrong, cached, node affinity [this proves we are not querying the remote registry]")
+				Expect(pod).To(HaveEquivalentNodeAffinity(
+					&corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      utils.ArchLabel,
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   sets.List(supportedArchitectures),
+										},
+									},
+								},
+							},
+						},
+					}), "unexpected node affinity")
+			})
 		})
 	})
 	When("Handling Multi-container Pods", func() {

--- a/pkg/image/facade.go
+++ b/pkg/image/facade.go
@@ -34,8 +34,8 @@ type Facade struct {
 	storeGlobalPullSecret func(pullSecret []byte)
 }
 
-func (i *Facade) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (architectures sets.Set[string], err error) {
-	return i.inspectionCache.GetCompatibleArchitecturesSet(ctx, imageReference, secrets)
+func (i *Facade) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, skipCache bool, secrets [][]byte) (architectures sets.Set[string], err error) {
+	return i.inspectionCache.GetCompatibleArchitecturesSet(ctx, imageReference, skipCache, secrets)
 }
 
 func (i *Facade) StoreGlobalPullSecret(pullSecret []byte) {

--- a/pkg/image/inspector.go
+++ b/pkg/image/inspector.go
@@ -55,7 +55,7 @@ type registryInspector struct {
 // If the image is a manifest, it will return the architecture set in the manifest's config.
 // If the image is an operator bundle image, it will return an empty set. This is because operator bundle images
 // are not tied to a specific architecture, and we should not set any constraints based on the architecture they report.
-func (i *registryInspector) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (supportedArchitectures sets.Set[string], err error) {
+func (i *registryInspector) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, _ bool, secrets [][]byte) (supportedArchitectures sets.Set[string], err error) {
 	// Create the auth file
 	log := ctrllog.FromContext(ctx, "imageReference", imageReference)
 	i.mutex.RLock()

--- a/pkg/image/interfaces.go
+++ b/pkg/image/interfaces.go
@@ -25,7 +25,7 @@ import (
 type ICache interface {
 	// GetCompatibleArchitecturesSet takes an image reference. a list of secrets and the client to the cluster and
 	// returns a set of architectures that are compatible with the image reference.
-	GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (sets.Set[string], error)
+	GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, skipCache bool, secrets [][]byte) (sets.Set[string], error)
 }
 
 type IRegistryInspector interface {

--- a/pkg/testing/image/fake/cache.go
+++ b/pkg/testing/image/fake/cache.go
@@ -12,7 +12,7 @@ type cacheProxy struct {
 	imageRefsArchitectureMap map[string]sets.Set[string]
 }
 
-func (c *cacheProxy) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string,
+func (c *cacheProxy) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, skipCache bool,
 	secrets [][]byte) (supportedArchitectures sets.Set[string], err error) {
 	// we expect the imageReference to start with `//`. Let's remove it
 	imageReference = imageReference[2:]

--- a/pkg/testing/image/fake/facade.go
+++ b/pkg/testing/image/fake/facade.go
@@ -19,9 +19,9 @@ type Facade struct {
 	inspectionCache image.ICache
 }
 
-func (i *Facade) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string,
+func (i *Facade) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, skipCache bool,
 	secrets [][]byte) (architectures sets.Set[string], err error) {
-	return i.inspectionCache.GetCompatibleArchitecturesSet(ctx, imageReference, secrets)
+	return i.inspectionCache.GetCompatibleArchitecturesSet(ctx, imageReference, skipCache, secrets)
 }
 
 func newImageFacade() *Facade {

--- a/pkg/testing/image/fake/inspector.go
+++ b/pkg/testing/image/fake/inspector.go
@@ -34,7 +34,7 @@ func MockImagesArchitectureMap() map[string]sets.Set[string] {
 }
 
 func (i *registryInspector) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string,
-	secrets [][]byte) (supportedArchitectures sets.Set[string], err error) {
+	skipCache bool, secrets [][]byte) (supportedArchitectures sets.Set[string], err error) {
 	// we expect the imageReference to start with `//`. Let's remove it
 	imageReference = imageReference[2:]
 	if archSet, ok := MockImagesArchitectureMap()[imageReference]; ok {

--- a/pkg/testing/image/fake/registry/mock_image.go
+++ b/pkg/testing/image/fake/registry/mock_image.go
@@ -79,6 +79,7 @@ func (i *MockImage) prepareSingleArchImage(ctx context.Context, dst *types.Image
 	arch, _ := i.Architectures.PopAny()
 	labelsJsonBytes, _ := json.Marshal(i.Labels)
 	configData := []byte(fmt.Sprintf(`{"architecture":"%s","os":"linux","config":{"Labels":%s}}`, arch, string(labelsJsonBytes)))
+	log.Info(fmt.Sprintf("%s (%s): %s", i.GetUrl(), arch, string(configData)))
 	configDataDigest, err := manifest.Digest(configData)
 	if err != nil {
 		log.Error(err, "Error computing the digest of the image config data")
@@ -140,6 +141,7 @@ func (i *MockImage) prepareManifestList(ctx context.Context, authFile string, ds
 			MediaType:     singleArchManifestMediaType,
 			Repository:    i.Repository,
 			Name:          i.Name,
+			Labels:        i.Labels,
 			Tag:           i.Tag,
 			partial:       true,
 			destination:   i.destination,

--- a/pkg/testing/image/fake/registry/seed.go
+++ b/pkg/testing/image/fake/registry/seed.go
@@ -74,17 +74,23 @@ func GetMockImages() []MockImage {
 		}
 	}
 	mockImages = append(mockImages, MockImage{
-		Architectures: sets.New[string](utils.ArchitecturePpc64le, utils.ArchitectureS390x),
+		Architectures: sets.New[string](utils.ArchitecturePpc64le, utils.ArchitectureArm64),
 		MediaType:     imgspecv1.MediaTypeImageIndex,
 		Repository:    PublicRepo,
 		Name:          ComputeNameByMediaType(imgspecv1.MediaTypeImageIndex, "bundle"),
 		Tag:           "latest",
+		Labels: map[string]string{
+			"operators.operatorframework.io.metrics.builder": "",
+		},
 	}, MockImage{
 		Architectures: sets.New[string](utils.ArchitecturePpc64le),
 		MediaType:     imgspecv1.MediaTypeImageManifest,
 		Repository:    PublicRepo,
 		Name:          ComputeNameByMediaType(imgspecv1.MediaTypeImageManifest, "bundle"),
 		Tag:           "latest",
+		Labels: map[string]string{
+			"operators.operatorframework.io.metrics.builder": "",
+		},
 	}, MockImage{
 		Architectures: sets.New[string](utils.ArchitecturePpc64le, utils.ArchitectureS390x),
 		MediaType:     imgspecv1.MediaTypeImageIndex,


### PR DESCRIPTION
When a container in a pod uses the ImagePullPolicy `Always`, we should not use the cache to retrieve its metadata.

While changing a behavior in the pod_builder to accommodate a test for this PR, I noticed an issue with the integration test of the operators bundle cases. This PR includes the fix as the new behavior of the `WithContainerImages` function would let the test to fail.