### PR TITLE
MULTIARCH-5421: Lifecycle of the exec format error plugin

### DIFF
--- a/apis/multiarch/v1beta1/groupversion_info.go
+++ b/apis/multiarch/v1beta1/groupversion_info.go
@@ -37,3 +37,5 @@ var (
 
 const ClusterPodPlacementConfigResource = "clusterpodplacementconfigs"
 const ClusterPodPlacementConfigKind = "ClusterPodPlacementConfig"
+const ENoExecEventKind = "ENoExecEvent"
+const ENoExecEventResource = "enoexecevents"

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -204,6 +204,7 @@ spec:
         - apiGroups:
           - apps
           resources:
+          - daemonsets
           - deployments
           verbs:
           - create

--- a/cmd/main-binary/main.go
+++ b/cmd/main-binary/main.go
@@ -126,6 +126,12 @@ func main() {
 			},
 		}
 	}
+	if enableENoExecEventControllers {
+		leaderID = fmt.Sprintf("enoexecevent-controllers-%s", leaderID)
+		cacheOpts.DefaultNamespaces = map[string]cache.Config{
+			utils.Namespace(): {},
+		}
+	}
 
 	// Rapid Reset CVEs. For more information see:
 	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
@@ -272,17 +278,17 @@ func RunENoExecEventControllers(mgr ctrl.Manager) {
 		mgr.GetClient(),
 		clientset,
 		mgr.GetScheme(),
-		mgr.GetEventRecorderFor("enoexecevent-controller"),
+		mgr.GetEventRecorderFor(utils.EnoexecControllerName),
 	).SetupWithManager(mgr), unableToCreateController, controllerKey, "ENoExecEventController")
 }
 
 func validateFlags() error {
-	if !enableOperator && !enableClusterPodPlacementConfigOperandControllers && !enableClusterPodPlacementConfigOperandWebHook {
-		return errors.New("at least one of the following flags must be set: --enable-operator, --enable-ppc-controllers, --enable-ppc-webhook")
+	if !enableOperator && !enableClusterPodPlacementConfigOperandControllers && !enableClusterPodPlacementConfigOperandWebHook && !enableENoExecEventControllers {
+		return errors.New("at least one of the following flags must be set: --enable-operator, --enable-ppc-controllers, --enable-ppc-webhook, --enable-enoexec-event-controllers")
 	}
 	// no more than one of the flags can be set
-	if btoi(enableOperator)+btoi(enableClusterPodPlacementConfigOperandControllers)+btoi(enableClusterPodPlacementConfigOperandWebHook) > 1 {
-		return errors.New("only one of the following flags can be set: --enable-operator, --enable-ppc-controllers, --enable-ppc-webhook")
+	if btoi(enableOperator)+btoi(enableClusterPodPlacementConfigOperandControllers)+btoi(enableClusterPodPlacementConfigOperandWebHook)+btoi(enableENoExecEventControllers) > 1 {
+		return errors.New("only one of the following flags can be set: --enable-operator, --enable-ppc-controllers, --enable-ppc-webhook, --enable-enoexec-event-controllers")
 	}
 	return nil
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -99,6 +99,7 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
   - deployments
   verbs:
   - create

--- a/controllers/operator/clusterpodplacementconfig_controller.go
+++ b/controllers/operator/clusterpodplacementconfig_controller.go
@@ -79,6 +79,7 @@ const (
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch;create;delete
 //+kubebuilder:rbac:groups=core,resources=services/status,verbs=get
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;update;patch;create;delete
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts/status,verbs=get

--- a/controllers/operator/clusterpodplacementconfig_controller.go
+++ b/controllers/operator/clusterpodplacementconfig_controller.go
@@ -249,6 +249,12 @@ func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context,
 	clusterPodPlacementConfig *multiarchv1beta1.ClusterPodPlacementConfig) error {
 	// The ClusterPodPlacementConfig is being deleted, cleanup the resources
 	log := ctrllog.FromContext(ctx).WithValues("operation", "handleDelete")
+
+	err := r.handleEnoexecDelete(ctx)
+	if err != nil {
+		return err
+	}
+
 	// The error by the updateStatus function, if any, is ignored, as the deletion should always proceed.
 	// We execute the update here because this function returns multiple times before the whole deletion process is completed.
 	// Executing it here ensures that the conditions are updated throughout the deletion process.
@@ -285,7 +291,7 @@ func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context,
 		log.Error(err, "Unable to delete resources")
 		return err
 	}
-	_, err := r.ClientSet.CoreV1().Services(utils.Namespace()).Get(ctx, utils.PodPlacementWebhookName, metav1.GetOptions{})
+	_, err = r.ClientSet.CoreV1().Services(utils.Namespace()).Get(ctx, utils.PodPlacementWebhookName, metav1.GetOptions{})
 	// We look for the webhook service to ensure that the webhook has stopped communicating with the API server.
 	// If the error is nil, the service was found. If the error is not nil and the error is not NotFound, some other error occurred.
 	// In both the cases we return an error, to requeue the request and ensure no race conditions between the verification of the
@@ -401,6 +407,69 @@ func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context,
 	return err
 }
 
+func (r *ClusterPodPlacementConfigReconciler) handleEnoexecDelete(ctx context.Context) error {
+	log := ctrllog.FromContext(ctx)
+	log.Info("Disabling ENoExecEvent Controller")
+	objsToDelete := []utils.ToDeleteRef{
+		{
+			NamespacedTypedClient: r.ClientSet.RbacV1().Roles(utils.Namespace()),
+			ObjName:               utils.EnoexecControllerName,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.RbacV1().RoleBindings(utils.Namespace()),
+			ObjName:               utils.EnoexecControllerName,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.RbacV1().ClusterRoles(),
+			ObjName:               utils.EnoexecDaemonSet,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.RbacV1().ClusterRoleBindings(),
+			ObjName:               utils.EnoexecDaemonSet,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.RbacV1().Roles(utils.Namespace()),
+			ObjName:               utils.EnoexecDaemonSet,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.RbacV1().RoleBindings(utils.Namespace()),
+			ObjName:               utils.EnoexecDaemonSet,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.RbacV1().ClusterRoles(),
+			ObjName:               utils.EnoexecControllerName,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.RbacV1().ClusterRoleBindings(),
+			ObjName:               utils.EnoexecControllerName,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.CoreV1().ServiceAccounts(utils.Namespace()),
+			ObjName:               utils.EnoexecControllerName,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.CoreV1().ServiceAccounts(utils.Namespace()),
+			ObjName:               utils.EnoexecDaemonSet,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.AppsV1().Deployments(utils.Namespace()),
+			ObjName:               utils.EnoexecControllerName,
+		},
+		{
+			NamespacedTypedClient: r.ClientSet.AppsV1().DaemonSets(utils.Namespace()),
+			ObjName:               utils.EnoexecDaemonSet,
+		},
+	}
+
+	log.Info("Deleting the ENoExecEvent resources")
+	// NOTE: err aggregates non-nil errors, excluding NotFound errors
+	if err := utils.DeleteResources(ctx, objsToDelete); err != nil {
+		log.Error(err, "Unable to delete resources")
+		return err
+	}
+	return nil
+}
+
 // reconcile reconciles the ClusterPodPlacementConfig operand's resources.
 func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clusterPodPlacementConfig *multiarchv1beta1.ClusterPodPlacementConfig) error {
 	log := ctrllog.FromContext(ctx)
@@ -412,53 +481,26 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 		log.Error(err, "Unable to ensure namespace labels")
 		return errorutils.NewAggregate([]error{err, r.updateStatus(ctx, clusterPodPlacementConfig)})
 	}
-	requiredSCCHostmountAnyUID, seLinuxOptionsType, err := r.getCorrectHostmountAnyUIDSCC(ctx)
+	clusterPodPlacementConfigObjects, err := r.buildPodPlacementConfigObjects(clusterPodPlacementConfig, ctx)
 	if err != nil {
-		log.Error(err, "Unable to set correct hostmount SCC", "requiredSCCHostmoundAnyUID", requiredSCCHostmountAnyUID)
-		return errorutils.NewAggregate([]error{err, r.updateStatus(ctx, clusterPodPlacementConfig)})
+		return err
 	}
-	objects := []client.Object{
-		// The finalizer will not affect the reconciliation of ReplicaSets and Pods
-		// when updates to the ClusterPodPlacementConfig are made.
-		buildService(utils.PodPlacementControllerName),
-		buildService(utils.PodPlacementWebhookName),
-		buildClusterRoleController(), buildClusterRoleWebhook(), buildRoleController(),
-		buildServiceAccount(utils.PodPlacementWebhookName), buildServiceAccount(utils.PodPlacementControllerName),
-		buildClusterRoleBinding(utils.PodPlacementControllerName, rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     clusterRoleKind,
-			Name:     utils.PodPlacementControllerName,
-		}, []rbacv1.Subject{
-			{
-				Kind:      serviceAccountKind,
-				Name:      utils.PodPlacementControllerName,
-				Namespace: utils.Namespace(),
-			},
-		}),
-		buildRoleBinding(utils.PodPlacementControllerName, rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     roleKind,
-			Name:     utils.PodPlacementControllerName,
-		}, []rbacv1.Subject{
-			{
-				Kind: serviceAccountKind,
-				Name: utils.PodPlacementControllerName,
-			},
-		}),
-		buildClusterRoleBinding(utils.PodPlacementWebhookName, rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     clusterRoleKind,
-			Name:     utils.PodPlacementWebhookName,
-		}, []rbacv1.Subject{
-			{
-				Kind:      serviceAccountKind,
-				Name:      utils.PodPlacementWebhookName,
-				Namespace: utils.Namespace(),
-			},
-		}),
-		buildControllerDeployment(clusterPodPlacementConfig, requiredSCCHostmountAnyUID, seLinuxOptionsType),
-		buildWebhookDeployment(clusterPodPlacementConfig),
+
+	execFormatErrorObjects := []client.Object{}
+	if clusterPodPlacementConfig.Spec.Plugins != nil && clusterPodPlacementConfig.Spec.Plugins.ExecFormatErrorMonitor != nil && clusterPodPlacementConfig.Spec.Plugins.ExecFormatErrorMonitor.IsEnabled() {
+		execFormatErrorObjects, err = r.buildENoExecEventObjects(ctx, clusterPodPlacementConfig)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := r.handleEnoexecDelete(ctx)
+		if err != nil {
+			return err
+		}
 	}
