### PR TITLE
ensure VerifyPodLabelsAreSet executes returned function

### DIFF
--- a/pkg/testing/framework/pod.go
+++ b/pkg/testing/framework/pod.go
@@ -283,6 +283,6 @@ func VerifyPodLabelsAreSet(ctx context.Context, client runtimeclient.Client, ns 
 		for i := 0; i < len(labelsKeyValuePair); i += 2 {
 			entries[labelsKeyValuePair[i]] = labelsKeyValuePair[i+1]
 		}
-		VerifyPodLabels(ctx, client, ns, labelKey, labelInValue, true, entries)
+		VerifyPodLabels(ctx, client, ns, labelKey, labelInValue, true, entries)(g)
 	}
 }


### PR DESCRIPTION
VerifyPodLabelsAreSet called VerifyPodLabels but did not execute the returned func(g gomega.Gomega), causing Gomega assertions inside VerifyPodLabels to be skipped. This fix ensures the returned function is executed properly.