### PR TITLE
MULTIARCH-5372: Add finalizers to ClusterPodPlacementConfig early to ensure proper cleanup

### DIFF
--- a/controllers/operator/clusterpodplacementconfig_controller_test.go
+++ b/controllers/operator/clusterpodplacementconfig_controller_test.go
@@ -398,6 +398,18 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 				Eventually(framework.ValidateDeletion(k8sClient, ctx)).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
 			})
 		})
+		Context("the ClusterPodPlacementConfig is deleted within 1s after creation", func() {
+			It("Should cleanup all finalizers", func() {
+				By("Creating the ClusterPodPlacementConfig")
+				err := k8sClient.Create(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
+				Expect(err).NotTo(HaveOccurred(), "failed to create ClusterPodPlacementConfig", err)
+				By("imeditately deleting it after creation")
+				err = k8sClient.Delete(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
+				Expect(err).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
+				By("Verify all corresponding resources are deleted")
+				Eventually(framework.ValidateDeletion(k8sClient, ctx)).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
+			})
+		})
 	})
 	Context("the operand is deployed", func() {
 		BeforeAll(func() {

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -421,4 +421,23 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			Eventually(framework.VerifyPodPreferredNodeAffinity(ctx, client, ns, "app", "test", nil), e2e.WaitShort).Should(Succeed())
 		})
 	})
+	Context("the ClusterPodPlacementConfig is deleted within 1s after creation", func() {
+		It("Should cleanup all finalizers", func() {
+			err := client.Create(ctx, &v1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			By("imeditately deleting the clusterpodplacementconfig after creation")
+			err = client.Delete(ctx, &v1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			By("Verify all corresponding resources are deleted")
+			Eventually(framework.ValidateDeletion(client, ctx)).Should(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
The PR moves the block that adds finalizers to ClusterPodPlacementConfig before creating the corresponding CRs to ensure proper cleanup