### PR TITLE
update multiarch-tuning-operator to 600037b9f

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -1,5 +1,5 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as builder
-ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:67d6faf34cbdca0af9bbdcc80d2d0c2969b7207ba31a4c9fbbee404974c9edd7
+ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:b443550bc54c401a6282568e6d23042b8eda66cb50b18b3d4d2e133600037b9f
 ARG ORIGINAL_IMG=registry.ci.openshift.org/origin/multiarch-tuning-operator:v1.x
 WORKDIR /code
 COPY ./ ./


### PR DESCRIPTION
Image created from https://github.com/openshift/multiarch-tuning-operator/commit/b4806b5a39611061d76b596a9353f35362c82554

Updating image from 67d6faf34cbdca0af9bbdcc80d2d0c2969b7207ba31a4c9fbbee404974c9edd7 -> b443550bc54c401a6282568e6d23042b8eda66cb50b18b3d4d2e133600037b9f

Konflux: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/multiarch-tuning-ope-tenant/applications/multiarch-tuning-operator-v1-x/snapshots/multiarch-tuning-operator-v1-x-76wwk