### PR TITLE
MULTIARCH-5546: Fix bundle image detection logic for multi-arch scheduling

### DIFF
--- a/pkg/testing/image/fake/registry/seed.go
+++ b/pkg/testing/image/fake/registry/seed.go
@@ -89,7 +89,7 @@ func GetMockImages() []MockImage {
 		Name:          ComputeNameByMediaType(imgspecv1.MediaTypeImageManifest, "bundle"),
 		Tag:           "latest",
 		Labels: map[string]string{
-			"operators.operatorframework.io.metrics.builder": "",
+			"operators.operatorframework.io.bundle.package.v1": "",
 		},
 	}, MockImage{
 		Architectures: sets.New[string](utils.ArchitecturePpc64le, utils.ArchitectureS390x),


### PR DESCRIPTION
Bundle images are typically shipped as single-architecture images, as they do not contain any architecture-specific content. OLM uses these images as container images with an external entrypoint binary, usually initialized via a volume and an init container.

Previously, the registry inspector logic was partially updated to treat bundle images as supporting all architectures, ensuring they do not interfere with scheduling predicate evaluation. However, this logic relied on a limited set of labels to detect bundle images, which caused some valid bundles to be missed.

This commit expands the set of recognized labels used to detect bundle images. If any of the known labels are present in the image config metadata, the image is now treated as a bundle and assumed to support all architectures. This ensures consistent behavior during installation of operators in clusters that do not run amd64 nodes.

Other container images in the same OLM pod will still be used to restrict the supported architecture set if necessary.

Note: There appears to be no reliable way to detect a bundle image solely from image metadata, apart from these labels. As such, this detection continues to rely on label presence. Also, we have no e2e tests in place for this as they should rely on external content we cannot control.

Closes #645