### PR TITLE
MULTIARCH-5053: Make e2e pass on hypershift managed clusters

### DIFF
--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -624,23 +624,12 @@ var _ = Describe("The Pod Placement Operand", func() {
 				Build()
 			err = client.Create(ctx, b)
 			Expect(err).NotTo(HaveOccurred())
-			archLabelNSR := NewNodeSelectorRequirement().
-				WithKeyAndValues(utils.ArchLabel, corev1.NodeSelectorOpIn, utils.ArchitectureAmd64,
-					utils.ArchitectureArm64, utils.ArchitectureS390x, utils.ArchitecturePpc64le).
-				Build()
-			expectedNSTs := NewNodeSelectorTerm().WithMatchExpressions(archLabelNSR).Build()
 			By("The pod should have been processed by the webhook and the scheduling gate label should be added")
 			Eventually(framework.VerifyPodLabels(ctx, client, ns, "openshift.io/build.name", "test-build", e2e.Present, schedulingGateLabel), e2e.WaitShort).Should(Succeed())
-			By("Verify arch label are set")
+			By("Verify node affinity label are set")
 			Eventually(framework.VerifyPodLabelsAreSet(ctx, client, ns, "openshift.io/build.name", "test-build",
-				utils.MultiArchLabel, "",
-				utils.ArchLabelValue(utils.ArchitectureAmd64), "",
-				utils.ArchLabelValue(utils.ArchitectureArm64), "",
-				utils.ArchLabelValue(utils.ArchitectureS390x), "",
-				utils.ArchLabelValue(utils.ArchitecturePpc64le), "",
+				utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet,
 			), e2e.WaitShort).Should(Succeed())
-			By("The pod should have been set node affinity of arch info.")
-			Eventually(framework.VerifyPodNodeAffinity(ctx, client, ns, "openshift.io/build.name", "test-build", *expectedNSTs), e2e.WaitShort).Should(Succeed())
 		})
 		It("should set the node affinity on DeploymentConfig owning pod", func() {
 			var err error

--- a/pkg/e2e/podplacement/pod_placement_test.go
+++ b/pkg/e2e/podplacement/pod_placement_test.go
@@ -710,6 +710,9 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodNodeAffinity(ctx, client, ns, "app", "test"), e2e.WaitShort).Should(Succeed())
 		})
 		It("should set the node affinity in pods with images requiring credentials set in the global pull secret", func() {
+			if len(masterNodes.Items) == 0 {
+				Skip("The current cluster is a hosted cluster, skipping global pull secret tests")
+			}
 			var err error
 			By("Create an ephemeral namespace")
 			ns := framework.NewEphemeralNamespace()
@@ -800,6 +803,9 @@ var _ = Describe("The Pod Placement Operand", func() {
 			Eventually(framework.VerifyPodNodeAffinity(ctx, client, ns, "app", "test", *expectedNSTs), e2e.WaitShort).Should(Succeed())
 		})
 		It("should set the node affinity in pods with images that require both global and local pull secrets", func() {
+			if len(masterNodes.Items) == 0 {
+				Skip("The current cluster is a hosted cluster, skipping global pull secret tests")
+			}
 			var err error
 			By("Create an ephemeral namespace")
 			ns := framework.NewEphemeralNamespace()
@@ -852,6 +858,11 @@ var _ = Describe("The Pod Placement Operand", func() {
 		})
 	})
 	Context("When deploying workloads that registry of image uses a self-signed certificate", Serial, func() {
+		BeforeEach(func() {
+			if len(masterNodes.Items) == 0 {
+				Skip("The current cluster is a hosted cluster, skipping image config tests")
+			}
+		})
 		It("should set the node affinity when registry url added to insecureRegistries list", func() {
 			var err error
 			By("Create an ephemeral namespace")
@@ -985,6 +996,11 @@ var _ = Describe("The Pod Placement Operand", func() {
 		})
 	})
 	Context("When deploying workloads running images in registries that have mirrors configuration", func() {
+		BeforeEach(func() {
+			if len(masterNodes.Items) == 0 {
+				Skip("The current cluster is a hosted cluster, skipping registry config tests")
+			}
+		})
 		It("Should set node affinity when source registry is unavailable, mirrors working and AllowContactingSource enabled in a ImageContentSourcePolicy", func() {
 			var err error
 			By("Create an ephemeral namespace")


### PR DESCRIPTION
I have tested all e2e cases locally in a hosted cluster(iscp, pull-secret,image.config need to be configurated at mgmt hostedcluster CR side). then we will skip those test cases which need to config at mgmt side from e2e.  there is no different between ocp and hosted cluster, so it doesn't need to make e2e complex.
This pr fix below issue
- skip registry and image config tests on hypershift managed offerings
- fix Build tests, the supported arch is related to the payload of the cluster, so it's enough to just verify label `multiarch.openshift.io/node-affinity:set` and `multiarch.openshift.io/scheduling-gate: removed` 