### PR TITLE
Partially move Pod model in pkg/models

### DIFF
--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
 	"github.com/openshift/multiarch-tuning-operator/controllers/podplacement/metrics"
 	"github.com/openshift/multiarch-tuning-operator/pkg/image"
+	"github.com/openshift/multiarch-tuning-operator/pkg/models"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
 
@@ -47,12 +48,36 @@ type containerImage struct {
 }
 
 type Pod struct {
-	corev1.Pod
-	ctx      context.Context
-	recorder record.EventRecorder
+	models.Pod
 }
 
-func (pod *Pod) GetPodImagePullSecrets() []string {
+func newPod(pod *corev1.Pod, ctx context.Context, recorder record.EventRecorder) *Pod {
+	return &Pod{
+		Pod: *models.NewPod(pod, ctx, recorder),
+	}
+}
+
+// HasSchedulingGate checks if the pod has the scheduling gate utils.SchedulingGateName.
+func (pod *Pod) HasSchedulingGate() bool {
+	return pod.HasGate(utils.SchedulingGateName)
+}
+
+// RemoveSchedulingGate removes the scheduling gate utils.SchedulingGateName from the pod.
+func (pod *Pod) RemoveSchedulingGate() {
+	pod.RemoveGate(utils.SchedulingGateName)
+	// The scheduling gate is removed. We also add a label to the pod to indicate that the scheduling gate was removed
+	// and this pod was processed by the operator. That's useful for testing and debugging, but also gives the user
+	// an indication that the pod was processed by the operator.
+	pod.EnsureLabel(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved)
+}
+
+// ensureSchedulingGate ensures that the pod has the scheduling gate utils.SchedulingGateName.
+func (pod *Pod) ensureSchedulingGate() {
+	pod.AddGate(utils.SchedulingGateName)
+}
+
+// getPodImagePullSecrets returns the names of the image pull secrets used by the pod.
+func (pod *Pod) getPodImagePullSecrets() []string {
 	if pod.Spec.ImagePullSecrets == nil {
 		// If the imagePullSecrets array is nil, return emptylist
 		return []string{}
@@ -62,38 +87,6 @@ func (pod *Pod) GetPodImagePullSecrets() []string {
 		secretRefs[i] = secret.Name
 	}
 	return secretRefs
-}
-
-func (pod *Pod) HasSchedulingGate() bool {
-	if pod.Spec.SchedulingGates == nil {
-		// If the schedulingGates array is nil, we return false
-		return false
-	}
-	for _, condition := range pod.Spec.SchedulingGates {
-		if condition.Name == utils.SchedulingGateName {
-			return true
-		}
-	}
-	// the scheduling gate is not found.
-	return false
-}
-
-func (pod *Pod) RemoveSchedulingGate() {
-	if len(pod.Spec.SchedulingGates) == 0 {
-		// If the schedulingGates array is nil, we return
-		return
-	}
-	filtered := make([]corev1.PodSchedulingGate, 0, len(pod.Spec.SchedulingGates))
-	for _, schedulingGate := range pod.Spec.SchedulingGates {
-		if schedulingGate.Name != utils.SchedulingGateName {
-			filtered = append(filtered, schedulingGate)
-		}
-	}
-	pod.Spec.SchedulingGates = filtered
-	// The scheduling gate is removed. We also add a label to the pod to indicate that the scheduling gate was removed
-	// and this pod was processed by the operator. That's useful for testing and debugging, but also gives the user
-	// an indication that the pod was processed by the operator.
-	pod.ensureLabel(utils.SchedulingGateLabel, utils.SchedulingGateLabelValueRemoved)
 }
 
 // SetNodeAffinityArchRequirement wraps the logic to set the nodeAffinity for the pod.
@@ -109,9 +102,9 @@ func (pod *Pod) SetNodeAffinityArchRequirement(pullSecretDataList [][]byte) (boo
 	if err != nil {
 		return false, err
 	}
-	pod.ensureNoLabel(utils.ImageInspectionErrorLabel)
+	pod.EnsureNoLabel(utils.ImageInspectionErrorLabel)
 	if len(requirement.Values) == 0 {
-		pod.publishEvent(corev1.EventTypeNormal, NoSupportedArchitecturesFound, NoSupportedArchitecturesFoundMsg)
+		pod.PublishEvent(corev1.EventTypeNormal, NoSupportedArchitecturesFound, NoSupportedArchitecturesFoundMsg)
 	}
 	pod.ensureArchitectureLabels(requirement)
 
@@ -166,8 +159,8 @@ func (pod *Pod) setRequiredArchNodeAffinity(requirement corev1.NodeSelectorRequi
 	}
 	// if the nodeSelectorTerms were patched at least once, we set the nodeAffinity label to the set value, to keep
 	// track of the fact that the nodeAffinity was patched by the operator.
-	pod.ensureLabel(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet)
-	pod.publishEvent(corev1.EventTypeNormal, ArchitectureAwareNodeAffinitySet,
+	pod.EnsureLabel(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet)
+	pod.PublishEvent(corev1.EventTypeNormal, ArchitectureAwareNodeAffinitySet,
 		ArchitecturePredicateSetupMsg+fmt.Sprintf("{%s}", strings.Join(requirement.Values, ", ")))
 }
 
@@ -209,8 +202,8 @@ func (pod *Pod) SetPreferredArchNodeAffinity(cppc *v1beta1.ClusterPodPlacementCo
 
 	// if the nodeSelectorTerms were patched at least once, we set the nodeAffinity label to the set value, to keep
 	// track of the fact that the nodeAffinity was patched by the operator.
-	pod.ensureLabel(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet)
-	pod.publishEvent(corev1.EventTypeNormal, ArchitectureAwareNodeAffinitySet, ArchitecturePreferredPredicateSetupMsg)
+	pod.EnsureLabel(utils.PreferredNodeAffinityLabel, utils.NodeAffinityLabelValueSet)
+	pod.PublishEvent(corev1.EventTypeNormal, ArchitectureAwareNodeAffinitySet, ArchitecturePreferredPredicateSetupMsg)
 }
 
 func (pod *Pod) getArchitecturePredicate(pullSecretDataList [][]byte) (corev1.NodeSelectorRequirement, error) {
@@ -247,7 +240,7 @@ func (pod *Pod) imagesNamesSet() sets.Set[containerImage] {
 // inspect returns the list of supported architectures for the images used by the pod.
 // if an error occurs, it returns the error and a nil slice of strings.
 func (pod *Pod) intersectImagesArchitecture(pullSecretDataList [][]byte) (supportedArchitectures []string, err error) {
-	log := ctrllog.FromContext(pod.ctx)
+	log := ctrllog.FromContext(pod.Ctx())
 	imageNamesSet := pod.imagesNamesSet()
 	log.V(1).Info("Images list for pod", "imageNamesSet", fmt.Sprintf("%+v", imageNamesSet))
 	// https://github.com/containers/skopeo/blob/v1.11.1/cmd/skopeo/inspect.go#L72
@@ -261,7 +254,7 @@ func (pod *Pod) intersectImagesArchitecture(pullSecretDataList [][]byte) (suppor
 		// We are collecting the time to inspect the image here to avoid implementing a metric in each of the
 		// cache implementations.
 		now := time.Now()
-		currentImageSupportedArchitectures, err := imageInspectionCache.GetCompatibleArchitecturesSet(pod.ctx,
+		currentImageSupportedArchitectures, err := imageInspectionCache.GetCompatibleArchitecturesSet(pod.Ctx(),
 			imageContainer.imageName, imageContainer.skipCache, pullSecretDataList)
 		utils.HistogramObserve(now, metrics.TimeToInspectImage)
 		if err != nil {
@@ -275,53 +268,6 @@ func (pod *Pod) intersectImagesArchitecture(pullSecretDataList [][]byte) (suppor
 		}
 	}
 	return sets.List(supportedArchitecturesSet), nil
-}
-
-func (pod *Pod) publishEvent(eventType, reason, message string) {
-	if pod.recorder != nil {
-		pod.recorder.Event(&pod.Pod, eventType, reason, message)
-	}
-}
-
-// ensureLabel ensures that the pod has the given label with the given value.
-func (pod *Pod) ensureLabel(label string, value string) {
-	if pod.Labels == nil {
-		pod.Labels = make(map[string]string)
-	}
-	pod.Labels[label] = value
-}
-
-func (pod *Pod) ensureNoLabel(label string) {
-	if pod.Labels == nil {
-		return
-	}
-	delete(pod.Labels, label)
-}
-
-// ensureLabel ensures that the pod has the given label with the given value.
-func (pod *Pod) ensureAnnotation(annotation string, value string) {
-	if pod.Annotations == nil {
-		pod.Annotations = make(map[string]string)
-	}
-	pod.Annotations[annotation] = value
-}
-
-// ensureAndIncrementLabel ensures that the pod has the given label with the given value.
-// If the label is already set, it increments the value.
-func (pod *Pod) ensureAndIncrementLabel(label string) {
-	if pod.Labels == nil {
-		pod.Labels = make(map[string]string)
-	}
-	if _, ok := pod.Labels[label]; !ok {
-		pod.Labels[label] = "1"
-		return
-	}
-	cur, err := strconv.ParseInt(pod.Labels[label], 10, 32)
-	if err != nil {
-		pod.Labels[label] = "1"
-	} else {
-		pod.Labels[label] = fmt.Sprintf("%d", cur+1)
-	}
 }
 
 func (pod *Pod) maxRetries() bool {
@@ -348,29 +294,15 @@ func (pod *Pod) ensureArchitectureLabels(requirement corev1.NodeSelectorRequirem
 		// if the requirement has no values, we set the NoSupportedArchLabel as a label for the node. That's a dummy
 		// and non-available-by-default label that we use to prevent the pod from being scheduled when it cannot run all
 		// the containers in at least one architecture.
-		pod.ensureLabel(utils.NoSupportedArchLabel, "")
+		pod.EnsureLabel(utils.NoSupportedArchLabel, "")
 	case 1:
-		pod.ensureLabel(utils.SingleArchLabel, "")
+		pod.EnsureLabel(utils.SingleArchLabel, "")
 	default:
-		pod.ensureLabel(utils.MultiArchLabel, "")
+		pod.EnsureLabel(utils.MultiArchLabel, "")
 	}
 	for _, value := range requirement.Values {
-		pod.ensureLabel(utils.ArchLabelValue(value), "")
+		pod.EnsureLabel(utils.ArchLabelValue(value), "")
 	}
-}
-
-// hasControlPlaneNodeSelector returns true if the pod has a node selector that matches the control plane nodes.
-func (pod *Pod) hasControlPlaneNodeSelector() bool {
-	if pod.Spec.NodeSelector == nil {
-		return false
-	}
-	requiredSelectors := []string{utils.MasterNodeSelectorLabel, utils.ControlPlaneNodeSelectorLabel}
-	for _, value := range requiredSelectors {
-		if _, ok := pod.Spec.NodeSelector[value]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 // shouldIgnorePod returns true if the pod should be ignored by the operator.
@@ -384,24 +316,9 @@ func (pod *Pod) hasControlPlaneNodeSelector() bool {
 // - only the nodeSelector/nodeAffinity is set for the kubernetes.io/arch label and the NodeAffinityScoring plugin is disabled.
 func (pod *Pod) shouldIgnorePod(cppc *v1beta1.ClusterPodPlacementConfig) bool {
 	return utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "kube-") ||
-		pod.Spec.NodeName != "" || pod.hasControlPlaneNodeSelector() || pod.isFromDaemonSet() ||
+		pod.Spec.NodeName != "" || pod.HasControlPlaneNodeSelector() || pod.IsFromDaemonSet() ||
 		pod.isNodeSelectorConfiguredForArchitecture() && (cppc.Spec.Plugins == nil ||
 			!cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() || pod.isPreferredAffinityConfiguredForArchitecture())
-}
-
-// ensureSchedulingGate ensures that the pod has the scheduling gate utils.SchedulingGateName.
-func (pod *Pod) ensureSchedulingGate() {
-	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3521-pod-scheduling-readiness
-	if pod.Spec.SchedulingGates == nil {
-		pod.Spec.SchedulingGates = []corev1.PodSchedulingGate{}
-	}
-	// if the gate is already present, do not try to patch (it would fail)
-	for _, schedulingGate := range pod.Spec.SchedulingGates {
-		if schedulingGate.Name == utils.SchedulingGateName {
-			return
-		}
-	}
-	pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: utils.SchedulingGateName})
 }
 
 // isNodeSelectorConfiguredForArchitecture returns true if the pod has already a nodeSelector for the architecture label
@@ -449,34 +366,23 @@ func (pod *Pod) isNodeSelectorConfiguredForArchitecture() bool {
 	return true
 }
 
-// isPodFromDaemonSet returns true if the pod is from a daemonSet.
-func (pod *Pod) isFromDaemonSet() bool {
-	// Check all ownerRef
-	for _, ownerRef := range pod.OwnerReferences {
-		if ownerRef.Kind == "DaemonSet" && ownerRef.Controller != nil && *ownerRef.Controller {
-			return true
-		}
-	}
-	return false
-}
-
 func (pod *Pod) publishIgnorePod() {
-	log := ctrllog.FromContext(pod.ctx)
+	log := ctrllog.FromContext(pod.Ctx())
 	log.V(1).Info("The pod has the nodeSelector or all the nodeAffinityTerms set for the kubernetes.io/arch label. Ignoring the pod...")
-	pod.ensureLabel(utils.NodeAffinityLabel, utils.LabelValueNotSet)
-	pod.publishEvent(corev1.EventTypeNormal, ArchitecturePredicatesConflict, ArchitecturePredicatesConflictMsg)
+	pod.EnsureLabel(utils.NodeAffinityLabel, utils.LabelValueNotSet)
+	pod.PublishEvent(corev1.EventTypeNormal, ArchitecturePredicatesConflict, ArchitecturePredicatesConflictMsg)
 }
 
 func (pod *Pod) handleError(err error, s string) {
 	if err == nil {
 		return
 	}
-	log := ctrllog.FromContext(pod.ctx)
+	log := ctrllog.FromContext(pod.Ctx())
 	metrics.FailedInspectionCounter.Inc()
-	pod.ensureLabel(utils.ImageInspectionErrorLabel, "")
-	pod.ensureAnnotation(utils.ImageInspectionErrorLabel, err.Error())
-	pod.ensureAndIncrementLabel(utils.ImageInspectionErrorCountLabel)
-	pod.publishEvent(corev1.EventTypeWarning, ImageArchitectureInspectionError, ImageArchitectureInspectionErrorMsg+err.Error())
+	pod.EnsureLabel(utils.ImageInspectionErrorLabel, "")
+	pod.EnsureAnnotation(utils.ImageInspectionErrorLabel, err.Error())
+	pod.EnsureAndIncrementLabel(utils.ImageInspectionErrorCountLabel)
+	pod.PublishEvent(corev1.EventTypeWarning, ImageArchitectureInspectionError, ImageArchitectureInspectionErrorMsg+err.Error())
 	log.Error(err, s)
 }
 

--- a/controllers/podplacement/pod_model_test.go
+++ b/controllers/podplacement/pod_model_test.go
@@ -54,12 +54,9 @@ func TestPod_GetPodImagePullSecrets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			g := NewGomegaWithT(t)
-			g.Expect(pod.GetPodImagePullSecrets()).To(Equal(tt.want))
+			g.Expect(pod.getPodImagePullSecrets()).To(Equal(tt.want))
 		})
 	}
 }
@@ -99,10 +96,7 @@ func TestPod_HasSchedulingGate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			g := NewGomegaWithT(t)
 			g.Expect(pod.HasSchedulingGate()).To(Equal(tt.want))
 		})
@@ -156,10 +150,7 @@ func TestPod_RemoveSchedulingGate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			pod.RemoveSchedulingGate()
 			g := NewGomegaWithT(t)
 			g.Expect(pod.Spec.SchedulingGates).To(Equal(tt.want))
@@ -224,10 +215,7 @@ func TestPod_imagesNamesSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			g := NewGomegaWithT(t)
 			g.Expect(pod.imagesNamesSet()).To(Equal(tt.want))
 		})
