### PR TITLE
Automated changes to index.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: help build-index update-graph
+
+# Default target
+help:  ## Show this help
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS=":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+build-index: ## Run build-indexs.sh with SNAPSHOT=<snapshot-or-url>
+	@if [ -z "$(SNAPSHOT)" ]; then \
+		echo "Error: SNAPSHOT variable not set. Use: make build-index SNAPSHOT=<snapshot-or-url>"; \
+		exit 1; \
+	fi
+	./hack/build-indexs.sh $(SNAPSHOT)
+
+update-graph: ## Run update-graph.sh with VERSION=<version>
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION variable not set. Use: make update-graph VERSION=<version>"; \
+		exit 1; \
+	fi
+	./hack/update-graph.sh $(VERSION)

--- a/hack/build-indexs.sh
+++ b/hack/build-indexs.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+INPUT="$1"
+BUNDLE_IMAGE=""
+
+# Function to extract bundle image from snapshot
+get_bundle_image_from_snapshot() {
+    local snapshot_name="$1"
+    echo "Getting bundle image from snapshot: $snapshot_name" >&2
+    oc describe snapshot "$snapshot_name" | \
+        awk '/Container Image:/ && /bundle/ {print $NF; exit}'
+}
+
+
+# Detect if input is a snapshot or a direct image URL
+if [[ "$INPUT" == quay.io/* || "$INPUT" == *"@"* ]]; then
+    echo "Using provided bundle image URL directly."
+    BUNDLE_IMAGE="$INPUT"
+else
+    echo "Input appears to be a snapshot. Extracting bundle image..."
+    BUNDLE_IMAGE=$(get_bundle_image_from_snapshot "$INPUT")
+    if [[ -z "$BUNDLE_IMAGE" ]]; then
+        echo "Error: Could not find bundle image in snapshot $INPUT"
+        exit 1
+    fi
+    echo "Found bundle image: $BUNDLE_IMAGE"
+fi
+
+
+# Yellow color escape code
+YELLOW='\033[1;33m'
+# Reset color escape code
+NC='\033[0m'
+
+echo -e "${YELLOW}Warning: verify opm version is updated${NC}"
+
+# Loop over directories that match the pattern fbc-v*-*
+for dir in fbc-v*-*; do
+    if [[ -d "$dir" ]]; then
+        echo "Processing directory: $dir"
+
+        # Extract version from directory name (e.g., 4-16 from fbc-v4-16)
+        version=$(echo "$dir" | sed -E 's/^fbc-v([0-9]+-[0-9]+).*/\1/')
+
+        pushd "$dir/catalog/multiarch-tuning-operator" > /dev/null
+
+        if [[ ! -f index.yaml ]]; then
+            echo "Warning: index.yaml not found in $dir/catalog/multiarch-tuning-operator"
+            popd > /dev/null
+            continue
+        fi
+
+        if [[ "$version" < "4-17" ]]; then
+            echo "" >> index.yaml
+            opm render --output=yaml "$BUNDLE_IMAGE" >> index.yaml
+        else
+          echo "Using migrate-level option for version $version"
+          echo "" >> index.yaml
+          opm render --output=yaml --migrate-level bundle-object-to-csv-metadata "$BUNDLE_IMAGE" >> index.yaml
+        fi
+        # Fix top-level image field
+        sed -i -E 's|(image: )quay.io/redhat-user-workloads[^@]*multiarch-tuning-operator-bundle[^@]*@sha256:([a-f0-9]{64})|\1registry.redhat.io/multiarch-tuning/multiarch-tuning-operator-bundle@sha256:\2|' index.yaml
+
+        # Fix relatedImages entries
+        sed -i -E 's|(- image: )quay.io/redhat-user-workloads[^@]*multiarch-tuning-operator-bundle[^@]*@sha256:([a-f0-9]{64})|\1registry.redhat.io/multiarch-tuning/multiarch-tuning-operator-bundle@sha256:\2|' index.yaml
+
+
+        echo "Appended bundle data to $dir/catalog/multiarch-tuning-operator/index.yaml"
+        popd > /dev/null
+    fi
+done
+
+echo "Done."

--- a/hack/update-graph.sh
+++ b/hack/update-graph.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+INPUT_VERSION="$1"
+
+# Ensure version starts with "v"
+if [[ "$INPUT_VERSION" != v* ]]; then
+  VERSION="v$INPUT_VERSION"
+else
+  VERSION="$INPUT_VERSION"
+fi
+
+ENTRY_NAME="multiarch-tuning-operator.$VERSION"
+
+for dir in fbc-*; do
+  YAML_PATH="$dir/catalog/multiarch-tuning-operator/index.yaml"
+
+  if [[ ! -f "$YAML_PATH" ]]; then
+    echo "Skipping $dir (no index.yaml found)"
+    continue
+  fi
+
+  echo "Processing $YAML_PATH"
+
+  # Extract first existing entry
+  PREVIOUS_ENTRY=$(awk '
+    $1 == "entries:" { in_entries=1; next }
+    in_entries && $1 == "-name:" { print $2; exit }
+    in_entries && $1 == "-" && $2 == "name:" { print $3; exit }
+  ' "$YAML_PATH")
+
+  if [[ -z "$PREVIOUS_ENTRY" ]]; then
+    echo "Error: No previous entry found in $YAML_PATH"
+    continue
+  fi
+
+  # Prepare new entry block
+  NEW_ENTRY="  - name: $ENTRY_NAME\n    replaces: $PREVIOUS_ENTRY"
+
+  # Insert the new entry after 'entries:' without adding newline at end
+  awk -v new_entry="$NEW_ENTRY" '
+    BEGIN { added=0 }
+    {
+      if (!added && $1 == "entries:") {
+        print $0
+        print new_entry
+        added=1
+      } else {
+        print $0
+      }
+    }
+    END { if (added == 0) exit 1 }
+  ' "$YAML_PATH" | awk 'NR == 1 { printf "%s", $0; next } { printf "\n%s", $0 }' > "$YAML_PATH.tmp" && mv "$YAML_PATH.tmp" "$YAML_PATH"
+
+  echo "Updated $YAML_PATH with new entry: $ENTRY_NAME replaces $PREVIOUS_ENTRY"
+done
+
+echo "Done."


### PR DESCRIPTION
Instead of manually updating the index.yaml we can run scripts 

```
 ./hack/build-indexs.sh <snapshot or url> 
 ./hack/build-indexs.sh multiarch-tuning-operator-v1-x-xfsm2
 ./hack/build-indexs.sh quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator-v1-x/multiarch-tuning-operator-bundle-v1-x@sha256:fb66e7951e96423ddc809aa25e35215932761291bfaafe57ac8ce8927689e7d9
```
```
./hack/update-graph.sh <version>
./hack/update-graph.sh v1.1.1
./hack/update-graph.sh 1.1.1
```

can also use make 

```
make update-graph VERSION=v1.1.1
make build-index SNAPSHOT=multiarch-tuning-operator-v1-x-xfsm2
```