### PR TITLE
Konflux Remove JAVA_COMMUNITY_DEPENDENCIES

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -126,9 +126,6 @@ spec:
       - description: ""
         name: CHAINS-GIT_COMMIT
         value: $(tasks.clone-repository.results.commit)
-      - description: ""
-        name: JAVA_COMMUNITY_DEPENDENCIES
-        value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
       - name: init
         params:

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -123,9 +123,6 @@ spec:
       - description: ""
         name: CHAINS-GIT_COMMIT
         value: $(tasks.clone-repository.results.commit)
-      - description: ""
-        name: JAVA_COMMUNITY_DEPENDENCIES
-        value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
       - name: init
         params:

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -128,9 +128,6 @@ spec:
       - description: ""
         name: CHAINS-GIT_COMMIT
         value: $(tasks.clone-repository.results.commit)
-      - description: ""
-        name: JAVA_COMMUNITY_DEPENDENCIES
-        value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
       - name: init
         params:

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -124,9 +124,6 @@ spec:
       - description: ""
         name: CHAINS-GIT_COMMIT
         value: $(tasks.clone-repository.results.commit)
-      - description: ""
-        name: JAVA_COMMUNITY_DEPENDENCIES
-        value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
       - name: init
         params:


### PR DESCRIPTION
Failed to resolve pipeline result reference for "multiarch-tuning-operator-on-pull-request-v77rk" with error %!w(*fmt.wrapError=&{invalid pipeline result "JAVA_COMMUNITY_DEPENDENCIES": "JAVA_COMMUNITY_DEPENDENCIES" is not a named result returned by pipeline task "build-container-amd64" 0xc0f8321c50})

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1736235862881429