### PR TITLE
Konflux: fixing pipeline fail

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -59,7 +59,7 @@ spec:
             - name: name
               value: summary
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:ac5b078500566c204eaa23e3aea1e2f7e003ac750514198419cb322a2eaf177a
+              value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:716d50d6f79c119e729a41ddf4eca7ddc521dbfb32cc10c7e1ef1942da887e26
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -56,7 +56,7 @@ spec:
             - name: name
               value: summary
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:ac5b078500566c204eaa23e3aea1e2f7e003ac750514198419cb322a2eaf177a
+              value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:716d50d6f79c119e729a41ddf4eca7ddc521dbfb32cc10c7e1ef1942da887e26
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
             - name: name
               value: summary
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:ac5b078500566c204eaa23e3aea1e2f7e003ac750514198419cb322a2eaf177a
+              value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:716d50d6f79c119e729a41ddf4eca7ddc521dbfb32cc10c7e1ef1942da887e26
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -57,7 +57,7 @@ spec:
             - name: name
               value: summary
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:ac5b078500566c204eaa23e3aea1e2f7e003ac750514198419cb322a2eaf177a
+              value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:716d50d6f79c119e729a41ddf4eca7ddc521dbfb32cc10c7e1ef1942da887e26
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
Pipeline multiarch-tuning-ope-tenant/multiarch-tuning-operator-on-pull-request-j789j can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "resolver type bundles\nname = summary\n": error requesting remote resource: error getting "bundleresolver" "multiarch-tuning-ope-tenant/bundles-41b705e47ef46150a600c82047c4e0fc": cannot retrieve the oci image: GET https://quay.io/v2/redhat-appstudio-tekton-catalog/task-summary/manifests/sha256:ac5b078500566c204eaa23e3aea1e2f7e003ac750514198419cb322a2eaf177a: MANIFEST_UNKNOWN: manifest unknown; map[]

updating sha with most recent version sha256:716d50d6f79c119e729a41ddf4eca7ddc521dbfb32cc10c7e1ef1942da887e26

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1733824270869739