+
+	objects := append(clusterPodPlacementConfigObjects, execFormatErrorObjects...)
+
 	// We ensure the MutatingWebHookConfiguration is created and present only if the operand is ready to serve the admission request and add/remove the scheduling gate.
 	shouldEnsureMWC := clusterPodPlacementConfig.Status.CanDeployMutatingWebhook()
 	shouldDeleteMWC := !shouldEnsureMWC && !clusterPodPlacementConfig.Status.IsMutatingWebhookConfigurationNotAvailable()
@@ -528,6 +570,142 @@ func (r *ClusterPodPlacementConfigReconciler) updateStatus(ctx context.Context, 
 	return err
 }
 
+func (r *ClusterPodPlacementConfigReconciler) buildPodPlacementConfigObjects(clusterPodPlacementConfig *multiarchv1beta1.ClusterPodPlacementConfig, ctx context.Context) ([]client.Object, error) {
+	log := ctrllog.FromContext(ctx)
+
+	requiredSCCHostmountAnyUID, seLinuxOptionsType, err := r.getCorrectHostmountAnyUIDSCC(ctx)
+	if err != nil {
+		log.Error(err, "Unable to set correct hostmount SCC", "requiredSCCHostmoundAnyUID", requiredSCCHostmountAnyUID)
+		return []client.Object{}, errorutils.NewAggregate([]error{err, r.updateStatus(ctx, clusterPodPlacementConfig)})
+	}
+	objects := []client.Object{
+		// The finalizer will not affect the reconciliation of ReplicaSets and Pods
+		// when updates to the ClusterPodPlacementConfig are made.
+		buildService(utils.PodPlacementControllerName),
+		buildService(utils.PodPlacementWebhookName),
+		buildClusterRoleController(), buildClusterRoleWebhook(), buildRoleController(),
+		buildServiceAccount(utils.PodPlacementWebhookName), buildServiceAccount(utils.PodPlacementControllerName),
+		buildClusterRoleBinding(utils.PodPlacementControllerName, rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     clusterRoleKind,
+			Name:     utils.PodPlacementControllerName,
+		}, []rbacv1.Subject{
+			{
+				Kind:      serviceAccountKind,
+				Name:      utils.PodPlacementControllerName,
+				Namespace: utils.Namespace(),
+			},
+		}),
+		buildRoleBinding(utils.PodPlacementControllerName, rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     roleKind,
+			Name:     utils.PodPlacementControllerName,
+		}, []rbacv1.Subject{
+			{
+				Kind: serviceAccountKind,
+				Name: utils.PodPlacementControllerName,
+			},
+		}),
+		buildClusterRoleBinding(utils.PodPlacementWebhookName, rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     clusterRoleKind,
+			Name:     utils.PodPlacementWebhookName,
+		}, []rbacv1.Subject{
+			{
+				Kind:      serviceAccountKind,
+				Name:      utils.PodPlacementWebhookName,
+				Namespace: utils.Namespace(),
+			},
+		}),
+		buildControllerDeployment(clusterPodPlacementConfig, requiredSCCHostmountAnyUID, seLinuxOptionsType),
+		buildWebhookDeployment(clusterPodPlacementConfig),
+	}
+	return objects, nil
+}
+
+// buildENoExecEventObjects if the ExecFormatErrorMonitor plugin is enabled create the deployment to start the controller
+// if it does not already exist
+func (r *ClusterPodPlacementConfigReconciler) buildENoExecEventObjects(ctx context.Context, clusterPodPlacementConfig *multiarchv1beta1.ClusterPodPlacementConfig) ([]client.Object, error) {
+	log := ctrllog.FromContext(ctx)
+	logVerbosityLevel := clusterPodPlacementConfig.Spec.LogVerbosity.ToZapLevelInt()
+
+	log.Info("Starting ENoExecEvent Controller")
+	objects := []client.Object{
+		buildServiceAccount(utils.EnoexecControllerName),
+		buildServiceAccount(utils.EnoexecDaemonSet),
+
+		// Then Roles and ClusterRoles
+		buildClusterRoleENoExecEventsController(),
+		buildRoleENoExecEventController(),
+		buildClusterRoleENoExecEventsDaemonSet(),
+		buildRoleENoExecEventDaemonSet(),
+
+		buildClusterRoleBinding(
+			utils.EnoexecControllerName,
+			rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     clusterRoleKind,
+				Name:     utils.EnoexecControllerName,
+			},
+			[]rbacv1.Subject{
+				{
+					Kind:      serviceAccountKind,
+					Name:      utils.EnoexecControllerName,
+					Namespace: utils.Namespace(),
+				},
+			},
+		),
+		buildRoleBinding(
+			utils.EnoexecControllerName,
+			rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     roleKind,
+				Name:     utils.EnoexecControllerName,
+			},
+			[]rbacv1.Subject{
+				{
+					Kind:      serviceAccountKind,
+					Name:      utils.EnoexecControllerName,
+					Namespace: utils.Namespace(),
+				},
+			},
+		),
+		buildClusterRoleBinding(
+			utils.EnoexecDaemonSet,
+			rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     clusterRoleKind,
+				Name:     utils.EnoexecDaemonSet,
+			},
+			[]rbacv1.Subject{
+				{
+					Kind:      serviceAccountKind,
+					Name:      utils.EnoexecDaemonSet,
+					Namespace: utils.Namespace(),
+				},
+			},
+		),
+		buildRoleBinding(
+			utils.EnoexecDaemonSet,
+			rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     roleKind,
+				Name:     utils.EnoexecDaemonSet,
+			},
+			[]rbacv1.Subject{
+				{
+					Kind:      serviceAccountKind,
+					Name:      utils.EnoexecDaemonSet,
+					Namespace: utils.Namespace(),
+				},
+			},
+		),
+		buildDeploymentENoExecEventHandler(logVerbosityLevel),
+		buildDaemonSetENoExecEvent(utils.EnoexecDaemonSet, utils.EnoexecDaemonSet, logVerbosityLevel),
+	}
+	return objects, nil
+}
+
 func isDeploymentAvailable(deployment *appsv1.Deployment) bool {
 	if deployment == nil {
 		return false
@@ -556,6 +734,7 @@ func (r *ClusterPodPlacementConfigReconciler) SetupWithManager(mgr ctrl.Manager)
 	c := ctrl.NewControllerManagedBy(mgr).
 		For(&multiarchv1beta1.ClusterPodPlacementConfig{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&appsv1.DaemonSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).

--- a/controllers/operator/enoexecevent_objects.go
+++ b/controllers/operator/enoexecevent_objects.go
@@ -1,0 +1,216 @@
+package operator
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
+)
+
+func buildClusterRoleENoExecEventsController() *rbacv1.ClusterRole {
+	return buildClusterRole(utils.EnoexecControllerName, []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods", "nodes"},
+			Verbs:     []string{LIST, GET},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{CREATE, PATCH},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods", "pods/status"},
+			Verbs:     []string{UPDATE},
+		},
+	})
+}
+
+func buildRoleENoExecEventController() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.EnoexecControllerName,
+			Namespace: utils.Namespace(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{v1beta1.GroupVersion.Group},
+				Resources: []string{v1beta1.ENoExecEventResource},
+				Verbs:     []string{LIST, WATCH, GET, UPDATE, PATCH, CREATE, DELETE},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{LIST, WATCH, GET, UPDATE, PATCH, CREATE, DELETE},
+			},
+			{
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+				Verbs:     []string{LIST, WATCH, GET, UPDATE, PATCH, CREATE, DELETE},
+			},
+		},
+	}
+}
+
+func buildClusterRoleENoExecEventsDaemonSet() *rbacv1.ClusterRole {
+	return buildClusterRole(utils.EnoexecDaemonSet, []rbacv1.PolicyRule{
+		{
+			APIGroups:     []string{"security.openshift.io"},
+			Resources:     []string{"securitycontextconstraints"},
+			ResourceNames: []string{"privileged"},
+			Verbs:         []string{USE},
+		},
+	})
+}
+
+func buildRoleENoExecEventDaemonSet() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.EnoexecDaemonSet,
+			Namespace: utils.Namespace(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{v1beta1.GroupVersion.Group},
+				Resources: []string{v1beta1.ENoExecEventResource},
+				Verbs:     []string{GET, CREATE},
+			},
+			{
+				APIGroups: []string{v1beta1.GroupVersion.Group},
+				Resources: []string{v1beta1.ENoExecEventResource + "/status"},
+				Verbs:     []string{UPDATE},
+			},
+		},
+	}
+}
+
+// buildDaemonSet returns the DaemonSet object for ENoExecEvent
+func buildDaemonSetENoExecEvent(serviceAccount string, name string, logVerbosity int, args ...string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.EnoexecDaemonSet,
+			Namespace: utils.Namespace(),
+			Labels: map[string]string{
+				"app": utils.EnoexecDaemonSet,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": utils.EnoexecDaemonSet,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": utils.EnoexecDaemonSet,
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName:           serviceAccount,
+					AutomountServiceAccountToken: utils.NewPtr(true),
+					HostPID:                      true,
+					Containers: []corev1.Container{
+						{
+							Name:            name,
+							Image:           utils.Image(),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+
+							Args: args,
+							Command: []string{
+								"/enoexec-daemon",
+								fmt.Sprintf("--initial-log-level=%d",
+									logVerbosity),
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "metadata.namespace",
+										},
+									},
+								},
+								{
+									Name: "NODE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "spec.nodeName",
+										},
+									},
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: utils.NewPtr(true),
+								// The bpftrace tool requires root privileges to interact with the kernel.
+								RunAsUser:              utils.NewPtr(int64(0)),
+								ReadOnlyRootFilesystem: utils.NewPtr(true),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "debugfs",
+									MountPath: "/sys/kernel/debug",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "tracingfs",
+									MountPath: "/sys/kernel/tracing",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "crio",
+									MountPath: "/var/run/crio/crio.sock",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "debugfs",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/sys/kernel/debug",
+									Type: utils.NewPtr(corev1.HostPathDirectory),
+								},
+							},
+						},
+						{
+							Name: "tracingfs",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/sys/kernel/tracing",
+									Type: utils.NewPtr(corev1.HostPathDirectory),
+								},
+							},
+						},
+						{
+							Name: "crio",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/run/crio/crio.sock",
+									Type: utils.NewPtr(corev1.HostPathSocket),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildEnoexecDeployment returns a minimal Deployment object matching your YAML
+func buildDeploymentENoExecEventHandler(logVerbosity int) *appsv1.Deployment {
+	return buildDeployment(logVerbosity, utils.EnoexecControllerName, 2, utils.EnoexecControllerName, "",
+		"--leader-elect", "--enable-enoexec-event-controllers",
+	)
+}

--- a/pkg/testing/builder/pod_spec.go
+++ b/pkg/testing/builder/pod_spec.go
@@ -49,6 +49,22 @@ func (ps *PodSpecBuilder) WithContainers(containers ...*v1.Container) *PodSpecBu
 	return ps
 }
 
