### PR TITLE
Update tekton pipeline refs and add :devel tag for the update scripts…

### DIFF
--- a/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
       - name: name
         value: docker-build-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:7f6a3254dc9ea0b9600b3c5e5d65982a9444eb1c31672121f8f0df462a20184a
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta:devel@sha256:a804ecdbff5d96ef9b59a9dc27cce344d0191112eafe437173de4eafc1e48e78
       - name: kind
         value: pipeline
   workspaces:

--- a/.tekton/multiarch-tuning-operator-bundle-push.yaml
+++ b/.tekton/multiarch-tuning-operator-bundle-push.yaml
@@ -43,7 +43,7 @@ spec:
       - name: name
         value: docker-build-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:7f6a3254dc9ea0b9600b3c5e5d65982a9444eb1c31672121f8f0df462a20184a
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta:devel@sha256:a804ecdbff5d96ef9b59a9dc27cce344d0191112eafe437173de4eafc1e48e78
       - name: kind
         value: pipeline
   workspaces:

--- a/.tekton/multiarch-tuning-operator-pull-request.yaml
+++ b/.tekton/multiarch-tuning-operator-pull-request.yaml
@@ -49,7 +49,7 @@ spec:
       - name: name
         value: docker-build-multi-platform-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:d13d7410f04a7d7ec946d1536f89d88f9f70924e2b4c41e8926f7deb8384c322
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel@sha256:803aaf4d8a269591a580d3920e455186a50af2e6b454b9f5ee342501292c330a
       - name: kind
         value: pipeline
   workspaces:

--- a/.tekton/multiarch-tuning-operator-push.yaml
+++ b/.tekton/multiarch-tuning-operator-push.yaml
@@ -45,7 +45,7 @@ spec:
       - name: name
         value: docker-build-multi-platform-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:d13d7410f04a7d7ec946d1536f89d88f9f70924e2b4c41e8926f7deb8384c322
+        value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel@sha256:803aaf4d8a269591a580d3920e455186a50af2e6b454b9f5ee342501292c330a
       - name: kind
         value: pipeline
   workspaces:


### PR DESCRIPTION
… to parse images when looking for updates

#572 changed the pipelines to make use of a single bundle resolver to resolve them instead of a per-task approach and hard-coding the pipeline in our repo. However, we missed adding the tag before the digest pinning the version, leading the update script to fail running and proposing updates to the pipeline.