### PR TITLE
MULTIARCH-5363: add logic to check if the preferred node affinity has already been set as to not overwrite it

### DIFF
--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -174,11 +174,8 @@ func (pod *Pod) setRequiredArchNodeAffinity(requirement corev1.NodeSelectorRequi
 // SetPreferredArchNodeAffinity sets the node affinity for the pod to the preferences given in the ClusterPodPlacementConfig.
 // TODO[Tori]: Missing unit tests for this method.
 func (pod *Pod) SetPreferredArchNodeAffinity(cppc *v1beta1.ClusterPodPlacementConfig) {
-	// Prevent overriding of user-provided kubernetes.io/arch preferred affinities
+	// Prevent overriding of user-provided kubernetes.io/arch preferred affinities or overwriting previously set preferred affinity
 	if pod.isPreferredAffinityConfiguredForArchitecture() {
-		pod.ensureLabel(utils.PreferredNodeAffinityLabel, utils.LabelValueNotSet)
-		pod.publishEvent(corev1.EventTypeNormal, ArchitectureAwareNodeAffinitySet,
-			ArchitecturePreferredPredicateSkippedMsg)
 		return
 	}
 

--- a/controllers/podplacement/pod_reconciler.go
+++ b/controllers/podplacement/pod_reconciler.go
@@ -142,7 +142,7 @@ func (r *PodReconciler) processPod(ctx context.Context, pod *Pod) {
 	}
 	// If the pod has been processed successfully or the max retries have been reached, remove the scheduling gate.
 	if err == nil || pod.maxRetries() {
-		if status := pod.Labels[utils.PreferredNodeAffinityLabel]; status == utils.LabelValueNotSet {
+		if pod.Labels[utils.PreferredNodeAffinityLabel] == utils.LabelValueNotSet {
 			pod.publishEvent(corev1.EventTypeNormal, ArchitectureAwareNodeAffinitySet,
 				ArchitecturePreferredPredicateSkippedMsg)
 		}

--- a/controllers/podplacement/pod_reconciler.go
+++ b/controllers/podplacement/pod_reconciler.go
@@ -142,6 +142,11 @@ func (r *PodReconciler) processPod(ctx context.Context, pod *Pod) {
 	}
 	// If the pod has been processed successfully or the max retries have been reached, remove the scheduling gate.
 	if err == nil || pod.maxRetries() {
+		if status := pod.Labels[utils.PreferredNodeAffinityLabel]; status == utils.LabelValueNotSet {
+			pod.publishEvent(corev1.EventTypeNormal, ArchitectureAwareNodeAffinitySet,
+				ArchitecturePreferredPredicateSkippedMsg)
+		}
+
 		log.V(1).Info("Removing the scheduling gate from pod.")
 		pod.RemoveSchedulingGate()
 	}

--- a/controllers/podplacement/pod_reconciler_test.go
+++ b/controllers/podplacement/pod_reconciler_test.go
@@ -50,6 +50,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				Eventually(func(g Gomega) {
 					g.Expect(*pod).To(HaveEquivalentNodeAffinity(
@@ -99,6 +103,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.ImageInspectionErrorCountLabel, strconv.Itoa(MaxRetryCount)), "image inspection error count not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.LabelValueNotSet),
+						"node affinity label not found")
 				}).WithTimeout(e2e.WaitShort).WithPolling(time.Millisecond*250).Should(Succeed(), "failed to remove scheduling gate from pod")
 				// Polling set to 250ms such that the error count is shown in the logs at each update.
 			})
@@ -147,6 +155,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				By("Checking that the pod has the correct node affinity")
 				Expect(*pod).To(HaveEquivalentNodeAffinity(
@@ -195,6 +207,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				By("Checking that the pod has the wrong, cached, node affinity [this proves we are not querying the remote registry]")
 				Expect(*pod).To(HaveEquivalentNodeAffinity(
@@ -246,6 +262,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				By("Checking that the pod has the correct node affinity")
 				Expect(*pod).To(HaveEquivalentNodeAffinity(
@@ -294,6 +314,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				By("Checking that the pod has the wrong, cached, node affinity [this proves we are not querying the remote registry]")
 				Expect(*pod).To(HaveEquivalentNodeAffinity(
@@ -355,6 +379,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				Eventually(func(g Gomega) {
 					if len(supportedArchitectures) == 0 {
@@ -404,6 +432,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 
 				Eventually(func(g Gomega) {
@@ -465,6 +497,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				Eventually(func(g Gomega) {
 					g.Expect(pod.Spec.Affinity).NotTo(BeNil(), "pod.Spec.Affinity should not be nil")
@@ -536,6 +572,10 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 					}), "scheduling gate not removed")
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
 						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.LabelValueNotSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"node affinity label not found")
 				}).Should(Succeed(), "failed to remove scheduling gate from pod")
 				Eventually(func(g Gomega) {
 					g.Expect(pod.Spec.Affinity).NotTo(BeNil(), "pod.Spec.Affinity should not be nil")
@@ -563,6 +603,38 @@ var _ = Describe("Controllers/Podplacement/PodReconciler", func() {
 						}),
 						"unexpected preferred node affinity")
 				}).Should(Succeed(), "failed to set preferred node affinity in pod")
+			})
+			It("sets the preferred node affinity and label when there is an error setting the required affinity", func() {
+				pod := NewPod().
+					WithContainersImages("quay.io/non-existing/image:latest").
+					WithGenerateName("test-pod-").
+					WithNamespace("test-namespace").
+					Build()
+				err := k8sClient.Create(ctx, pod)
+				Expect(err).NotTo(HaveOccurred(), "failed to create pod", err)
+				// Test the removal of the scheduling gate. However, since the pod is mutated and the reconciler
+				// removes the scheduling gate concurrently, we cannot ensure that the scheduling gate is added
+				// and that the following Eventually works on a pod with the scheduling gate.
+				// Waiting for the pod to be mutated is not enough, as the pod could be mutated and the reconciler
+				// could have removed the scheduling gate before our check.
+				Eventually(func(g Gomega) {
+					// Get pod from the API server
+					err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(pod), pod)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get pod", err)
+					By(fmt.Sprintf("Error count is set to '%s'", pod.Labels[utils.ImageInspectionErrorCountLabel]))
+					g.Expect(pod.Spec.SchedulingGates).NotTo(ContainElement(corev1.PodSchedulingGate{
+						Name: utils.SchedulingGateName,
+					}), "scheduling gate not removed")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved),
+						"scheduling gate annotation not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.ImageInspectionErrorCountLabel, strconv.Itoa(MaxRetryCount)), "image inspection error count not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet),
+						"preferred node affinity label not found")
+					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.LabelValueNotSet),
+						"node affinity label not found")
+				}).WithTimeout(e2e.WaitShort).Should(Succeed(), "failed to remove scheduling gate from pod")
+				// Polling set to 250ms such that the error count is shown in the logs at each update.
+
 			})
 		})
 	})


### PR DESCRIPTION
If there is an error setting the required node affinity the preferred node affinity will be set independently. However, when retrying to set the node affinity it will overwrite the preferred node affinity liable 

Adding in more e2e testing to validate results are as desired. This means incorporating MULTIARCH-5354. 