### PR TITLE
Deprecate sbom-json-check

### DIFF
--- a/.tekton/multiarch-tuning-operator-single-arch-build-pipeline.yaml
+++ b/.tekton/multiarch-tuning-operator-single-arch-build-pipeline.yaml
@@ -247,28 +247,6 @@ spec:
           value: "$(tasks.build-container.results.IMAGE_DIGEST)"
         - name: image-url
           value: "$(tasks.build-container.results.IMAGE_URL)"
-    - name: sbom-json-check
-      taskRef:
-        resolver: bundles
-        params:
-          - name: name
-            value: sbom-json-check
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.2@sha256:d043fc9bcdedeafb96ee3d2fa62e06bf2a15684a068968cce8134f7d8e8e3e37
-          - name: kind
-            value: task
-      when:
-        - input: "$(params.skip-checks)"
-          operator: in
-          values:
-            - 'false'
-      runAfter:
-        - build-container
-      params:
-        - name: IMAGE_URL
-          value: "$(tasks.build-container.results.IMAGE_URL)"
-        - name: IMAGE_DIGEST
-          value: "$(tasks.build-container.results.IMAGE_DIGEST)"
     - name: rpms-signature-scan
       params:
         - name: image-url


### PR DESCRIPTION
[WARNING]: !!!DEPRECATED!!! - sbom-json-check task is going to be removed in near future, please remove it from your pipeline. (Deprecation date: 2024-09-30)