### PR TITLE
MULTIARCH-5417: ENoExecEvent reconciler

### DIFF
--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2025-05-27T23:50:18Z"
+    createdAt: "2025-05-30T14:31:44Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -125,6 +125,13 @@ spec:
           verbs:
           - get
           - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
         - apiGroups:
           - ""
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,6 +30,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/enoexecevent/enoexecevent_controller.go
+++ b/controllers/enoexecevent/enoexecevent_controller.go
@@ -18,45 +18,153 @@ package enoexecevent
 
 import (
 	"context"
+	runtime2 "runtime"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrl2 "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	"github.com/openshift/multiarch-tuning-operator/pkg/models"
+	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
 
-// ENoExecEventReconciler reconciles a ENoExecEvent object
-type ENoExecEventReconciler struct {
+// Reconciler reconciles a ENoExecEvent object
+type Reconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	clientSet *kubernetes.Clientset
+	Scheme    *runtime.Scheme
+	recorder  record.EventRecorder
+}
+
+func NewReconciler(client client.Client, clientSet *kubernetes.Clientset, scheme *runtime.Scheme, recorder record.EventRecorder) *Reconciler {
+	return &Reconciler{
+		Client:    client,
+		clientSet: clientSet,
+		Scheme:    scheme,
+		recorder:  recorder,
+	}
 }
 
 //+kubebuilder:rbac:groups=multiarch.openshift.io,resources=enoexecevents,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=multiarch.openshift.io,resources=enoexecevents/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=multiarch.openshift.io,resources=enoexecevents/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;update
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ENoExecEvent object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
-func (r *ENoExecEventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+// Reconcile will reconcile the ENoExecEvent resource.
+// It will fetch the ENoExecEvent instance, retrieve the pod and node information,
+// label the pod with the ENoExecEvent label, update the metrics, and publish an event.
+// Finally, it will delete the ENoExecEvent resource if the reconciliation was successful or if the pod was not found.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
 
-	// TODO(user): your logic here
+	// Fetch the ENoExecEvent instance
+	enoExecEvent := &multiarchv1beta1.ENoExecEvent{}
+	if err := r.Get(ctx, req.NamespacedName, enoExecEvent); err != nil {
+		// If the resource is not found, we simply return. This is not an error.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
 
+	if enoExecEvent.Namespace != utils.Namespace() {
+		logger.Info("ENoExecEvent is not in the operator namespace, skipping reconciliation", "name", enoExecEvent.Name, "namespace", enoExecEvent.Namespace)
+		return ctrl.Result{}, nil
+	}
+
+	if enoExecEvent.Status.PodName == "" {
+		// If the ENoExecEvent does not have a pod name, we ignore it
+		logger.V(5).Info("ENoExecEvent does not have a pod name, skipping reconciliation", "name", enoExecEvent.Name, "namespace", enoExecEvent.Namespace)
+		return ctrl.Result{}, nil
+	}
+
+	// Log the ENoExecEvent instance
+	logger.Info("Reconciling ENoExecEvent", "name", enoExecEvent.Name, "namespace", enoExecEvent.Namespace)
+	ret, err := r.reconcile(ctx, enoExecEvent)
+	// If the reconciliation was successful, or one of the objects was not found, we delete the ENoExecEvent resource.
+	if client.IgnoreNotFound(err) == nil {
+		if err := r.Delete(ctx, enoExecEvent); err != nil {
+			logger.Error(err, "Failed to delete ENoExecEvent resource after reconciliation", "name", enoExecEvent.Name)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		logger.Info("Deleted ENoExecEvent resource after successful reconciliation", "name", enoExecEvent.Name)
+		return ret, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, enoExecEvent *multiarchv1beta1.ENoExecEvent) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	// Retrieve the pod
+	podObj, err := r.clientSet.CoreV1().Pods(enoExecEvent.Status.PodNamespace).Get(ctx, enoExecEvent.Status.PodName, metav1.GetOptions{})
+	if err != nil {
+		// If the pod is not found, the error will be ignored and the ENoExecEvent will be deleted by the caller.
+		// TODO: increment counter for exec format error failures and missed ENoExecEvent reconciliations
+		logger.Error(err, "Failed to get pod for ENoExecEvent", "podName",
+			enoExecEvent.Status.PodName, "namespace", enoExecEvent.Status.PodNamespace)
+		return ctrl.Result{}, err
+	}
+
+	pod := models.NewPod(podObj, ctx, r.recorder)
+	if pod.PodObject().Spec.NodeName != enoExecEvent.Status.NodeName {
+		// If the pod is not scheduled on the node where the ENoExecEvent was generated, we skip the reconciliation.
+		logger.Info("Pod is not scheduled on the node where the ENoExecEvent was generated", "podName",
+			pod.Name, "namespace", pod.Namespace, "nodeName", enoExecEvent.Status.NodeName)
+		return ctrl.Result{}, nil
+	}
+
+	// Retrieve the node
+	node, err := r.clientSet.CoreV1().Nodes().Get(ctx, enoExecEvent.Status.NodeName, metav1.GetOptions{})
+	if err != nil {
+		// When the error is "not found", the ENoExecEvent may refer a new pod with the same name scheduled on a different node.
+		// This ENoExecEvent is then not relevant anymore and will be deleted by the caller.
+		// Other errors will be returned to the caller, which will retry the reconciliation.
+		// TODO: increment counter for exec format error failures and missed ENoExecEvent reconciliations
+		logger.Error(err, "Failed to get node for ENoExecEvent", "nodeName", podObj.Spec.NodeName,
+			"podName", enoExecEvent.Status.PodName, "namespace", enoExecEvent.Status.PodNamespace)
+		return ctrl.Result{}, err
+	}
+
+	containerName, err := pod.ContainerNameFor(enoExecEvent.Status.ContainerID)
+	if err != nil {
+		logger.Error(err, "Container ID not found in pod status", "containerID", enoExecEvent.Status.ContainerID)
+		containerName = utils.UnknownContainer
+	}
+
+	logger.Info("Publishing event for ENoExecEvent", "podName", pod.Name, "namespace", pod.Namespace)
+	pod.PublishEvent(v1.EventTypeWarning, utils.ExecFormatErrorEventReason,
+		utils.ExecFormatErrorEventMessage(containerName, node.Labels[utils.ArchLabel], enoExecEvent.Status.Command))
+
+	// Label the pod with the ENoExecEvent label.
+	pod.EnsureLabel(utils.ExecFormatErrorLabelKey, utils.True)
+	// TODO: increment counter for exec format error failures
+	// Update the pod with the new label
+	if _, err = r.clientSet.CoreV1().Pods(pod.Namespace).Update(ctx, pod.PodObject(), metav1.UpdateOptions{}); err != nil {
+		logger.Error(err, "Failed to label the pod", "podName", pod.Name, "namespace", pod.Namespace)
+		// if the error is "not found", it means the pod has been deleted, the caller will handle this case.
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ENoExecEventReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// This reconciler is mostly I/O bound due to the pod and node retrievals, so we can increase the number of concurrent
+	// reconciles to the number of CPUs * 4.
+	maxConcurrentReconciles := runtime2.NumCPU() * 4
+	log.FromContext(context.Background()).Info("Setting up the ENoExecEventReconciler with the manager with max"+
+		" concurrent reconciles", "maxConcurrentReconciles", maxConcurrentReconciles)
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multiarchv1beta1.ENoExecEvent{}).
+		WithOptions(ctrl2.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+		}).
 		Complete(r)
 }

--- a/controllers/enoexecevent/enoexecevent_controller_test.go
+++ b/controllers/enoexecevent/enoexecevent_controller_test.go
@@ -5,33 +5,244 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
 	"github.com/openshift/multiarch-tuning-operator/pkg/testing/framework"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
-
-	"github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
 )
 
-var _ = Describe("Controllers/ENoExecEvent/ENoExecEventReconciler", func() {
-	When("The ENoExecEvent", func() {
-		Context("is handling the lifecycle of the operand", func() {
-			It("should create a ENoExecEvent CR", func() {
+func defaultENoExecFormatError() *builder.ENoExecEventBuilder {
+	return builder.NewENoExecEvent().WithCommand(testCommand).
+		WithNodeName(testNodeName).
+		WithPodNamespace(testNamespace).
+		WithNamespace(utils.Namespace()).WithContainerID(testContainerID)
+}
+
+func ensureEvent(podName string, message string) AsyncAssertion {
+	// Wait for the event to be published
+	return Eventually(func(g Gomega) {
+		// Get the pod from the API server
+		pod := &v1.Pod{}
+		err := k8sClient.Get(ctx, crclient.ObjectKey{
+			Name:      podName,
+			Namespace: testNamespace,
+		}, pod)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get Pod", err)
+		// Get the events
+		events, err := framework.GetEventsForObject(ctx, k8sClientSet, podName, testNamespace)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get events for Pod", err)
+		// Check if the event is present
+		found := false
+		for _, event := range events {
+			if event.Reason == utils.ExecFormatErrorEventReason &&
+				event.Message == message &&
+				event.InvolvedObject.Namespace == testNamespace &&
+				event.InvolvedObject.Name == podName {
+				found = true
+				break
+			}
+		}
+		g.Expect(found).To(BeTrue(), "Event not found in Pod events")
+	}).WithPolling(e2e.PollingInterval).WithTimeout(e2e.WaitShort)
+}
+
+func ensureDeletion(eneeName string) {
+	Eventually(func(g Gomega) {
+		enee := &v1beta1.ENoExecEvent{}
+		err := k8sClient.Get(ctx, crclient.ObjectKey{
+			Name:      eneeName,
+			Namespace: utils.Namespace(),
+		}, enee)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "ENoExecEvent should be deleted")
+	}).WithPolling(e2e.PollingInterval).WithTimeout(e2e.WaitShort).Should(Succeed(), "failed to delete ENoExecEvent")
+}
+
+func ensureLabel(podName string) AsyncAssertion {
+	return Eventually(func(g Gomega) {
+		pod := &v1.Pod{}
+		err := k8sClient.Get(ctx, crclient.ObjectKey{
+			Name:      podName,
+			Namespace: testNamespace,
+		}, pod)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get Pod", err)
+		g.Expect(pod.Labels).To(HaveKeyWithValue(utils.ExecFormatErrorLabelKey, utils.True), "Pod should be labeled with ENoExecEvent label")
+	})
+}
+
+func deletePod(podName string) {
+	pod := &v1.Pod{}
+	err := k8sClient.Get(ctx, crclient.ObjectKey{
+		Name:      podName,
+		Namespace: testNamespace,
+	}, pod)
+	if err != nil && !apierrors.IsNotFound(err) {
+		Fail(fmt.Sprintf("failed to get Pod %s: %v", podName, err))
+	}
+	if err == nil {
+		Expect(k8sClient.Delete(ctx, pod)).To(Succeed(), "failed to delete Pod")
+	}
+}
+
+func createENEEAndUpdateStatus(enee *v1beta1.ENoExecEvent) {
+	By("Creating the ENoExecEvent")
+	Expect(k8sClient.Create(ctx, enee.DeepCopy())).To(Succeed(), "failed to create ENoExecEvent")
+	var eneeToUpdate = &v1beta1.ENoExecEvent{}
+	Expect(k8sClient.Get(ctx, crclient.ObjectKey{
+		Name:      enee.Name,
+		Namespace: enee.Namespace,
+	}, eneeToUpdate)).To(Succeed(), "failed to get ENoExecEvent after creation")
+	eneeToUpdate.Status = enee.Status
+	By("Updating the ENoExecEvent status")
+	Expect(k8sClient.Status().Update(ctx, eneeToUpdate)).To(Succeed(), "failed to update ENoExecEvent status")
+}
+
+func createPodAndUpdateStatus(pod *v1.Pod) {
+	By("Creating the Pod")
+	Expect(k8sClient.Create(ctx, pod.DeepCopy())).To(Succeed(), "failed to create Pod")
+	var podToUpdate = &v1.Pod{}
+	Expect(k8sClient.Get(ctx, crclient.ObjectKey{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}, podToUpdate)).To(Succeed(), "failed to get Pod after creation")
+	podToUpdate.Status = pod.Status
+	By("Updating the Pod status")
+	Expect(k8sClient.Status().Update(ctx, podToUpdate)).To(Succeed(), "failed to update Pod status")
+}
+
+var _ = Describe("Controllers/ENoExecEvent/Reconciler", func() {
+	When("The operand", func() {
+		Context("reconciles an ENoExecEvent object", func() {
+			It("should publish an event to the pod", func() {
+				// Create the pod
+				podName := framework.GenerateName()
+				eneeName := framework.GenerateName()
+				pod := builder.NewPod().WithNamespace(testNamespace).WithName(podName).WithNodeName(testNodeName).
+					WithContainer("test-image", v1.PullAlways).
+					WithContainerStatuses(builder.NewContainerStatus().WithName(testContainerName).WithID(testContainerID).Build()).
+					Build()
+				createPodAndUpdateStatus(pod)
+				// Create the ENoExecEvent object
+				enee := defaultENoExecFormatError().WithPodName(podName).WithName(eneeName).Build()
+				createENEEAndUpdateStatus(enee)
+				By("Ensuring the event is published")
+				ensureEvent(podName, utils.ExecFormatErrorEventMessage(testContainerName, testNodeArch, testCommand)).
+					Should(Succeed(), "failed to get event for Pod")
+				By("Ensuring the ENoExecEvent is deleted")
+				ensureDeletion(eneeName)
+				By("Deleting pod")
+				deletePod(podName)
+			})
+			It("should label the pod with the ENoExecEvent label", func() {
+				// Create the pod
+				podName := framework.GenerateName()
+				eneeName := framework.GenerateName()
+				pod := builder.NewPod().WithNamespace(testNamespace).WithName(podName).WithNodeName(testNodeName).
+					WithContainer("test-image", v1.PullAlways).
+					WithContainerStatuses(builder.NewContainerStatus().WithName(testContainerName).WithID(testContainerID).Build()).
+					Build()
+				createPodAndUpdateStatus(pod)
+				enee := defaultENoExecFormatError().WithPodName(podName).WithName(eneeName).Build()
+				createENEEAndUpdateStatus(enee)
+				By("Ensuring the pod is labeled with ENoExecEvent label")
+				ensureLabel(podName).Should(Succeed(), "failed to label Pod with ENoExecEvent label")
+				By("Ensuring the ENoExecEvent is deleted")
+				ensureDeletion(eneeName)
+				By("Deleting pod")
+				deletePod(podName)
+			})
+			It("should delete the ENoExecEvent object if the pod is not found", func() {
+				// Create the ENoExecEvent object
+				eneeName := framework.GenerateName()
+				enee := defaultENoExecFormatError().WithPodName("non-existing-pod").WithName(eneeName).Build()
+				createENEEAndUpdateStatus(enee)
+				// Ensure the ENoExecEvent is deleted
+				By("Ensuring the ENoExecEvent is deleted")
+				ensureDeletion(eneeName)
+			})
+			It("should delete the ENoExecEvent object if the node is not found", func() {
+				// Create the pod
+				podName := framework.GenerateName()
+				eneeName := framework.GenerateName()
+				pod := builder.NewPod().WithNamespace(testNamespace).WithName(podName).WithNodeName(testNodeName).
+					WithContainer("test-image", v1.PullAlways).
+					WithContainerStatuses(builder.NewContainerStatus().WithName(testContainerName).WithID(testContainerID).Build()).
+					Build()
+				createPodAndUpdateStatus(pod)
+				// Create the ENoExecEvent object
+				enee := defaultENoExecFormatError().WithPodName(podName).WithNodeName("non-existing-node").WithName(eneeName).Build()
+				createENEEAndUpdateStatus(enee)
+				By("Ensuring the ENoExecEvent is deleted")
+				ensureDeletion(eneeName)
+				By("Ensuring the pod is not labeled with ENoExecEvent label")
+				ensureLabel(podName).ShouldNot(Succeed(), "the pod should not have the ENoExecEvent label if the node is not found")
+				By("Ensuring the pod does not have an event published")
+				ensureEvent(podName, utils.ExecFormatErrorEventMessage(testContainerName, testNodeArch, testCommand)).
+					ShouldNot(Succeed(), "the pod should not have an event published if the node is not found")
+				By("Deleting pod")
+				deletePod(podName)
+			})
+			It("should publish the event to the pod with a wrong container ID", func() {
+				// Create the pod
+				podName := framework.GenerateName()
+				eneeName := framework.GenerateName()
+				pod := builder.NewPod().WithNamespace(testNamespace).WithName(podName).WithNodeName(testNodeName).
+					WithContainer("test-image", v1.PullAlways).
+					WithContainerStatuses(builder.NewContainerStatus().WithName(testContainerName).WithID("wrong-container-id").Build()).
+					Build()
+				createPodAndUpdateStatus(pod)
+				// Create the ENoExecEvent object
+				enee := defaultENoExecFormatError().WithPodName(podName).WithName(eneeName).Build()
+				createENEEAndUpdateStatus(enee)
+				// Ensure the ENoExecEvent is deleted
+				ensureDeletion(eneeName)
+				// Ensure the event is published
+				ensureEvent(podName, utils.ExecFormatErrorEventMessage(utils.UnknownContainer, testNodeArch, testCommand)).
+					Should(Succeed(), "failed to get event for Pod with wrong container ID")
+				ensureLabel(podName).Should(Succeed(), "failed to label Pod with ENoExecEvent label for wrong container ID")
+
+			})
+			It("should delete the ENoExecEvent object if the node is not the same as the podSpec.NodeName value", func() {
+				// Create the pod
+				podName := framework.GenerateName()
+				eneeName := framework.GenerateName()
+				pod := builder.NewPod().WithNamespace(testNamespace).WithName(podName).WithNodeName("other-node").
+					WithContainer("test-image", v1.PullAlways).
+					WithContainerStatuses(builder.NewContainerStatus().WithName(testContainerName).WithID(testContainerID).Build()).
+					Build()
+				createPodAndUpdateStatus(pod)
+				// Create the ENoExecEvent object
+				enee := defaultENoExecFormatError().WithPodName(podName).WithNodeName(testNodeName).WithName(eneeName).Build()
+				createENEEAndUpdateStatus(enee)
+				ensureDeletion(eneeName)
+				By("Ensuring the pod is not labeled with ENoExecEvent label")
+				ensureLabel(podName).ShouldNot(Succeed(), "the pod should not have the ENoExecEvent label if the node is not found")
+				By("Ensuring the pod does not have an event published")
+				ensureEvent(podName, utils.ExecFormatErrorEventMessage(testContainerName, testNodeArch, testCommand)).
+					ShouldNot(Succeed(), "the pod should not have an event published if the node is not found")
+				By("Deleting pod")
+				deletePod(podName)
+			})
+		})
+		Context("basic creation", func() {
+			It("should create, delete an ENoExecEvent CR", func() {
 				By("Creating the ENoExecEvent")
-				enee := builder.NewENoExecEvent().WithName("test").WithNamespace(utils.Namespace()).Build()
+				enee := builder.NewENoExecEvent().WithName("test").WithNamespace(testNamespace).Build()
 				err := k8sClient.Create(ctx, enee)
 				Expect(err).NotTo(HaveOccurred(), "failed to create ENoExecEvent", err)
 				By("Deleting the ENoExecEvent")
 				err = k8sClient.Delete(ctx, enee)
 				Expect(err).NotTo(HaveOccurred(), "failed to delete ENoExecEvent", err)
-				Eventually(framework.ValidateDeletion(k8sClient, ctx)).Should(Succeed(), "the ENoExecEvent should be deleted")
 			})
 			It("should create a ENoExecEvent CR with set fields", func() {
 				By("Creating the ENoExecEvent")
-				enee := builder.NewENoExecEvent().WithName("test-name").WithNamespace(utils.Namespace()).Build()
+				enee := builder.NewENoExecEvent().WithName("test-name").WithNamespace(testNamespace).Build()
 				err := k8sClient.Create(ctx, enee)
 				Expect(err).NotTo(HaveOccurred(), "failed to create ENoExecEvent", err)
 
@@ -51,7 +262,7 @@ var _ = Describe("Controllers/ENoExecEvent/ENoExecEventReconciler", func() {
 					enee = &v1beta1.ENoExecEvent{}
 					err := k8sClient.Get(ctx, crclient.ObjectKey{
 						Name:      "test-name",
-						Namespace: utils.Namespace(),
+						Namespace: testNamespace,
 					}, enee)
 					g.Expect(err).NotTo(HaveOccurred(), "failed to get enee", err)
 					g.Expect(enee.Status.NodeName).To(Equal("test-node"))
@@ -75,7 +286,7 @@ var _ = Describe("Controllers/ENoExecEvent/ENoExecEventReconciler", func() {
 				By("Creating the ENoExecEvent")
 				enee = builder.NewENoExecEvent().
 					WithName(eneeName).
-					WithNamespace(utils.Namespace()).
+					WithNamespace(testNamespace).
 					Build()
 				err := k8sClient.Create(ctx, enee)
 				Expect(err).NotTo(HaveOccurred())
@@ -91,7 +302,7 @@ var _ = Describe("Controllers/ENoExecEvent/ENoExecEventReconciler", func() {
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{
 						Name:      eneeName,
-						Namespace: utils.Namespace(),
+						Namespace: testNamespace,
 					}, &v1beta1.ENoExecEvent{})
 				}).Should(MatchError(ContainSubstring("not found")), "the ENoExecEvent should be deleted")
 			})

--- a/pkg/models/pod.go
+++ b/pkg/models/pod.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -162,13 +161,6 @@ func (pod *Pod) ContainerNameFor(containerID string) (string, error) {
 	if err != nil || !matched {
 		return "", fmt.Errorf("invalid container ID format: %s", containerID)
 	}
-	// Extract the 64-hex-chars part from the containerID
-	parts := strings.SplitN(containerID, "://", 2)
-	if len(parts) != 2 || len(parts[1]) != 64 {
-		return "", fmt.Errorf("failed to extract container ID from: %s", containerID)
-	}
-	containerID = parts[1]
-
 	for _, container := range pod.PodObject().Status.ContainerStatuses {
 		if container.ContainerID == containerID {
 			return container.Name, nil

--- a/pkg/testing/builder/container_status.go
+++ b/pkg/testing/builder/container_status.go
@@ -1,0 +1,50 @@
+package builder
+
+import v1 "k8s.io/api/core/v1"
+
+// ContainerStatusBuilder is a builder for creating container statuses.
+type ContainerStatusBuilder struct {
+	containerStatus v1.ContainerStatus
+}
+
+// NewContainerStatus creates a new instance of ContainerStatusBuilder.
+func NewContainerStatus() *ContainerStatusBuilder {
+	return &ContainerStatusBuilder{
+		containerStatus: v1.ContainerStatus{},
+	}
+}
+
+// WithName sets the name of the container.
+func (b *ContainerStatusBuilder) WithName(name string) *ContainerStatusBuilder {
+	b.containerStatus.Name = name
+	return b
+}
+
+// WithState sets the state of the container.
+func (b *ContainerStatusBuilder) WithState(state v1.ContainerState) *ContainerStatusBuilder {
+	b.containerStatus.State = state
+	return b
+}
+
+// WithReady sets the ready status of the container.
+func (b *ContainerStatusBuilder) WithReady(ready bool) *ContainerStatusBuilder {
+	b.containerStatus.Ready = ready
+	return b
+}
+
+// WithRestartCount sets the restart count of the container.
+func (b *ContainerStatusBuilder) WithRestartCount(count int32) *ContainerStatusBuilder {
+	b.containerStatus.RestartCount = count
+	return b
+}
+
+// WithID sets the ID of the container.
+func (b *ContainerStatusBuilder) WithID(id string) *ContainerStatusBuilder {
+	b.containerStatus.ContainerID = id
+	return b
+}
+
+// Build returns the constructed ContainerStatus.
+func (b *ContainerStatusBuilder) Build() v1.ContainerStatus {
+	return b.containerStatus
+}

--- a/pkg/testing/builder/node.go
+++ b/pkg/testing/builder/node.go
@@ -1,0 +1,52 @@
+package builder
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NodeBuilder is a utility to build Kubernetes Node objects.
+type NodeBuilder struct {
+	node *corev1.Node
+}
+
+// NewNodeBuilder creates a new instance of NodeBuilder.
+func NewNodeBuilder() *NodeBuilder {
+	return &NodeBuilder{
+		node: &corev1.Node{},
+	}
+}
+
+// WithName sets the name of the Node.
+func (b *NodeBuilder) WithName(name string) *NodeBuilder {
+	b.node.Name = name
+	return b
+}
+
+// WithLabel adds a label to the Node.
+func (b *NodeBuilder) WithLabel(key, value string) *NodeBuilder {
+	if b.node.Labels == nil {
+		b.node.Labels = make(map[string]string)
+	}
+	b.node.Labels[key] = value
+	return b
+}
+
+// WithAnnotation adds an annotation to the Node.
+func (b *NodeBuilder) WithAnnotation(key, value string) *NodeBuilder {
+	if b.node.Annotations == nil {
+		b.node.Annotations = make(map[string]string)
+	}
+	b.node.Annotations[key] = value
+	return b
+}
+
+// WithTaint adds a taint to the Node.
+func (b *NodeBuilder) WithTaint(taint corev1.Taint) *NodeBuilder {
+	b.node.Spec.Taints = append(b.node.Spec.Taints, taint)
+	return b
+}
+
+// Build finalizes and returns the Node object.
+func (b *NodeBuilder) Build() *corev1.Node {
+	return b.node
+}

--- a/pkg/testing/builder/pod.go
+++ b/pkg/testing/builder/pod.go
@@ -20,6 +20,11 @@ func NewPod() *PodBuilder {
 	}
 }
 
+func (p *PodBuilder) WithName(name string) *PodBuilder {
+	p.pod.Name = name
+	return p
+}
+
 func (p *PodBuilder) WithImagePullSecrets(imagePullSecrets ...string) *PodBuilder {
 	p.pod.Spec.ImagePullSecrets = make([]v1.LocalObjectReference, len(imagePullSecrets))
 	for i, secret := range imagePullSecrets {
@@ -198,6 +203,11 @@ func (p *PodBuilder) WithLabels(labelsKeyValuesPair ...string) *PodBuilder {
 
 func (p *PodBuilder) WithOwnerReference(or metav1.OwnerReference) *PodBuilder {
 	p.pod.OwnerReferences = append(p.pod.OwnerReferences, or)
+	return p
+}
+
+func (p *PodBuilder) WithContainerStatuses(statuses ...v1.ContainerStatus) *PodBuilder {
+	p.pod.Status.ContainerStatuses = statuses
 	return p
 }
 

--- a/pkg/testing/framework/events.go
+++ b/pkg/testing/framework/events.go
@@ -1,0 +1,21 @@
+package framework
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetEventsForObject(ctx context.Context, client *kubernetes.Clientset, objectName string, objectNamespace string) ([]corev1.Event, error) {
+	var events *corev1.EventList
+	var err error
+
+	if events, err = client.CoreV1().Events(objectNamespace).List(ctx, metav1.ListOptions{
+		FieldSelector: "involvedObject.name=" + objectName,
+	}); err == nil {
+		return events.Items, nil
+	}
+	return nil, err
+}

--- a/pkg/testing/framework/utils.go
+++ b/pkg/testing/framework/utils.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"unicode"
 
+	"github.com/google/uuid"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -195,4 +197,9 @@ func GetImageRepository(image string) string {
 		image = image[:colonIndex]
 	}
 	return image
+}
+
+func GenerateName() string {
+	// Generate a random name using UUID
+	return NormalizeNameString("t-" + uuid.NewString())
 }

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -1,6 +1,10 @@
 package utils
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
 
 const (
 	ControllerNameKey = "controller"
@@ -48,6 +52,19 @@ const (
 	PodPlacementWebhookName             = "pod-placement-web-hook"
 )
 
+const (
+	ExecFormatErrorLabelKey        = "multiarch.openshift.io/exec-format-error"
+	True                           = "true"
+	False                          = "false"
+	ExecFormatErrorEventReason     = "ExecFormatError"
+	execFormatErrorEventMessageFmt = "Container \"%s\" is running a binary (\"%s\") that is not compatible with the node architecture (%s). This is likely due to an error in the image build process or a misconfiguration in other scripts used by the container. Please ensure that the container image is built for the correct architecture and that any scripts or binaries used within the container are compatible with the architectures supported by the image."
+	UnknownContainer               = "unknown-container" // Used when the container name is not known or not provided
+)
+
 func AllSupportedArchitecturesSet() sets.Set[string] {
 	return sets.New(ArchitectureAmd64, ArchitectureArm64, ArchitecturePpc64le, ArchitectureS390x)
+}
+
+func ExecFormatErrorEventMessage(containerName, nodeArch, command string) string {
+	return fmt.Sprintf(execFormatErrorEventMessageFmt, containerName, command, nodeArch)
 }


### PR DESCRIPTION
This PR implements the enoexec event reconciler to:
1. Publish an event in the pod affected by enoexec
2. Label the pod
3. Remove the ENoExecEvent temporary object

Blocked by 
- #643
- #612