### PR TITLE
MULTIARCH-5354: Do TODOs and update label checking 

### DIFF
--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -172,7 +172,6 @@ func (pod *Pod) setRequiredArchNodeAffinity(requirement corev1.NodeSelectorRequi
 }
 
 // SetPreferredArchNodeAffinity sets the node affinity for the pod to the preferences given in the ClusterPodPlacementConfig.
-// TODO[Tori]: Missing unit tests for this method.
 func (pod *Pod) SetPreferredArchNodeAffinity(cppc *v1beta1.ClusterPodPlacementConfig) {
 	// Prevent overriding of user-provided kubernetes.io/arch preferred affinities or overwriting previously set preferred affinity
 	if pod.isPreferredAffinityConfiguredForArchitecture() {
@@ -381,8 +380,8 @@ func (pod *Pod) hasControlPlaneNodeSelector() bool {
 // - the pod has a node name set
 // - the pod has a node selector that matches the control plane nodes
 // - the pod is owned by a DaemonSet
-// - both the nodeSelector/nodeAffinity and the preferredAffinity are set for the kubernetes.io/arch label. TODO[Tori]: Missing unit test
-// - only the nodeSelector/nodeAffinity is set for the kubernetes.io/arch label and the NodeAffinityScoring plugin is disabled. TODO[Tori]: Missing unit test
+// - both the nodeSelector/nodeAffinity and the preferredAffinity are set for the kubernetes.io/arch label.
+// - only the nodeSelector/nodeAffinity is set for the kubernetes.io/arch label and the NodeAffinityScoring plugin is disabled.
 func (pod *Pod) shouldIgnorePod(cppc *v1beta1.ClusterPodPlacementConfig) bool {
 	return utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "kube-") ||
 		pod.Spec.NodeName != "" || pod.hasControlPlaneNodeSelector() || pod.isFromDaemonSet() ||
@@ -481,8 +480,8 @@ func (pod *Pod) handleError(err error, s string) {
 	log.Error(err, s)
 }
 
-// TODO[Tori] Missing godoc
-// TODO[Tori] Missing unit tests
+// isPreferredAffinityConfiguredForArchitecture returns true if the pod has a MatchExpression in the PreferredDuringSchedulingIgnoredDuringExecution
+// that matches kubernetes.io/arch
 func (pod *Pod) isPreferredAffinityConfiguredForArchitecture() bool {
 	if pod.Spec.Affinity == nil ||
 		pod.Spec.Affinity.NodeAffinity == nil ||

--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -2,12 +2,12 @@ package podplacement
 
 import (
 	"context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"sort"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 

--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -2,6 +2,7 @@ package podplacement
 
 import (
 	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"sort"
 	"testing"
@@ -12,6 +13,8 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common/plugins"
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
 	"github.com/openshift/multiarch-tuning-operator/controllers/podplacement/metrics"
 	mmoimage "github.com/openshift/multiarch-tuning-operator/pkg/image"
@@ -519,6 +522,99 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 			pred, err := pod.getArchitecturePredicate(nil)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			pod.setRequiredArchNodeAffinity(pred)
+			g.Expect(pod.Spec.Affinity).Should(Equal(tt.want.Spec.Affinity))
+			imageInspectionCache = mmoimage.FacadeSingleton()
+		})
+	}
+}
+
+func TestPod_SetPreferredArchNodeAffinityWithCPPC(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want *v1.Pod
+	}{
+		{
+			name: "pod with no predefined preferred affinity",
+			pod:  NewPod().WithContainersImages(fake.SingleArchAmd64Image).Build(),
+			want: NewPod().WithContainersImages(fake.SingleArchAmd64Image).WithPreferredDuringSchedulingIgnoredDuringExecution(
+				NewPreferredSchedulingTerm().WithArchitecture(utils.ArchitectureAmd64).WithWeight(1).Build(),
+			).Build(),
+		},
+		{
+			name: "pod with predefined preferred node affinity",
+			pod: NewPod().WithContainersImages(fake.SingleArchAmd64Image).WithPreferredDuringSchedulingIgnoredDuringExecution(
+				NewPreferredSchedulingTerm().WithCustomKeyValue("foo", "bar").WithWeight(50).Build(),
+			).Build(),
+			want: NewPod().WithContainersImages(fake.SingleArchAmd64Image).WithPreferredDuringSchedulingIgnoredDuringExecution(
+				NewPreferredSchedulingTerm().WithCustomKeyValue("foo", "bar").WithWeight(50).Build(),
+				NewPreferredSchedulingTerm().WithArchitecture(utils.ArchitectureAmd64).WithWeight(1).Build(),
+			).Build(),
+		},
+		{
+			name: "pod with predefined preferred node affinity with arch label set",
+			pod: NewPod().WithContainersImages(fake.SingleArchAmd64Image).WithPreferredDuringSchedulingIgnoredDuringExecution(
+				NewPreferredSchedulingTerm().WithArchitecture(utils.ArchitectureAmd64).WithWeight(30).Build(),
+			).Build(),
+			want: NewPod().WithContainersImages(fake.SingleArchAmd64Image).WithPreferredDuringSchedulingIgnoredDuringExecution(
+				NewPreferredSchedulingTerm().WithArchitecture(utils.ArchitectureAmd64).WithWeight(30).Build(),
+			).Build(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageInspectionCache = fake.FacadeSingleton()
+			pod := &Pod{
+				Pod: *tt.pod,
+				ctx: ctx,
+			}
+			g := NewGomegaWithT(t)
+			pod.SetPreferredArchNodeAffinity(
+				NewClusterPodPlacementConfig().
+					WithName(common.SingletonResourceObjectName).
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 1).Build())
+			g.Expect(pod.Spec.Affinity).Should(Equal(tt.want.Spec.Affinity))
+			imageInspectionCache = mmoimage.FacadeSingleton()
+		})
+	}
+}
+
+func TestPod_SetPreferredArchNodeAffinity(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want *v1.Pod
+	}{
+		{
+			name: "pod with empty preferred node affinity",
+			pod:  NewPod().WithContainersImages(fake.MultiArchImage).WithPreferredDuringSchedulingIgnoredDuringExecution().Build(),
+			want: NewPod().WithContainersImages(fake.MultiArchImage).WithPreferredDuringSchedulingIgnoredDuringExecution().Build(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageInspectionCache = fake.FacadeSingleton()
+			pod := &Pod{
+				Pod: *tt.pod,
+				ctx: ctx,
+			}
+			g := NewGomegaWithT(t)
+			pod.SetPreferredArchNodeAffinity(&v1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: v1beta1.ClusterPodPlacementConfigSpec{
+					Plugins: &plugins.Plugins{
+						NodeAffinityScoring: &plugins.NodeAffinityScoring{
+							BasePlugin: plugins.BasePlugin{
+								Enabled: true, // Enable the plugin
+							},
+							Platforms: []plugins.NodeAffinityScoringPlatformTerm{},
+						},
+					},
+				},
+			})
 			g.Expect(pod.Spec.Affinity).Should(Equal(tt.want.Spec.Affinity))
 			imageInspectionCache = mmoimage.FacadeSingleton()
 		})