@@ -280,10 +268,7 @@ func TestPod_intersectImagesArchitecture(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			imageInspectionCache = fake.FacadeSingleton()
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			gotSupportedArchitectures, err := pod.intersectImagesArchitecture(tt.pullSecretDataList)
 			g := NewGomegaWithT(t)
 			g.Expect(err).Should(WithTransform(func(err error) bool { return err != nil }, Equal(tt.wantErr)),
@@ -360,10 +345,7 @@ func TestPod_getArchitecturePredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			imageInspectionCache = fake.FacadeSingleton()
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			got, err := pod.getArchitecturePredicate(tt.pullSecretDataList)
 			g := NewGomegaWithT(t)
 			g.Expect(err).Should(WithTransform(func(err error) bool { return err != nil }, Equal(tt.wantErr)),
@@ -514,10 +496,7 @@ func TestPod_setArchNodeAffinity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			imageInspectionCache = fake.FacadeSingleton()
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			g := NewGomegaWithT(t)
 			pred, err := pod.getArchitecturePredicate(nil)
 			g.Expect(err).ShouldNot(HaveOccurred())
@@ -564,10 +543,7 @@ func TestPod_SetPreferredArchNodeAffinityWithCPPC(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			imageInspectionCache = fake.FacadeSingleton()
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			g := NewGomegaWithT(t)
 			pod.SetPreferredArchNodeAffinity(
 				NewClusterPodPlacementConfig().
@@ -595,10 +571,7 @@ func TestPod_SetPreferredArchNodeAffinity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			imageInspectionCache = fake.FacadeSingleton()
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			g := NewGomegaWithT(t)
 			pod.SetPreferredArchNodeAffinity(&v1beta1.ClusterPodPlacementConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -804,10 +777,7 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			imageInspectionCache = fake.FacadeSingleton()
-			pod := &Pod{
-				Pod: *tt.pod,
-				ctx: ctx,
-			}
+			pod := newPod(tt.pod, ctx, nil)
 			_, err := pod.SetNodeAffinityArchRequirement(tt.pullSecretDataList)
 			g := NewGomegaWithT(t)
 			if tt.expectErr {
@@ -817,59 +787,6 @@ func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 			}
 			g.Expect(pod.Spec.Affinity).Should(Equal(tt.want.Spec.Affinity))
 			imageInspectionCache = mmoimage.FacadeSingleton()
-		})
-	}
-}
-
-// TestEnsureLabel checks the ensureLabel method to verify that it correctly sets labels.
-func TestEnsureLabel(t *testing.T) {
-	tests := []struct {
-		name           string
-		initialLabels  []string
-		label          string
-		value          string
-		expectedLabels map[string]string
-	}{
-		{
-			name:           "Empty Labels",
-			initialLabels:  nil,
-			label:          "testLabel",
-			value:          "testValue",
-			expectedLabels: map[string]string{"testLabel": "testValue"},
-		},
-		{
-			name:           "Non-empty Labels",
-			initialLabels:  []string{"existingLabel", "existingValue"},
-			label:          "testLabel",
-			value:          "testValue",
-			expectedLabels: map[string]string{"existingLabel": "existingValue", "testLabel": "testValue"},
-		},
-		{
-			name:           "Overwrite Existing Label",
-			initialLabels:  []string{"testLabel", "oldValue"},
-			label:          "testLabel",
-			value:          "newValue",
-			expectedLabels: map[string]string{"testLabel": "newValue"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: *NewPod().WithLabels(tt.initialLabels...).Build(),
-			}
-
-			pod.ensureLabel(tt.label, tt.value)
-
-			if len(pod.Labels) != len(tt.expectedLabels) {
-				t.Errorf("expected %d labels, got %d", len(tt.expectedLabels), len(pod.Labels))
-			}
-
-			for k, v := range tt.expectedLabels {
-				if pod.Labels[k] != v {
-					t.Errorf("expected label %s to have value %s, got %s", k, v, pod.Labels[k])
-				}
-			}
 		})
 	}
 }
@@ -922,9 +839,7 @@ func TestEnsureArchitectureLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: *NewPod().Build(),
-			}
+			pod := newPod(NewPod().Build(), ctx, nil)
 
 			pod.ensureArchitectureLabels(tt.requirement)
 