+func (ps *PodSpecBuilder) WithCommand(command ...string) *PodSpecBuilder {
+	if len(ps.podspec.Containers) == 0 {
+		panic("cannot set command on a podspec with no containers; call WithContainersImages first")
+	}
+	ps.podspec.Containers[0].Command = command
+	return ps
+}
+
+func (ps *PodSpecBuilder) WithArgs(args ...string) *PodSpecBuilder {
+	if len(ps.podspec.Containers) == 0 {
+		panic("cannot set args on a podspec with no containers; call WithContainersImages first")
+	}
+	ps.podspec.Containers[0].Args = args
+	return ps
+}
+
 func (ps *PodSpecBuilder) WithRestartPolicy(restartPolicy v1.RestartPolicy) *PodSpecBuilder {
 	ps.podspec.RestartPolicy = restartPolicy
 	return ps

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -59,6 +59,8 @@ const (
 	False                      = "false"
 	ExecFormatErrorEventReason = "ExecFormatError"
 	UnknownContainer           = "unknown-container" // Used when the container name is not known or not provided
+	EnoexecControllerName      = "enoexec-event-handler-controller"
+	EnoexecDaemonSet           = "enoexec-event-daemon"
 )
 
 func AllSupportedArchitecturesSet() sets.Set[string] {

--- a/pkg/utils/resource.go
+++ b/pkg/utils/resource.go
@@ -67,6 +67,8 @@ func ApplyResource(ctx context.Context, clientSet *kubernetes.Clientset, client 
 	switch t := obj.(type) {
 	case *appsv1.Deployment:
 		return resourceapply.ApplyDeployment(ctx, clientSet.AppsV1(), recorder, t, 0)
+	case *appsv1.DaemonSet:
+		return resourceapply.ApplyDaemonSet(ctx, clientSet.AppsV1(), recorder, t, 0)
 	case *corev1.Service:
 		return applyService(ctx, clientSet.CoreV1(), recorder, t)
 	case *admissionv1.MutatingWebhookConfiguration:


### PR DESCRIPTION
depends on https://github.com/outrigger-project/multiarch-tuning-operator/pull/648, https://github.com/outrigger-project/multia

When the `execFormatErrorMonitor` plugin is enabled via the ClusterPodPlacementConfig, the operator now deploys and manages the necessary components to monitor, handle, and report on executable format errors.

Key Changes:

- ENOEXEC Controller: A new controller is enabled to manage the lifecycle of the custom resource `execFormatErrorMonitor` 
- DaemonSet and Deployment: 
     - ` enoexec-event-daemon` (DaemonSet): Deployed on each node. This DaemonSet runs as a privileged container in order to load an eBPF program that detects ENOEXEC errors and creates an ENoExecEvent custom resource
     - ` enoexec-event-handler` (Deployment): Consumes ENoExecEvent resources and creates corresponding Kubernetes events on the affected pods.
- RBAC Implementation: Creates dedicated ServiceAccounts for the daemon and the handler. Implements the necessary ClusterRoles, Roles, ClusterRoleBindings, and RoleBindings to grant the precise permissions required for each component, as outlined in the design. This includes permissions for the daemon to create ENoExecEvent resources and for the handler to read them and update pods cluster-wide.

Main Function Flags: The operator's main.go has been updated to include the flag `enable-enoexec-event-controllers` to enable and configure the new controller. 

Known Issues: A race condition can occur when deleting resources. If the Enoexexc CR still exists and the objects get deleted 