### PR TITLE
MULTIARCH-5320: Only create the monitoring stack objects when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ described in the [Openshift EP](https://github.com/openshift/enhancements/blob/6
 The aim of this operator will be to run on any Kubernetes cluster, although the main focus of development and testing
 will be carried out on Openshift clusters.
 
+## Enable metrics
+
+The operator can expose metrics for the prometheus operator. To enable the deployment of the metrics objects (`monitoring.coreos.com/(servicemonitors|prometheusrules)`), you can label the namespace where the operator runs with `k8s.io/cluster-monitoring: "true"`. 
+
+Use `openshift.io/cluster-monitoring: "true"` for Openshift clusters.
 
 ### Development
 

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2025-01-14T00:47:27Z"
+    createdAt: "2025-02-07T12:09:52Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -160,6 +160,7 @@ spec:
           - namespaces
           verbs:
           - get
+          - list
           - update
         - apiGroups:
           - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,7 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
   - update
 - apiGroups:
   - ""

--- a/pkg/e2e/operator/e2e_test.go
+++ b/pkg/e2e/operator/e2e_test.go
@@ -7,22 +7,28 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/framework"
 )
 
 var (
 	client    runtimeclient.Client
 	clientset *kubernetes.Clientset
+	dClient   *dynamic.DynamicClient
 	ctx       context.Context
 	suiteLog  = ctrl.Log.WithName("setup")
 )
 
 func init() {
 	e2e.CommonInit()
+	var err error
+	dClient, err = framework.LoadDynamicClient()
+	Expect(err).ToNot(HaveOccurred())
 }
 
 func TestE2E(t *testing.T) {

--- a/pkg/testing/framework/utils.go
+++ b/pkg/testing/framework/utils.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -113,6 +114,14 @@ func LoadClientset() (*kubernetes.Clientset, error) {
 	}
 
 	return kubernetes.NewForConfig(cfg)
+}
+
+func LoadDynamicClient() (*dynamic.DynamicClient, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	return dynamic.NewForConfig(cfg)
 }
 
 func RegisterScheme(s *runtime.Scheme) error {

--- a/pkg/utils/runtime.go
+++ b/pkg/utils/runtime.go
@@ -55,3 +55,18 @@ func IsResourceAvailable(ctx context.Context, client *dynamic.DynamicClient, res
 	availableResourcesMap[resource] = err == nil
 	return availableResourcesMap[resource]
 }
+
+func IsOpenshift(ctx context.Context, client *dynamic.DynamicClient) bool {
+	return IsResourceAvailable(ctx, client, schema.GroupVersionResource{
+		Group:    "config.openshift.io",
+		Version:  "v1",
+		Resource: "clusterversions",
+	})
+}
+
+func MonitoringLabelKey(ctx context.Context, client *dynamic.DynamicClient) string {
+	if !IsOpenshift(ctx, client) {
+		return "k8s.io/cluster-monitoring"
+	}
+	return "openshift.io/cluster-monitoring"
+}


### PR DESCRIPTION
This PR changes the behavior of the operator to create the monitoring objects only when needed (when the namespace is labeled to enable monitoring) so that we can avoid the prometheus operator prints warnings because finding a ServiceMonitor in a namespace that should not be monitored.