@@ -984,78 +899,16 @@ func TestPod_EnsureSchedulingGate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: v1.Pod{
-					Spec: v1.PodSpec{
-						SchedulingGates: test.schedulingGates,
-					},
-				},
+			var schedulingGates []string
+			for _, gate := range test.schedulingGates {
+				schedulingGates = append(schedulingGates, gate.Name)
 			}
+
+			pod := newPod(NewPod().WithSchedulingGates(schedulingGates...).Build(), ctx, nil)
 
 			pod.ensureSchedulingGate()
 			if !reflect.DeepEqual(pod.Spec.SchedulingGates, test.expectedGates) {
 				t.Errorf("expected %v, got %v", test.expectedGates, pod.Spec.SchedulingGates)
-			}
-		})
-	}
-}
-
-func TestPod_hasControlPlaneNodeSelector(t *testing.T) {
-	type fields struct {
-		Pod      *v1.Pod
-		ctx      context.Context
-		recorder record.EventRecorder
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   bool
-	}{
-		{
-			name: "pod with no node selector terms",
-			fields: fields{
-				Pod: NewPod().Build(),
-			},
-			want: false,
-		},
-		{
-			name: "pod with empty node selector terms",
-			fields: fields{
-				Pod: NewPod().WithNodeSelectors().Build(),
-			},
-			want: false,
-		},
-		{
-			name: "pod with node selector terms and no control plane node selector",
-			fields: fields{
-				Pod: NewPod().WithNodeSelectors("foo", "bar").Build(),
-			},
-			want: false,
-		},
-		{
-			name: "pod with node selector terms and control plane node selector",
-			fields: fields{
-				Pod: NewPod().WithNodeSelectors("foo", "bar", utils.ControlPlaneNodeSelectorLabel, "").Build(),
-			},
-			want: true,
-		},
-		{
-			name: "pod with node selector terms and control plane node selector and other node selector",
-			fields: fields{
-				Pod: NewPod().WithNodeSelectors("foo", "bar", utils.MasterNodeSelectorLabel, "", "baz", "foo").Build(),
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod:      *tt.fields.Pod,
-				ctx:      tt.fields.ctx,
-				recorder: tt.fields.recorder,
-			}
-			if got := pod.hasControlPlaneNodeSelector(); got != tt.want {
-				t.Errorf("hasControlPlaneNodeSelector() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -1154,11 +1007,7 @@ func TestPod_shouldIgnorePod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod:      *tt.fields.Pod,
-				ctx:      tt.fields.ctx,
-				recorder: tt.fields.recorder,
-			}
+			pod := newPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
 			if got := pod.shouldIgnorePod(&v1beta1.ClusterPodPlacementConfig{}); got != tt.want {
 				t.Errorf("shouldIgnorePod() = %v, want %v", got, tt.want)
 			}
@@ -1213,11 +1062,7 @@ func TestPod_shouldIgnorePodWithPluginsEnabledInCPPC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod:      *tt.fields.Pod,
-				ctx:      tt.fields.ctx,
-				recorder: tt.fields.recorder,
-			}
+			pod := newPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
 			if got := pod.shouldIgnorePod(NewClusterPodPlacementConfig().
 				WithName(common.SingletonResourceObjectName).
 				WithNodeAffinityScoring(true).
@@ -1258,11 +1103,7 @@ func TestPod_shouldIgnorePodWithPluginsDisabledInCPPC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod:      *tt.fields.Pod,
-				ctx:      tt.fields.ctx,
-				recorder: tt.fields.recorder,
-			}
+			pod := newPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
 			if got := pod.shouldIgnorePod(NewClusterPodPlacementConfig().
 				WithName(common.SingletonResourceObjectName).
 				WithNodeAffinityScoring(false).
@@ -1342,14 +1183,7 @@ func TestIsPreferredAffinityConfiguredForArchitecture(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: v1.Pod{
-					Spec: v1.PodSpec{
-						Affinity: test.affinity,
-					},
-				},
-			}
-
+			pod := newPod(NewPod().WithAffinity(test.affinity).Build(), ctx, nil)
 			result := pod.isPreferredAffinityConfiguredForArchitecture()
 			if result != test.expected {
 				t.Errorf("expected %v, got %v", test.expected, result)
@@ -1452,14 +1286,11 @@ func TestIsNodeSelectorConfiguredForArchitecture(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			pod := &Pod{
-				Pod: v1.Pod{
-					Spec: v1.PodSpec{
-						NodeSelector: test.nodeSelector,
-						Affinity:     test.affinity,
-					},
-				},
+			var nodeSelectors []string
+			for k, v := range test.nodeSelector {
+				nodeSelectors = append(nodeSelectors, k, v)
 			}
+			pod := newPod(NewPod().WithNodeSelectors(nodeSelectors...).WithAffinity(test.affinity).Build(), ctx, nil)
 
 			result := pod.isNodeSelectorConfiguredForArchitecture()
 			if result != test.expected {

--- a/pkg/models/pod.go
+++ b/pkg/models/pod.go
@@ -1,0 +1,155 @@
+package models
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
+)
+
+type Pod struct {
+	corev1.Pod
+	ctx      context.Context
+	recorder record.EventRecorder
+}
+
+func NewPod(pod *corev1.Pod, ctx context.Context, recorder record.EventRecorder) *Pod {
+	return &Pod{
+		Pod:      *pod,
+		ctx:      ctx,
+		recorder: recorder,
+	}
+}
+
+// Ctx returns the context associated with the Pod.
+func (pod *Pod) Ctx() context.Context {
+	return pod.ctx
+}
+
+// Recorder returns the EventRecorder associated with the Pod.
+func (pod *Pod) Recorder() record.EventRecorder {
+	return pod.recorder
+}
+
+func (pod *Pod) PodObject() *corev1.Pod {
+	return &pod.Pod
+}
+
+// PublishEvent publishes an event for the pod using the EventRecorder.
+func (pod *Pod) PublishEvent(eventType, reason, message string) {
+	if pod.recorder != nil {
+		pod.recorder.Event(&pod.Pod, eventType, reason, message)
+	}
+}
+
+// HasGate checks if the pod has a specific scheduling gate.
+func (pod *Pod) HasGate(gateName string) bool {
+	if pod.Spec.SchedulingGates == nil {
+		return false
+	}
+	for _, gate := range pod.Spec.SchedulingGates {
+		if gate.Name == gateName {
+			return true
+		}
+	}
+	return false
+}
+
+// AddGate adds a scheduling gate to the pod if it does not already exist.
+func (pod *Pod) AddGate(gateName string) {
+	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3521-pod-scheduling-readiness
+	if pod.HasGate(gateName) {
+		// If the gate is already present, we return
+		return
+	}
+	if pod.Spec.SchedulingGates == nil {
+		pod.Spec.SchedulingGates = make([]corev1.PodSchedulingGate, 0)
+	}
+	pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: gateName})
+}
+
+// RemoveGate removes a scheduling gate from the pod if it exists.
+func (pod *Pod) RemoveGate(gateName string) {
+	if !pod.HasGate(gateName) {
+		// If the gate is not present, we return
+		return
+	}
+	filtered := make([]corev1.PodSchedulingGate, 0, len(pod.Spec.SchedulingGates)-1)
+	for _, schedulingGate := range pod.Spec.SchedulingGates {
+		if schedulingGate.Name != gateName {
+			filtered = append(filtered, schedulingGate)
+		}
+	}
+	pod.Spec.SchedulingGates = filtered
+}
+
+// EnsureLabel ensures that the pod has the given label with the given value.
+func (pod *Pod) EnsureLabel(label string, value string) {
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	pod.Labels[label] = value
+}
+
+// EnsureNoLabel ensures that the pod does not have the given label.
+func (pod *Pod) EnsureNoLabel(label string) {
+	if pod.Labels == nil {
+		return
+	}
+	delete(pod.Labels, label)
+}
+
+// EnsureAnnotation ensures that the pod has the given annotation with the given value.
+func (pod *Pod) EnsureAnnotation(annotation string, value string) {
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations[annotation] = value
+}
+
+// EnsureAndIncrementLabel ensures that the pod has the given label with the given value.
+// If the label is already set, it increments the value.
+func (pod *Pod) EnsureAndIncrementLabel(label string) {
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	if _, ok := pod.Labels[label]; !ok {
+		pod.Labels[label] = "1"
+		return
+	}
+	cur, err := strconv.ParseInt(pod.Labels[label], 10, 32)
+	if err != nil {
+		pod.Labels[label] = "1"
+	} else {
+		pod.Labels[label] = fmt.Sprintf("%d", cur+1)
+	}
+}
+
+// HasControlPlaneNodeSelector returns true if the pod has a node selector that matches the control plane nodes.
+func (pod *Pod) HasControlPlaneNodeSelector() bool {
+	if pod.Spec.NodeSelector == nil {
+		return false
+	}
+	requiredSelectors := []string{utils.MasterNodeSelectorLabel, utils.ControlPlaneNodeSelectorLabel}
+	for _, value := range requiredSelectors {
+		if _, ok := pod.Spec.NodeSelector[value]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// IsFromDaemonSet returns true if the pod is from a daemonSet.
+func (pod *Pod) IsFromDaemonSet() bool {
+	// Check all ownerRef
+	for _, ownerRef := range pod.OwnerReferences {
+		if ownerRef.Kind == "DaemonSet" && ownerRef.Controller != nil && *ownerRef.Controller {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/models/pod_test.go
+++ b/pkg/models/pod_test.go
@@ -1,0 +1,547 @@
+package models
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
+	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
+)
+
+var ctx context.Context
+
+func init() {
+	ctx = context.TODO()
+}
+
+func TestPod_AddGate(t *testing.T) {
+	type fields struct {
+		Pod *v1.Pod
+	}
+	type args struct {
+		gateName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "pod with no scheduling gates",
+			fields: fields{
+				Pod: builder.NewPod().Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+		},
+		{
+			name: "pod with empty scheduling gates",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates().Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+		},
+		{
+			name: "pod with scheduling gates and no matching gate",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates("other-gate").Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+		},
+		{
+			name: "pod with scheduling gates and matching gate",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates("test-gate", "other-gate").Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(tt.fields.Pod, ctx, nil)
+			pod.AddGate(tt.args.gateName)
+			if !pod.HasGate(tt.args.gateName) {
+				t.Errorf("AddGate() did not add gate %s to pod", tt.args.gateName)
+			}
+		})
+	}
+}
+
+func TestPod_HasGate(t *testing.T) {
+	type fields struct {
+		Pod      *v1.Pod
+		ctx      context.Context
+		recorder record.EventRecorder
+	}
+	type args struct {
+		gateName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "pod with no scheduling gates",
+			fields: fields{
+				Pod: builder.NewPod().Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+			want: false,
+		},
+		{
+			name: "pod with empty scheduling gates",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates().Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+			want: false,
+		},
+		{
+			name: "pod with scheduling gates and no matching gate",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates("other-gate").Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+			want: false,
+		},
+		{
+			name: "pod with scheduling gates and matching gate",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates("test-gate").Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+			want: true,
+		},
+		{
+			name: "pod with multiple scheduling gates and matching gate",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates("other-gate", "test-gate", "another-gate").Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
+			if got := pod.HasGate(tt.args.gateName); got != tt.want {
+				t.Errorf("HasGate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPod_RemoveGate(t *testing.T) {
+	type fields struct {
+		Pod      *v1.Pod
+		ctx      context.Context
+		recorder record.EventRecorder
+	}
+	type args struct {
+		gateName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "pod with no scheduling gates",
+			fields: fields{
+				Pod: builder.NewPod().Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+		},
+		{
+			name: "pod with non-matching scheduling gates",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates("other-gate").Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+		},
+		{
+			name: "pod with matching scheduling gate",
+			fields: fields{
+				Pod: builder.NewPod().WithSchedulingGates("test-gate").Build(),
+			},
+			args: args{
+				gateName: "test-gate",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
+			pod.RemoveGate(tt.args.gateName)
+			if got := pod.HasGate(tt.args.gateName); got {
+				t.Errorf("RemoveGate() = true, want false")
+			}
+		})
+	}
+}
+
+func TestEnsureLabel(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialLabels  []string
+		label          string
+		value          string
+		expectedLabels map[string]string
+	}{
+		{
+			name:           "Empty Labels",
+			initialLabels:  nil,
+			label:          "testLabel",
+			value:          "testValue",
+			expectedLabels: map[string]string{"testLabel": "testValue"},
+		},
+		{
+			name:           "Non-empty Labels",
+			initialLabels:  []string{"existingLabel", "existingValue"},
+			label:          "testLabel",
+			value:          "testValue",
+			expectedLabels: map[string]string{"existingLabel": "existingValue", "testLabel": "testValue"},
+		},
+		{
+			name:           "Overwrite Existing Label",
+			initialLabels:  []string{"testLabel", "oldValue"},
+			label:          "testLabel",
+			value:          "newValue",
+			expectedLabels: map[string]string{"testLabel": "newValue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(builder.NewPod().WithLabels(tt.initialLabels...).Build(), ctx, nil)
+			pod.EnsureLabel(tt.label, tt.value)
+
+			if len(pod.Labels) != len(tt.expectedLabels) {
+				t.Errorf("expected %d labels, got %d", len(tt.expectedLabels), len(pod.Labels))
+			}
+
+			for k, v := range tt.expectedLabels {
+				if pod.Labels[k] != v {
+					t.Errorf("expected label %s to have value %s, got %s", k, v, pod.Labels[k])
+				}
+			}
+		})
+	}
+}
+
+func TestPod_EnsureAnnotation(t *testing.T) {
+	type args struct {
+		annotation string
+		value      string
+	}
+	tests := []struct {
+		name               string
+		initialAnnotations map[string]string
+		args               args
+	}{
+		{
+			name:               "pod with no annotations",
+			initialAnnotations: nil,
+			args: args{
+				annotation: "test-annotation",
+				value:      "test-value",
+			},
+		},
+		{
+			name: "pod with existing annotation",
+			initialAnnotations: map[string]string{
+				"existing-annotation": "existing-value",
+			},
+			args: args{
+				annotation: "test-annotation",
+				value:      "test-value",
+			},
+		},
+		{
+			name: "pod with multiple annotations including the one to update",
+			initialAnnotations: map[string]string{
+				"existing-annotation": "existing-value",
+				"test-annotation":     "old-value",
+			},
+			args: args{
+				annotation: "test-annotation",
+				value:      "new-value",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(builder.NewPod().WithAnnotations(tt.initialAnnotations).Build(), ctx, nil)
+			pod.EnsureAnnotation(tt.args.annotation, tt.args.value)
+			for k, v := range tt.initialAnnotations {
+				if k == tt.args.annotation {
+					if pod.Annotations[k] != tt.args.value {
+						t.Errorf("EnsureAnnotation() did not update annotation %s, expected %s, got %s", k, tt.args.value, pod.Annotations[k])
+					}
+				} else {
+					if pod.Annotations[k] != v {
+						t.Errorf("EnsureAnnotation() removed annotation %s unexpectedly, expected %s, got %s", k, v, pod.Annotations[k])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestPod_EnsureNoLabel(t *testing.T) {
+	type args struct {
+		label string
+	}
+	tests := []struct {
+		name            string
+		labelValuePairs []string
+		args            args
+	}{
+		{
+			name: "pod with no labels",
+			args: args{
+				label: "test-label",
+			},
+		},
+		{
+			name: "pod with existing label",
+			labelValuePairs: []string{
+				"test-label", "test-value",
+			},
+			args: args{
+				label: "test-label",
+			},
+		},
+		{
+			name: "pod with multiple labels including the one to remove",
+			labelValuePairs: []string{
+				"test-label", "test-value",
+				"another-label", "another-value",
+			},
+			args: args{
+				label: "test-label",
+			},
+		},
+		{
+			name: "pod with multiple labels but not the one to remove",
+			labelValuePairs: []string{
+				"another-label", "another-value",
+				"yet-another-label", "yet-another-value",
+			},
+			args: args{
+				label: "test-label",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(builder.NewPod().WithLabels(tt.labelValuePairs...).Build(), ctx, nil)
+			pod.EnsureNoLabel(tt.args.label)
+			for i, label := range tt.labelValuePairs {
+				if i%2 != 0 {
+					continue // Skip values, only check keys
+				}
+				if pl, ok := pod.Labels[label]; ok && label == tt.args.label {
+					t.Errorf("EnsureNoLabel() did not remove label %s, found value %s", label, pl)
+				} else if !ok && label != tt.args.label {
+					t.Errorf("EnsureNoLabel() removed label %s unexpectedly", label)
+				}
+			}
+		})
+	}
+}
+func TestPod_HasControlPlaneNodeSelector(t *testing.T) {
+	type fields struct {
+		Pod      *v1.Pod
+		ctx      context.Context
+		recorder record.EventRecorder
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "pod with no node selector terms",
+			fields: fields{
+				Pod: builder.NewPod().Build(),
+			},
+			want: false,
+		},
+		{
+			name: "pod with empty node selector terms",
+			fields: fields{
+				Pod: builder.NewPod().WithNodeSelectors().Build(),
+			},
+			want: false,
+		},
+		{
+			name: "pod with node selector terms and no control plane node selector",
+			fields: fields{
+				Pod: builder.NewPod().WithNodeSelectors("foo", "bar").Build(),
+			},
+			want: false,
+		},
+		{
+			name: "pod with node selector terms and control plane node selector",
+			fields: fields{
+				Pod: builder.NewPod().WithNodeSelectors("foo", "bar", utils.ControlPlaneNodeSelectorLabel, "").Build(),
+			},
+			want: true,
+		},
+		{
+			name: "pod with node selector terms and control plane node selector and other node selector",
+			fields: fields{
+				Pod: builder.NewPod().WithNodeSelectors("foo", "bar", utils.MasterNodeSelectorLabel, "", "baz", "foo").Build(),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
+			if got := pod.HasControlPlaneNodeSelector(); got != tt.want {
+				t.Errorf("hasControlPlaneNodeSelector() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPod_EnsureAndIncrementLabel(t *testing.T) {
+	type fields struct {
+		Pod      *v1.Pod
+		ctx      context.Context
+		recorder record.EventRecorder
+	}
+	type args struct {
+		label string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "pod with no labels",
+			fields: fields{
+				Pod: builder.NewPod().Build(),
+			},
+			args: args{
+				label: "test-label",
+			},
+			want: "1",
+		},
+		{
+			name: "pod with existing label",
+			fields: fields{
+				Pod: builder.NewPod().WithLabels("test-label", "2").Build(),
+			},
+			args: args{
+				label: "test-label",
+			},
+			want: "3",
+		},
+		{
+			name: "pod with existing label as non-numeric",
+			fields: fields{
+				Pod: builder.NewPod().WithLabels("test-label", "non-numeric").Build(),
+			},
+			args: args{
+				label: "test-label",
+			},
+			want: "1", // Non-numeric value should reset to 1
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
+			pod.EnsureAndIncrementLabel(tt.args.label)
+			if value, exists := pod.Labels[tt.args.label]; exists {
+				if value != tt.want {
+					t.Errorf("EnsureAndIncrementLabel() = %v, want %v", value, tt.want)
+				}
+			} else {
+				t.Errorf("EnsureAndIncrementLabel() did not set label %s", tt.args.label)
+			}
+		})
+	}
+}
+
+func TestPod_IsFromDaemonSet(t *testing.T) {
+	type fields struct {
+		Pod      *v1.Pod
+		ctx      context.Context
+		recorder record.EventRecorder
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "pod with no owner references",
+			fields: fields{
+				Pod: builder.NewPod().Build(),
+			},
+			want: false,
+		},
+		{
+			name: "pod with owner reference not a DaemonSet",
+			fields: fields{
+				Pod: builder.NewPod().WithOwnerReference(metav1.OwnerReference{
+					Kind:       "Deployment",
+					Name:       "test-deployment",
+					Controller: utils.NewPtr(true),
+				}).Build(),
+			},
+			want: false,
+		},
+		{
+			name: "pod with owner reference as DaemonSet",
+			fields: fields{
+				Pod: builder.NewPod().WithOwnerReference(metav1.OwnerReference{
+					Kind:       "DaemonSet",
+					Name:       "test-daemonset",
+					Controller: utils.NewPtr(true),
+				}).Build(),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := NewPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
+			if got := pod.IsFromDaemonSet(); got != tt.want {
+				t.Errorf("IsFromDaemonSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/testing/builder/pod.go
+++ b/pkg/testing/builder/pod.go
@@ -172,6 +172,16 @@ func (p *PodBuilder) WithNodeName(nodeName string) *PodBuilder {
 	return p
 }
 
+func (p *PodBuilder) WithAnnotations(annotations map[string]string) *PodBuilder {
+	if p.pod.Annotations == nil {
+		p.pod.Annotations = make(map[string]string)
+	}
+	for key, value := range annotations {
+		p.pod.Annotations[key] = value
+	}
+	return p
+}
+
 func (p *PodBuilder) WithLabels(labelsKeyValuesPair ...string) *PodBuilder {
 	if p.pod.Labels == nil {
 		p.pod.Labels = make(map[string]string)
@@ -183,6 +193,11 @@ func (p *PodBuilder) WithLabels(labelsKeyValuesPair ...string) *PodBuilder {
 	for i := 0; i < len(labelsKeyValuesPair); i += 2 {
 		p.pod.Labels[labelsKeyValuesPair[i]] = labelsKeyValuesPair[i+1]
 	}
+	return p
+}
+
+func (p *PodBuilder) WithOwnerReference(or metav1.OwnerReference) *PodBuilder {
+	p.pod.OwnerReferences = append(p.pod.OwnerReferences, or)
 	return p
 }
 


### PR DESCRIPTION
The model in the pod placement controller's pod_model.go file implements methods that can be used in other controllers. While starting the implementation of the enoexec reconciler, this commit creates a more generic model that can be extended by controller-specific ones.

Refer [MULTIARCH-5010](https://issues.redhat.com//browse/MULTIARCH-5010)