### PR TITLE
WIP: test: adding execution for test/

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - test/**


### PR DESCRIPTION
In konflux coverity-results fail with the following. These are false positives as these test/ is only for testing and docs 

```
oras pull quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator/multiarch-tuning-operator-bundle@sha256:c75a22f5a62b3815587ffa124571ff3df12c2157b9959c6359847bb26ec67c59

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/01-example-no-affinity.yaml:11: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/01-example-no-affinity.yaml:11: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#    9|       fail: "yes"
#   10|   spec:
#   11|->   securityContext:
#   12|       runAsNonRoot: true
#   13|       seccompProfile:

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/02-example-affinity-no-node-affinity.yaml:10: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/02-example-affinity-no-node-affinity.yaml:10: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#    8|       result: "This pod get the affinity update from the controller. This affinity is just set to be an empty map at the beginning."
#    9|   spec:
#   10|->   securityContext:
#   11|       runAsNonRoot: true
#   12|       seccompProfile:

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/03-example-affinity-node-affinity-non-conflicting.yaml:8: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/03-example-affinity-node-affinity-non-conflicting.yaml:8: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#    6|       app: httpd
#    7|   spec:
#    8|->   securityContext:
#    9|       runAsNonRoot: true
#   10|       seccompProfile:

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/04-example-affinity-node-affinity-conflicting.yaml:8: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/04-example-affinity-node-affinity-conflicting.yaml:8: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#    6|       app: httpd
#    7|   spec:
#    8|->   securityContext:
#    9|       runAsNonRoot: true
#   10|       seccompProfile:

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/05-example-multiple-containers.yaml:8: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/05-example-multiple-containers.yaml:8: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#    6|       app: httpd
#    7|   spec:
#    8|->   securityContext:
#    9|       runAsNonRoot: true
#   10|       seccompProfile:

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/06-example-registry-auth.yaml:10: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/06-example-registry-auth.yaml:10: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#    8|       result: "This pod get the affinity update from the controller. This tests the registry authentication logic"
#    9|   spec:
#   10|->   securityContext:
#   11|       runAsNonRoot: true
#   12|       seccompProfile:

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/07-example-affinity-node-affinity.yaml:18: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/07-example-affinity-node-affinity.yaml:18: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#   16|       result: "This pod should not get the affinity update from the controller. The label in the namespace is set to exclude it from affinity setting."
#   17|   spec:
#   18|->   securityContext:
#   19|       runAsNonRoot: true
#   20|       seccompProfile:

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/08-example-node-selector.yaml:10: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/08-example-node-selector.yaml:10: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#    8|       result: "This pod should set Affinity to nil."
#    9|   spec:
#   10|->   nodeSelector:
#   11|       kubernetes.io/arch: amd64
#   12|     securityContext:

Error: SIGMA.automounting_service_account_token (CWE-284):
/code/test/manifests/09-example-multiple-affinity.yaml:10: Sigma main event: The service account token is automatically mounted for a `Kubernetes.Pod` or `Kubernetes.ServiceAccount`. Auto-mounting the service account token means this shared bearer token will be written to the container file system at `/var/run/secrets/kubernetes.io/serviceaccount`. If an attacker were to compromise the container, this token can easily be used to elevate privileges, interact with the Kubernetes API, and pivot to other resources.
/code/test/manifests/09-example-multiple-affinity.yaml:10: remediation: Disable the automount feature by explicitly setting the `automountServiceAccountToken` attribute to `false`. If this field is missing, it should be added to the resource specification. There may be scenarios where the service account token must be automounted due to backwards compatibility with certain tooling. In these cases, one must evaluate the risk of using automounted tokens and implement mitigating controls if necessary.
#    8|       result: "This pod should get an affinity set in the non-conflicting matchExpressions, while keep the original set in the conflicting one."
#    9|   spec:
#   10|->   securityContext:
#   11|       runAsNonRoot: true
#   12|       seccompProfile:


```