### PR TITLE
re-enable run case in parallel

### DIFF
--- a/controllers/operator/clusterpodplacementconfig_controller_test.go
+++ b/controllers/operator/clusterpodplacementconfig_controller_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
 
-var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfigReconciler", Ordered, func() {
+var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfigReconciler", Serial, Ordered, func() {
 	When("The ClusterPodPlacementConfig", func() {
 		Context("is handling the lifecycle of the operand", func() {
 			BeforeEach(func() {

--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -23,7 +23,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 export ARTIFACT_DIR=${ARTIFACT_DIR:-$(mktemp -d)}
 GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
-GINKGO_ARGS=${GINKGO_ARGS:-"-vv --randomize-all --randomize-suites -race -trace --keep-going --timeout=40m "}
+GINKGO_ARGS=${GINKGO_ARGS:-"-vv --randomize-all --randomize-suites -p -race -trace --keep-going --timeout=40m "}
 TEST_LABEL=${TEST_LABEL:-"integration"}
 GINKGO_ARGS="${GINKGO_ARGS} --label-filter ${TEST_LABEL}"
 GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -23,7 +23,7 @@ const (
 	helloOpenshiftPublicMultiarchImage = "quay.io/openshifttest/hello-openshift:1.2.0"
 )
 
-var _ = Describe("The Multiarch Tuning Operator", func() {
+var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 	var (
 		podLabel                  = map[string]string{"app": "test"}
 		schedulingGateLabel       = map[string]string{utils.SchedulingGateLabel: utils.SchedulingGateLabelValueRemoved}

--- a/pkg/e2e/suites_lifecycle.go
+++ b/pkg/e2e/suites_lifecycle.go
@@ -29,14 +29,14 @@ func CommonInit() {
 func CommonBeforeSuite() (client runtimeclient.Client, clientset *kubernetes.Clientset,
 	ctx context.Context, suiteLog logr.Logger) {
 	var err error
+	suiteLog = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.Level(-5)))
+	logf.SetLogger(suiteLog)
+
 	client, err = framework.LoadClient()
 	Expect(err).ToNot(HaveOccurred())
 
 	clientset, err = framework.LoadClientset()
 	Expect(err).ToNot(HaveOccurred())
-
-	suiteLog = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.Level(-5)))
-	logf.SetLogger(suiteLog)
 
 	ctx = context.Background()
 

--- a/pkg/image/systemconfig.go
+++ b/pkg/image/systemconfig.go
@@ -16,38 +16,78 @@ limitations under the License.
 
 package image
 
-import "os"
+import (
+	"os"
+	"sync"
+)
 
 var (
 	dockerCertsDir,
 	registriesCertsDir,
 	registriesConfPath,
 	policyConfPath string
+	rwMutex sync.RWMutex
 )
 
 func DockerCertsDir() string {
+	rwMutex.RLock()
+	if dockerCertsDir != "" {
+		defer rwMutex.RUnlock()
+		return dockerCertsDir
+	}
+	rwMutex.RUnlock()
+	rwMutex.Lock()
+	defer rwMutex.Unlock()
 	if dockerCertsDir == "" {
+		// avoid race condition in-between rwMutex.RUnlock and rwMutex.Lock
 		dockerCertsDir = lookupEnvOr("DOCKER_CERTS_DIR", "/etc/docker/certs.d")
 	}
 	return dockerCertsDir
 }
 
 func RegistryCertsDir() string {
+	rwMutex.RLock()
+	if registriesCertsDir != "" {
+		defer rwMutex.RUnlock()
+		return registriesCertsDir
+	}
+	rwMutex.RUnlock()
+	rwMutex.Lock()
+	defer rwMutex.Unlock()
 	if registriesCertsDir == "" {
+		// avoid race condition in-between rwMutex.RUnlock and rwMutex.Lock
 		registriesCertsDir = lookupEnvOr("REGISTRIES_CERTS_DIR", "/etc/containers/registries.d")
 	}
 	return registriesCertsDir
 }
 
 func RegistriesConfPath() string {
+	rwMutex.RLock()
+	if registriesConfPath != "" {
+		defer rwMutex.RUnlock()
+		return registriesConfPath
+	}
+	rwMutex.RUnlock()
+	rwMutex.Lock()
+	defer rwMutex.Unlock()
 	if registriesConfPath == "" {
+		// avoid race condition in-between rwMutex.RUnlock and rwMutex.Lock
 		registriesConfPath = lookupEnvOr("REGISTRIES_CONF_PATH", "/etc/containers/registries.conf")
 	}
 	return registriesConfPath
 }
 
 func PolicyConfPath() string {
+	rwMutex.RLock()
+	if policyConfPath != "" {
+		defer rwMutex.RUnlock()
+		return policyConfPath
+	}
+	rwMutex.RUnlock()
+	rwMutex.Lock()
+	defer rwMutex.Unlock()
 	if policyConfPath == "" {
+		// avoid race condition in-between rwMutex.RUnlock and rwMutex.Lock
 		policyConfPath = lookupEnvOr("POLICY_CONF_PATH", "/etc/containers/policy.json")
 	}
 	return policyConfPath

--- a/pkg/testing/image/fake/registry/registry.go
+++ b/pkg/testing/image/fake/registry/registry.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"sync"
 	"time"
 
 	"github.com/distribution/distribution/v3/configuration"
@@ -34,7 +35,10 @@ type registryTLSConfig struct {
 	caCertBytes     []byte
 }
 
-var perRegistryCertDirPath string
+var (
+	perRegistryCertDirPath string
+	mu                     sync.Mutex
+)
 
 const (
 	// TODO: Port 5001 could be busy, we might set this to 0 to get an ephemeral port, but the Registry object
@@ -189,4 +193,14 @@ func buildRegistryTLSConfig() (*registryTLSConfig, error) {
 	}
 
 	return &tlsTestCfg, nil
+}
+
+func SetCertPath(path string) {
+	mu.Lock()
+	defer mu.Unlock()
+	perRegistryCertDirPath = path
+}
+
+func GetCertPath() string {
+	return perRegistryCertDirPath
 }


### PR DESCRIPTION
The PR implements the following items:
- Changing test cases to run in parallel
- Moving `AddToScheme` to `func init()` to avoid registering a data race
- Fixing other data races that occur when running cases concurrently