### PR TITLE
WIP: OCPBUGS-41554: remove service-ca.crt

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2024-09-30T12:29:39Z"
+    createdAt: "2024-10-16T20:07:51Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -432,12 +432,6 @@ spec:
               - name: ca-projected-volume
                 projected:
                   sources:
-                  - configMap:
-                      items:
-                      - key: service-ca.crt
-                        path: openshift-ca.crt
-                      name: openshift-service-ca.crt
-                      optional: true
                   - configMap:
                       items:
                       - key: ca.crt

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -135,12 +135,6 @@ spec:
           projected:
             sources:
               - configMap:
-                  name: openshift-service-ca.crt
-                  items:
-                    - key: service-ca.crt
-                      path: openshift-ca.crt
-                  optional: true
-              - configMap:
                   name: kube-root-ca.crt
                   items:
                     - key: ca.crt

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -312,11 +312,6 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 									ReadOnly:  true,
 								},
 								{
-									Name:      "ca-projected-volume",
-									MountPath: "/etc/ssl/certs",
-									ReadOnly:  true,
-								},
-								{
 									Name:      "trusted-ca",
 									MountPath: "/etc/pki/ca-trust/extracted/pem",
 									ReadOnly:  true,
@@ -362,20 +357,6 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 								Projected: &corev1.ProjectedVolumeSource{
 									DefaultMode: utils.NewPtr(int32(420)),
 									Sources: []corev1.VolumeProjection{
-										{
-											ConfigMap: &corev1.ConfigMapProjection{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "openshift-service-ca.crt",
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "service-ca.crt",
-														Path: "openshift-ca.crt",
-													},
-												},
-												Optional: utils.NewPtr(true), // Account for the case where the ConfigMap does not exist (non openshift clusters)
-											},
-										},
 										{
 											ConfigMap: &corev1.ConfigMapProjection{
 												LocalObjectReference: corev1.LocalObjectReference{


### PR DESCRIPTION
The pod placement controller does not need the cluster service-ca.crt to function. In fact, it  should not use cluster service-ca.crt CA to inspect image arch if the user did not add it to trusted anchors explicitly.