### PR TITLE
Konflux: deprecated coverity-availability-check-oci-ta

### DIFF
--- a/.tekton/multiarch-tuning-operator-build-pipeline.yaml
+++ b/.tekton/multiarch-tuning-operator-build-pipeline.yaml
@@ -353,7 +353,7 @@ spec:
           operator: in
           values:
             - "false"
-    - name: sast-coverity-check
+    - name: sast-coverity-check-oci-ta
       params:
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -408,9 +408,9 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: coverity-availability-check-oci-ta
+            value: coverity-availability-check
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:e4d3de79e1b7224dabaca34363fe74c8a090d974be509ce0cd5de4456d017db5
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:aeb4ecc32ed4012686ab370b3417902082b894a9b1e27aa4f6e35a301c50f4cb
           - name: kind
             value: task
       when:

--- a/.tekton/multiarch-tuning-operator-single-arch-build-pipeline.yaml
+++ b/.tekton/multiarch-tuning-operator-single-arch-build-pipeline.yaml
@@ -249,7 +249,7 @@ spec:
           operator: in
           values:
             - "false"
-    - name: sast-coverity-check
+    - name: sast-coverity-check-oci-ta
       params:
         - name: image-url
           value: $(tasks.build-container.results.IMAGE_URL)
@@ -304,9 +304,9 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: coverity-availability-check-oci-ta
+            value: coverity-availability-check
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:e4d3de79e1b7224dabaca34363fe74c8a090d974be509ce0cd5de4456d017db5
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:aeb4ecc32ed4012686ab370b3417902082b894a9b1e27aa4f6e35a301c50f4cb
           - name: kind
             value: task
       when:


### PR DESCRIPTION
✕ [Violation] tasks.unsupported
  ImageRef: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator@sha256:84756a69bf729ec261b5ca5330a371ffe74d6225182e3d812317cf49c4e393ad
  Reason: Task "coverity-availability-check-oci-ta" is used by pipeline task "coverity-availability-check" is or will be
  unsupported as of 2025-03-31T00:00:00Z. Starting with version 0.2, the coverity-availability-check-oci-ta task is deprecated.
  Please use coverity-availability-check instead.
  Title: Task version unsupported
  Description: The Tekton Task used is or will be unsupported. The Task is annotated with `build.appstudio.redhat.com/expires-on`
  annotation marking it as unsupported after a certain date. To exclude this rule add
  "tasks.unsupported:coverity-availability-check-oci-ta" to the `exclude` section of the policy configuration.
  
  https://github.com/konflux-ci/build-definitions/tree/main/task/coverity-availability-check-oci-ta/0.2
  