### PR TITLE
OCPBUGS-44703: Invalidate registry cache before inspection of pods

### DIFF
--- a/pkg/image/inspector.go
+++ b/pkg/image/inspector.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
@@ -72,6 +73,11 @@ func (i *registryInspector) GetCompatibleArchitecturesSet(ctx context.Context, i
 			}
 		}(authFile)
 	}
+	// Invalidate registry cache before calling image APIs to catch updates to registry configurations.
+	// TODO: watch ICSP/IDMS/ITMS for changes or alternatively invalidate only on MCP updates rather
+	// than do this everytime
+	sysregistriesv2.InvalidateCache()
+
 	// Check if the image is a manifest list
 	ref, err := docker.ParseReference(imageReference)
 	if err != nil {


### PR DESCRIPTION
Registry config is cached by the container image library. Invalidate the cache each time we inspect images for a pod in the case of any updates.

A follow up refinement to this should be to only invalidate cache when the MCP has been updated for optimization.