### PR TITLE
OCPBUGS-41554: remove cluster-ca.crt and kube-root-ca.crt from operator

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2024-09-30T12:29:39Z"
+    createdAt: "2024-10-16T20:07:51Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -414,9 +414,6 @@ spec:
                 - mountPath: /var/run/manager/tls
                   name: multiarch-tuning-operator-controller-manager-service-cert
                   readOnly: true
-                - mountPath: /etc/ssl/certs/
-                  name: ca-projected-volume
-                  readOnly: true
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: true
@@ -429,20 +426,6 @@ spec:
                 secret:
                   defaultMode: 420
                   secretName: multiarch-tuning-operator-controller-manager-service-cert
-              - name: ca-projected-volume
-                projected:
-                  sources:
-                  - configMap:
-                      items:
-                      - key: service-ca.crt
-                        path: openshift-ca.crt
-                      name: openshift-service-ca.crt
-                      optional: true
-                  - configMap:
-                      items:
-                      - key: ca.crt
-                        path: kube-root-ca.crt
-                      name: kube-root-ca.crt
       permissions:
       - rules:
         - apiGroups:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -120,9 +120,6 @@ spec:
         - mountPath: /var/run/manager/tls
           name: multiarch-tuning-operator-controller-manager-service-cert
           readOnly: true
-        - mountPath: /etc/ssl/certs/
-          name: ca-projected-volume
-          readOnly: true
       priorityClassName: system-cluster-critical
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
@@ -131,17 +128,3 @@ spec:
           secret:
             secretName: multiarch-tuning-operator-controller-manager-service-cert
             defaultMode: 420
-        - name: ca-projected-volume
-          projected:
-            sources:
-              - configMap:
-                  name: openshift-service-ca.crt
-                  items:
-                    - key: service-ca.crt
-                      path: openshift-ca.crt
-                  optional: true
-              - configMap:
-                  name: kube-root-ca.crt
-                  items:
-                    - key: ca.crt
-                      path: kube-root-ca.crt

--- a/controllers/operator/objects.go
+++ b/controllers/operator/objects.go
@@ -312,11 +312,6 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 									ReadOnly:  true,
 								},
 								{
-									Name:      "ca-projected-volume",
-									MountPath: "/etc/ssl/certs",
-									ReadOnly:  true,
-								},
-								{
 									Name:      "trusted-ca",
 									MountPath: "/etc/pki/ca-trust/extracted/pem",
 									ReadOnly:  true,
@@ -353,43 +348,6 @@ func buildDeployment(clusterPodPlacementConfig *v1beta1.ClusterPodPlacementConfi
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  name,
 									DefaultMode: utils.NewPtr(int32(420)),
-								},
-							},
-						},
-						{
-							Name: "ca-projected-volume",
-							VolumeSource: corev1.VolumeSource{
-								Projected: &corev1.ProjectedVolumeSource{
-									DefaultMode: utils.NewPtr(int32(420)),
-									Sources: []corev1.VolumeProjection{
-										{
-											ConfigMap: &corev1.ConfigMapProjection{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "openshift-service-ca.crt",
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "service-ca.crt",
-														Path: "openshift-ca.crt",
-													},
-												},
-												Optional: utils.NewPtr(true), // Account for the case where the ConfigMap does not exist (non openshift clusters)
-											},
-										},
-										{
-											ConfigMap: &corev1.ConfigMapProjection{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "kube-root-ca.crt",
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "ca.crt",
-														Path: "kube-root-ca.crt",
-													},
-												},
-											},
-										},
-									},
 								},
 							},
 						},


### PR DESCRIPTION
Continuing off of https://github.com/openshift/multiarch-tuning-operator/pull/334

The pod placement controller does not need the cluster service-ca.crt to function. In fact, it should not use cluster service-ca.crt CA to inspect image arch if the user did not add it to trusted anchors explicitly.