### PR TITLE
[4.18] [sig-auth] all workloads in ns/openshift-multiarch-tuning-operator must set the 'openshift.io/required-scc' annotation

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2025-02-27T15:35:11Z"
+    createdAt: "2025-03-03T12:15:46Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -317,6 +317,7 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
                 multiarch.openshift.io/image: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
+                openshift.io/required-scc: restricted-v2
                 target.workload.openshift.io/management: |
                   {"effect": "PreferredDuringScheduling"}
               labels:
@@ -390,8 +391,6 @@ spec:
                   privileged: false
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
-                  seccompProfile:
-                    type: RuntimeDefault
                 volumeMounts:
                 - mountPath: /var/run/manager/tls
                   name: multiarch-tuning-operator-controller-manager-service-cert
@@ -399,8 +398,6 @@ spec:
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
               serviceAccountName: multiarch-tuning-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,8 @@ spec:
         # See https://github.com/openshift/enhancements/blob/c5b9aea25e2a7afd5f460c6a0eca7584b1685ce3/enhancements/workload-partitioning/management-workload-partitioning.md
         target.workload.openshift.io/management: |
           {"effect": "PreferredDuringScheduling"}
+        # See https://github.com/openshift/enhancements/blob/9b5d8a964fc91e8ace17e373923f1c61cdd1a96f/enhancements/authentication/custom-scc-preemption-prevention.md?plain=1#L100
+        openshift.io/required-scc: restricted-v2
       labels:
         control-plane: controller-manager
     spec:
@@ -60,8 +62,6 @@ spec:
                     - linux
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -98,8 +98,6 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
The test in the title is failing in 4.18, but not on the past releases (maybe it was considered flacky in the <4.18 suites). 

This PR fixes the manifests to comply with it for openshift. It is harmless and not considered in non-OCP distributions of k8s.

The test is related to https://github.com/openshift/enhancements/blob/9b5d8a964fc91e8ace17e373923f1c61cdd1a96f/enhancements/authentication/custom-scc-preemption-prevention.md?plain=1#L100