### PR TITLE
update multiarch-tuning-operator to b8ffdcdc91

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -1,5 +1,5 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as builder
-ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:b443550bc54c401a6282568e6d23042b8eda66cb50b18b3d4d2e133600037b9f
+ARG IMG=registry.redhat.io/multiarch-tuning/multiarch-tuning-rhel9-operator@sha256:d532619b2090be5cc69a70225ca3dcbbc701af35a533be277783beb8ffdcdc91
 ARG ORIGINAL_IMG=registry.ci.openshift.org/origin/multiarch-tuning-operator:v1.x
 WORKDIR /code
 COPY ./ ./


### PR DESCRIPTION
Image created from https://github.com/openshift/multiarch-tuning-operator/commit/29cd16e046c925afd66ba29844f89c64f3b3f9be


Updating image from   b443550bc54c401a6282568e6d23042b8eda66cb50b18b3d4d2e133600037b9f -> d532619b2090be5cc69a70225ca3dcbbc701af35a533be277783beb8ffdcdc91

konflux: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/multiarch-tuning-ope-tenant/applications/multiarch-tuning-operator-v1-x/snapshots/multiarch-tuning-operator-v1-x-4wwqz