### PR TITLE
MULTIARCH-5536: support glob-based registries in the pull secrets 

### DIFF
--- a/pkg/image/auth_test.go
+++ b/pkg/image/auth_test.go
@@ -1,0 +1,337 @@
+package image
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_matchAndExpandGlob(t *testing.T) {
+	type args struct {
+		registry       string
+		imageReference string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		expectedOk  bool
+		expectedURL string
+	}{
+		{
+			name: "*.kubernetes.io will not match kubernetes.io",
+			args: args{
+				registry:       "*.kubernetes.io",
+				imageReference: "kubernetes.io/foo:bar",
+			},
+			expectedOk: false,
+		},
+		{
+			name: "*.kubernetes.io will match abc.kubernetes.io",
+			args: args{
+				registry:       "*.kubernetes.io",
+				imageReference: "abc.kubernetes.io/foo:bar",
+			},
+			expectedOk:  true,
+			expectedURL: "abc.kubernetes.io",
+		},
+		{
+			name: "*.*.kubernetes.io will not match abc.kubernetes.io",
+			args: args{
+				registry:       "*.*.kubernetes.io",
+				imageReference: "abc.kubernetes.io/foo:bar",
+			},
+			expectedOk: false,
+		},
+		{
+			name: "*.*.kubernetes.io will match abc.def.kubernetes.io",
+			args: args{
+				registry:       "*.*.kubernetes.io",
+				imageReference: "abc.def.kubernetes.io/baz/foo:bar",
+			},
+			expectedOk:  true,
+			expectedURL: "abc.def.kubernetes.io",
+		},
+		{
+			name: "prefix.*.io will match prefix.kubernetes.io",
+			args: args{
+				registry:       "prefix.*.io",
+				imageReference: "prefix.kubernetes.io/foo:bar",
+			},
+			expectedOk:  true,
+			expectedURL: "prefix.kubernetes.io",
+		},
+		{
+			name: "*-good.kubernetes.io will match prefix-good.kubernetes.io",
+			args: args{
+				registry:       "*-good.kubernetes.io",
+				imageReference: "prefix-good.kubernetes.io/baz/foo:bar",
+			},
+			expectedOk:  true,
+			expectedURL: "prefix-good.kubernetes.io",
+		},
+		{
+			name: "no glob. Registry should not be processed for expansion",
+			args: args{
+				registry:       "kubernetes.io",
+				imageReference: "kubernetes.io/foo:bar",
+			},
+			expectedOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotOk := matchAndExpandGlob(tt.args.registry, tt.args.imageReference)
+			if gotOk != tt.expectedOk {
+				t.Errorf("globMatch() = %v, expectedOk %v", gotOk, tt.expectedOk)
+			}
+			if gotOk && gotURL != tt.expectedURL {
+				t.Errorf("globMatch() = %v, expectedURL %v", gotURL, tt.expectedURL)
+			}
+		})
+	}
+}
+
+func Test_authCfg_expandGlobs(t *testing.T) {
+	type fields struct {
+		Auths map[string]authData
+	}
+	type args struct {
+		imageReference string
+	}
+	const cred = "dXNlcm5hbWU6cGFzc3dvcmQ="
+	tests := []struct {
+		name                string
+		fields              fields
+		args                args
+		additionalAuthsWant *authCfg
+	}{
+		{
+			name: "no globs",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "docker.io/foo:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{},
+			},
+		},
+		{
+			name: "with globs and no match",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+					"*.kubernetes.io": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "docker.io/foo:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{},
+			},
+		},
+		{
+			name: "with globs, match but existing auth for the same registry. Should ignore adding the resolved glob",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+					"*.kubernetes.io/my-repo": {
+						Auth: cred,
+					},
+					"abc.kubernetes.io/my-repo": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "abc.kubernetes.io/my-repo/my-image:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{},
+			},
+		},
+		{
+			name: "with globs, match and no existing auth for the same registry/repo",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+					"*.kubernetes.io": {
+						Auth: cred,
+					},
+					"abc.kubernetes.io/my-repo": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "abc.kubernetes.io/my-repo/my-image:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{
+					"abc.kubernetes.io": {
+						Auth: cred,
+					},
+				},
+			},
+		},
+		{
+			name: "with globs, match and no existing auth for the same registry",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+					"*.kubernetes.io": {
+						Auth: cred,
+					},
+					"abc.kubernetes.io/other-repo": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "abc.kubernetes.io/my-repo/my-image:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{
+					"abc.kubernetes.io": {
+						Auth: cred,
+					},
+				},
+			},
+		},
+		{
+			name: "with globs, match and no existing auth for the same registry/repo",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+					"*.kubernetes.io/my-repo": {
+						Auth: cred,
+					},
+					"abc.kubernetes.io/other-repo": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "abc.kubernetes.io/my-repo/my-image:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{
+					"abc.kubernetes.io/my-repo": {
+						Auth: cred,
+					},
+				},
+			},
+		},
+		{
+			name: "with globs, match and glob including port number",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+					"*.kubernetes.io:443": {
+						Auth: cred,
+					},
+					"abc.kubernetes.io:443/other-repo": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "abc.kubernetes.io:443/my-repo/my-image:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{
+					"abc.kubernetes.io:443": {
+						Auth: cred,
+					},
+				},
+			},
+		},
+		{
+			name: "with two globs, match and glob including port number",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+					"*.kubernetes.io:443": {
+						Auth: cred,
+					},
+					"abc.kubernetes.io:443/other-repo": {
+						Auth: cred,
+					},
+					"*.*.kubernetes.io:443": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "abc.def.kubernetes.io:443/my-repo/my-image:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{
+					"abc.def.kubernetes.io:443": {
+						Auth: cred,
+					},
+				},
+			},
+		},
+		{
+			name: "with one glob for 3rd level domain, should not match 4th level domain",
+			fields: fields{
+				Auths: map[string]authData{
+					"docker.io": {
+						Auth: cred,
+					},
+					"*.kubernetes.io:443": {
+						Auth: cred,
+					},
+					"abc.kubernetes.io:443/other-repo": {
+						Auth: cred,
+					},
+				},
+			},
+			args: args{
+				imageReference: "abc.def.kubernetes.io:443/my-repo/my-image:bar",
+			},
+			additionalAuthsWant: &authCfg{
+				Auths: map[string]authData{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac := authCfg{
+				Auths: tt.fields.Auths,
+			}
+			// merge initial auths with the expanded globs
+			want := ac.Auths
+			for k, v := range tt.additionalAuthsWant.Auths {
+				want[k] = v
+			}
+			if got := ac.expandGlobs(tt.args.imageReference); !reflect.DeepEqual(got, &authCfg{
+				Auths: want,
+			}) {
+				t.Errorf("expandGlobs() = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/pkg/image/cache.go
+++ b/pkg/image/cache.go
@@ -41,7 +41,7 @@ func (c *cacheProxy) GetCompatibleArchitecturesSet(ctx context.Context, imageRef
 	metrics.InitCommonMetrics()
 	metrics.InspectionGauge.Set(float64(c.imageRefsCache.Len()))
 	now := time.Now()
-	authJSON, err := marshaledImagePullSecrets(secrets)
+	authJSON, err := marshaledImagePullSecrets(imageReference, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/helpers_glob.go
+++ b/pkg/image/helpers_glob.go
@@ -1,0 +1,90 @@
+package image
+
+import (
+	"net"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// The following code come from the kubernetes official repo, but build constraints prevent
+// us from importing it directly.
+// TODO: use the markers below to automatically maintain the code up to date?
+// ## IMPORTED CODE BEGIN [github.com/openshift/kubernetes/blob/a9593d634c6a053848413e600dadbf974627515f/pkg/credentialprovider/keyring.go#L160-L233]
+
+// ParseSchemelessURL parses a schemeless url and returns a url.URL
+// url.Parse require a scheme, but ours don't have schemes.  Adding a
+// scheme to make url.Parse happy, then clear out the resulting scheme.
+func ParseSchemelessURL(schemelessURL string) (*url.URL, error) {
+	parsed, err := url.Parse("https://" + schemelessURL)
+	if err != nil {
+		return nil, err
+	}
+	// clear out the resulting scheme
+	parsed.Scheme = ""
+	return parsed, nil
+}
+
+// SplitURL splits the host name into parts, as well as the port
+func SplitURL(url *url.URL) (parts []string, port string) {
+	host, port, err := net.SplitHostPort(url.Host)
+	if err != nil {
+		// could not parse port
+		host, port = url.Host, ""
+	}
+	return strings.Split(host, "."), port
+}
+
+// URLsMatchStr is wrapper for URLsMatch, operating on strings instead of URLs.
+func URLsMatchStr(glob string, target string) (bool, error) {
+	globURL, err := ParseSchemelessURL(glob)
+	if err != nil {
+		return false, err
+	}
+	targetURL, err := ParseSchemelessURL(target)
+	if err != nil {
+		return false, err
+	}
+	return URLsMatch(globURL, targetURL)
+}
+
+// URLsMatch checks whether the given target url matches the glob url, which may have
+// glob wild cards in the host name.
+//
+// Examples:
+//
+//	globURL=*.docker.io, targetURL=blah.docker.io => match
+//	globURL=*.docker.io, targetURL=not.right.io   => no match
+//
+// Note that we don't support wildcards in ports and paths yet.
+func URLsMatch(globURL *url.URL, targetURL *url.URL) (bool, error) {
+	globURLParts, globPort := SplitURL(globURL)
+	targetURLParts, targetPort := SplitURL(targetURL)
+	if globPort != targetPort {
+		// port doesn't match
+		return false, nil
+	}
+	if len(globURLParts) != len(targetURLParts) {
+		// host name does not have the same number of parts
+		return false, nil
+	}
+	if !strings.HasPrefix(targetURL.Path, globURL.Path) {
+		// the path of the credential must be a prefix
+		return false, nil
+	}
+	for k, globURLPart := range globURLParts {
+		targetURLPart := targetURLParts[k]
+		matched, err := filepath.Match(globURLPart, targetURLPart)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			// glob mismatch for some part
+			return false, nil
+		}
+	}
+	// everything matches
+	return true, nil
+}
+
+// ## IMPORTED CODE END [github.com/openshift/kubernetes/blob/a9593d634c6a053848413e600dadbf974627515f/pkg/credentialprovider/keyring.go#L160-L233]


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/containers/images/#config-json specifies Kubernetes supports glob-style matching for the host part of the registry credentials when Kubelet pulls images. The OCI, instead, does not support globs in the auth.json, hence the containers/image lib wouldn't suffice to support such cases. This PR adds the support for it.