### PR TITLE
Konflux: update task-clair-scan

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -287,7 +287,7 @@ spec:
             - name: name
               value: clair-scan
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:c2c88e251702dcf0db4a0ce0a8053c51aa1a2f7329defa9bb6ce4121c506dd55
+              value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:a0e3302b0cf4b79ff632940d5c5695b826c32da7a0efb1644241c77648d85d70
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -284,7 +284,7 @@ spec:
             - name: name
               value: clair-scan
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:c2c88e251702dcf0db4a0ce0a8053c51aa1a2f7329defa9bb6ce4121c506dd55
+              value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:a0e3302b0cf4b79ff632940d5c5695b826c32da7a0efb1644241c77648d85d70
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -515,7 +515,7 @@ spec:
             - name: name
               value: clair-scan
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:c2c88e251702dcf0db4a0ce0a8053c51aa1a2f7329defa9bb6ce4121c506dd55
+              value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:a0e3302b0cf4b79ff632940d5c5695b826c32da7a0efb1644241c77648d85d70
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -511,7 +511,7 @@ spec:
             - name: name
               value: clair-scan
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:c2c88e251702dcf0db4a0ce0a8053c51aa1a2f7329defa9bb6ce4121c506dd55
+              value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:a0e3302b0cf4b79ff632940d5c5695b826c32da7a0efb1644241c77648d85d70
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
Pipeline multiarch-tuning-ope-tenant/multiarch-tuning-operator-on-pull-request-rdb2c can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "resolver type bundles\nname = clair-scan\n": error requesting remote resource: error getting "bundleresolver" "multiarch-tuning-ope-tenant/bundles-d45e5bc8c0bf7387896ada318ff6ba42": cannot retrieve the oci image: GET https://quay.io/v2/redhat-appstudio-tekton-catalog/task-clair-scan/manifests/sha256:c2c88e251702dcf0db4a0ce0a8053c51aa1a2f7329defa9bb6ce4121c506dd55: MANIFEST_UNKNOWN: manifest unknown; map[]

Updating with:
` quay.io/redhat-appstudio-tekton-catalog/task-clair-scan@sha256:a0e3302b0cf4b79ff632940d5c5695b826c32da7a0efb1644241c77648d85d70`