@@ -1040,6 +1136,21 @@ func TestPod_shouldIgnorePod(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "pod with nodeSelector/nodeAffinity and the preferredAffinity is not set for the kubernetes.io/arch label",
+			fields: fields{
+				Pod: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectorTermsMatchExpressions(
+					[]v1.NodeSelectorRequirement{
+						{
+							Key:      utils.ArchLabel,
+							Operator: v1.NodeSelectorOpExists,
+							Values:   []string{utils.ArchitectureAmd64},
+						},
+					},
+				).Build(),
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1050,6 +1161,198 @@ func TestPod_shouldIgnorePod(t *testing.T) {
 			}
 			if got := pod.shouldIgnorePod(&v1beta1.ClusterPodPlacementConfig{}); got != tt.want {
 				t.Errorf("shouldIgnorePod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPod_shouldIgnorePodWithPluginsEnabledInCPPC(t *testing.T) {
+	type fields struct {
+		Pod      *v1.Pod
+		ctx      context.Context
+		recorder record.EventRecorder
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "pod with nodeSelector/nodeAffinity and the preferredAffinity is set for the kubernetes.io/arch label",
+			fields: fields{
+				Pod: NewPod().WithContainersImages(fake.SingleArchAmd64Image).WithPreferredDuringSchedulingIgnoredDuringExecution(
+					NewPreferredSchedulingTerm().WithArchitecture(utils.ArchitectureAmd64).WithWeight(1).Build()).
+					WithNodeSelectorTermsMatchExpressions(
+						[]v1.NodeSelectorRequirement{
+							{
+								Key:      utils.ArchLabel,
+								Operator: v1.NodeSelectorOpExists,
+								Values:   []string{utils.ArchitectureAmd64},
+							},
+						},
+					).Build(),
+			},
+			want: true,
+		},
+		{
+			name: "pod with set nodeAffinity, the preferredAffinity is not set for the kubernetes.io/arch label",
+			fields: fields{
+				Pod: NewPod().WithContainersImages(fake.SingleArchAmd64Image).
+					WithNodeSelectorTermsMatchExpressions(
+						[]v1.NodeSelectorRequirement{
+							{
+								Key:      utils.ArchLabel,
+								Operator: v1.NodeSelectorOpExists,
+								Values:   []string{utils.ArchitectureAmd64},
+							},
+						},
+					).Build(),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &Pod{
+				Pod:      *tt.fields.Pod,
+				ctx:      tt.fields.ctx,
+				recorder: tt.fields.recorder,
+			}
+			if got := pod.shouldIgnorePod(NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				WithNodeAffinityScoring(true).
+				WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 1).Build(),
+			); got != tt.want {
+				t.Errorf("shouldIgnorePod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPod_shouldIgnorePodWithPluginsDisabledInCPPC(t *testing.T) {
+	type fields struct {
+		Pod      *v1.Pod
+		ctx      context.Context
+		recorder record.EventRecorder
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "pod with nodeSelector/nodeAffinity is set for the kubernetes.io/arch label and the NodeAffinityScoring plugin is disabled ",
+			fields: fields{
+				Pod: NewPod().WithContainersImages(fake.MultiArchImage).WithNodeSelectorTermsMatchExpressions(
+					[]v1.NodeSelectorRequirement{
+						{
+							Key:      utils.ArchLabel,
+							Operator: v1.NodeSelectorOpExists,
+							Values:   []string{utils.ArchitectureAmd64},
+						},
+					},
+				).Build(),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &Pod{
+				Pod:      *tt.fields.Pod,
+				ctx:      tt.fields.ctx,
+				recorder: tt.fields.recorder,
+			}
+			if got := pod.shouldIgnorePod(NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				WithNodeAffinityScoring(false).
+				WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 1).Build()); got != tt.want {
+				t.Errorf("shouldIgnorePod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPreferredAffinityConfiguredForArchitecture(t *testing.T) {
+	tests := []struct {
+		name     string
+		affinity *v1.Affinity
+		expected bool
+	}{
+		{
+			name:     "Affinity is nil",
+			affinity: nil,
+			expected: false,
+		},
+		{
+			name:     "NodeAffinity is nil",
+			affinity: &v1.Affinity{NodeAffinity: nil},
+			expected: false,
+		},
+		{
+			name:     "NodeAffinity is nil",
+			affinity: &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: nil}},
+			expected: false,
+		},
+		{
+			name: "PreferredSchedulingTerm contains matchExpression with key=kubernetes.io/arch",
+			affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+						{
+							Weight: int32(1),
+							Preference: v1.NodeSelectorTerm{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      utils.ArchLabel,
+										Operator: v1.NodeSelectorOpIn,
+										Values:   []string{utils.ArchitectureArm64},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "PreferredSchedulingTerm does not contain a matchExpression with key=kubernetes.io/arch",
+			affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+						{
+							Weight: int32(1),
+							Preference: v1.NodeSelectorTerm{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "foo",
+										Operator: v1.NodeSelectorOpIn,
+										Values:   []string{"bar"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := &Pod{
+				Pod: v1.Pod{
+					Spec: v1.PodSpec{
+						Affinity: test.affinity,
+					},
+				},
+			}
+
+			result := pod.isPreferredAffinityConfiguredForArchitecture()
+			if result != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, result)
 			}
 		})
 	}

--- a/pkg/testing/builder/preferred_scheduling_term.go
+++ b/pkg/testing/builder/preferred_scheduling_term.go
@@ -34,6 +34,17 @@ func (p *PreferredSchedulingTermBuilder) WithArchitecture(architecture string) *
 	return p
 }
 
+func (p *PreferredSchedulingTermBuilder) WithCustomKeyValue(key string, value string) *PreferredSchedulingTermBuilder {
+	p.preferredSchedulingTerm.Preference.MatchExpressions = []v1.NodeSelectorRequirement{
+		{
+			Key:      key,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   []string{value},
+		},
+	}
+	return p
+}
+
 func (p *PreferredSchedulingTermBuilder) WithWeight(weight int32) *PreferredSchedulingTermBuilder {
 	p.preferredSchedulingTerm.Weight = weight
 	return p


### PR DESCRIPTION
- Resolve todo comments
-  Add more in depth label testing in e2e tests 
-  Add e2e tests for testing preferred scheduling terms
- Added unit tests for functions in pod_model.go that were added or modified when enabling CPPC NodeAffinityScoring