### PR TITLE
MULTIARCH-5419: enoexec eBPF program

### DIFF
--- a/controllers/enoexecevent/daemon/daemon.go
+++ b/controllers/enoexecevent/daemon/daemon.go
@@ -33,11 +33,11 @@ func RunDaemon(ctx context.Context, cancel context.CancelFunc) error {
 	maxEvents := 256
 	// The buffer size has to be a multiple of the page size.
 	// We calculate the required buffer size based on the maximum number of events as
-	// size_max = maxEvents * 32 [bytes].
+	// size_max = maxEvents * 24 [bytes].
 	// We obtain the number of pages required to store the events rounding up the number of pages required
 	// to store size_max bytes: required_pages = Ceil(size_max [bytes] / pageSize [bytes]).
 	// Finally, we multiply required_pages by the page size to get the buffer size.
-	bufferSize := pageSize * uint32(math.Ceil(float64(maxEvents*32)/float64(pageSize)))
+	bufferSize := pageSize * uint32(math.Ceil(float64(maxEvents*24)/float64(pageSize)))
 
 	log.Info("Buffer size calculated", "buffer_size", bufferSize, "page_size", pageSize, "max_events", maxEvents)
 

--- a/controllers/enoexecevent/daemon/daemon.go
+++ b/controllers/enoexecevent/daemon/daemon.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"sync"
 	"time"
@@ -21,40 +20,29 @@ func RunDaemon(ctx context.Context, cancel context.CancelFunc) error {
 	if err != nil {
 		return fmt.Errorf("failed to get logger from context: %w", err)
 	}
-
-	// Buffer Size must be a multiple of page size
-	if os.Getpagesize() <= 0 {
-		return fmt.Errorf("invalid page size")
-	}
-	pageSize := uint32(os.Getpagesize()) // [bytes]
-	// The payload is 8 bytes. Other 8 bytes are used for the header.
-	// 16 [bytes/event].
-	payloadSize := tracepoint.PayloadSize + 8
-	// See https://github.com/outrigger-project/multiarch-tuning-operator/blob/eabed5c4e54/enhancements/MTO-0004-enoexec-monitoring.md
-	maxEvents := 256
-	// The buffer size has to be a multiple of the page size.
-	// We calculate the required buffer size based on the maximum number of events as
-	// size_max = maxEvents * 8 [bytes].
-	// We obtain the number of pages required to store the events rounding up the number of pages required
-	// to store size_max bytes: required_pages = Ceil(size_max [bytes] / pageSize [bytes]).
-	// Finally, we multiply required_pages by the page size to get the buffer size.
-	bufferSize := pageSize * uint32(math.Ceil(float64(maxEvents*payloadSize)/float64(pageSize)))
-
-	log.Info("Buffer size calculated", "buffer_size", bufferSize, "page_size", pageSize, "max_events", maxEvents)
+	var (
+		maxEvents uint32     = 256
+		rateLimit rate.Limit = 5
+		burst                = 10
+		timeout              = time.Minute
+	)
 
 	log.Info("Initializing channel")
 	ch := make(chan *types.ENOEXECInternalEvent, maxEvents)
 
-	log.Info("Initializing storage")
-	storageImpl, err := storage.NewK8sENOExecEventStorage(ctx,
-		rate.NewLimiter(5, 10), ch, os.Getenv("NODE_NAME"), os.Getenv("NAMESPACE"), time.Minute,
-	)
+	nodeName := os.Getenv("NODE_NAME")
+	namespace := os.Getenv("NAMESPACE")
+
+	log.Info("Initializing storage", "node_name", nodeName, "namespace", namespace,
+		"rate limit", rateLimit, "burst", burst, "timeout", timeout)
+	storageImpl, err := storage.NewK8sENOExecEventStorage(
+		ctx, rate.NewLimiter(rateLimit, burst), ch, nodeName, namespace, timeout)
 	if err != nil {
 		return fmt.Errorf("failed to create storage: %w", err)
 	}
 
-	log.Info("Initializing tracepoint", "buffer_size", bufferSize)
-	tp, err := tracepoint.NewTracepoint(ctx, ch, bufferSize)
+	log.Info("Initializing tracepoint")
+	tp, err := tracepoint.NewTracepoint(ctx, ch, maxEvents)
 	if err != nil {
 		return fmt.Errorf("failed to create tracepoint: %w", err)
 	}

--- a/controllers/enoexecevent/daemon/daemon.go
+++ b/controllers/enoexecevent/daemon/daemon.go
@@ -27,17 +27,18 @@ func RunDaemon(ctx context.Context, cancel context.CancelFunc) error {
 		return fmt.Errorf("invalid page size")
 	}
 	pageSize := uint32(os.Getpagesize()) // [bytes]
-	// The payload is 24 bytes. Other 8 bytes are used for the header.
-	// 32 [bytes/event].
+	// The payload is 8 bytes. Other 8 bytes are used for the header.
+	// 16 [bytes/event].
+	payloadSize := tracepoint.PayloadSize + 8
 	// See https://github.com/outrigger-project/multiarch-tuning-operator/blob/eabed5c4e54/enhancements/MTO-0004-enoexec-monitoring.md
 	maxEvents := 256
 	// The buffer size has to be a multiple of the page size.
 	// We calculate the required buffer size based on the maximum number of events as
-	// size_max = maxEvents * 24 [bytes].
+	// size_max = maxEvents * 8 [bytes].
 	// We obtain the number of pages required to store the events rounding up the number of pages required
 	// to store size_max bytes: required_pages = Ceil(size_max [bytes] / pageSize [bytes]).
 	// Finally, we multiply required_pages by the page size to get the buffer size.
-	bufferSize := pageSize * uint32(math.Ceil(float64(maxEvents*24)/float64(pageSize)))
+	bufferSize := pageSize * uint32(math.Ceil(float64(maxEvents*payloadSize)/float64(pageSize)))
 
 	log.Info("Buffer size calculated", "buffer_size", bufferSize, "page_size", pageSize, "max_events", maxEvents)
 

--- a/controllers/enoexecevent/daemon/internal/storage/k8s_enoexecevent.go
+++ b/controllers/enoexecevent/daemon/internal/storage/k8s_enoexecevent.go
@@ -83,7 +83,7 @@ func (s *K8sENOExecEventStorage) Run() error {
 		_, _ = fmt.Fprintln(os.Stderr, "Failed to get logger:", err)
 		return fmt.Errorf("failed to get logger from context: %w", err)
 	}
-	defer utils.ShouldStdErr(s.close())
+	defer utils.ShouldStdErr(s.close)
 
 	for {
 		select {

--- a/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint.go
+++ b/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint.go
@@ -29,7 +29,6 @@ type Tracepoint struct {
 
 	tgidOffset       *int32
 	realParentOffset *int32
-	commOffset       *int32
 	bufferSize       uint32 // Size of the ring buffer in bytes
 
 	ch chan *types.ENOEXECInternalEvent
@@ -175,7 +174,6 @@ func (tp *Tracepoint) processRecord(record *ringbuf.Record) (*types.ENOEXECInter
 	}
 	realParentTGID := int32(order.Uint32(record.RawSample[:4]))
 	currentTaskTGID := int32(order.Uint32(record.RawSample[4:8]))
-	commandName := string(record.RawSample[8:])
 	log.V(4).Info("Processing record",
 		"real_parent_tgid", realParentTGID, "current_task_tgid", currentTaskTGID)
 	for _, pid := range []int32{currentTaskTGID, realParentTGID} {
@@ -203,7 +201,6 @@ func (tp *Tracepoint) processRecord(record *ringbuf.Record) (*types.ENOEXECInter
 			PodName:      podName,
 			PodNamespace: podNamespace,
 			ContainerID:  containerUUID,
-			ProcessName:  commandName,
 		}, nil
 	}
 	return nil, fmt.Errorf("failed to find pod/container UUIDs in record: %v", record) // No pod/container found

--- a/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint.go
+++ b/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint.go
@@ -127,14 +127,14 @@ func (tp *Tracepoint) Run() error {
 		return errors.Join(fmt.Errorf("failed to attach tracepoint: %w", err),
 			tp.close())
 	}
-	defer utils.ShouldStdErr(tp.close())
+	defer utils.ShouldStdErr(tp.close)
 
 	log.Info("Allocate Ring buffer reader")
 	rd, err := ringbuf.NewReader(tp.events)
 	if err != nil {
 		return errors.Join(fmt.Errorf("failed to create ring buffer reader: %w", err), tp.close())
 	}
-	defer utils.ShouldStdErr(rd.Close())
+	defer utils.ShouldStdErr(rd.Close)
 
 	// Start a goroutine to monitor the context and close the tracepoint when the context is done
 	// This is useful for graceful shutdowns and to unblock the main loop from the blocking rd.Read()

--- a/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint.go
+++ b/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint.go
@@ -29,6 +29,7 @@ type Tracepoint struct {
 
 	tgidOffset       *int32
 	realParentOffset *int32
+	commOffset       *int32
 	bufferSize       uint32 // Size of the ring buffer in bytes
 
 	ch chan *types.ENOEXECInternalEvent

--- a/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_helpers.go
+++ b/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_helpers.go
@@ -110,10 +110,10 @@ func (tp *Tracepoint) initializeOffsets() error {
 	}
 	var realParentOffset, tgidOffset int32
 	const (
-		realParentFound = 1 << 0
-		tgidFound       = 1 << 1
+		realParentFound uint8 = 1 << 0
+		tgidFound       uint8 = 1 << 1
 	)
-	var foundFlags uint32
+	var foundFlags uint8
 	for _, member := range taskStruct.Members {
 		if member.Name == "real_parent" {
 			realParentOffset = int32(member.Offset.Bytes())
@@ -125,7 +125,7 @@ func (tp *Tracepoint) initializeOffsets() error {
 		}
 
 	}
-	if foundFlags != (realParentFound | tgidFound) {
+	if foundFlags != uint8(realParentFound|tgidFound) {
 		return fmt.Errorf("failed to find real_parent or tgid in task_struct")
 	}
 	tp.realParentOffset = &realParentOffset

--- a/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_helpers.go
+++ b/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_helpers.go
@@ -108,11 +108,10 @@ func (tp *Tracepoint) initializeOffsets() error {
 	if !ok {
 		return fmt.Errorf("task_struct is not a struct")
 	}
-	var realParentOffset, tgidOffset, commOffset int32
+	var realParentOffset, tgidOffset int32
 	const (
 		realParentFound = 1 << 0
 		tgidFound       = 1 << 1
-		commFound       = 1 << 2
 	)
 	var foundFlags uint32
 	for _, member := range taskStruct.Members {
@@ -125,16 +124,11 @@ func (tp *Tracepoint) initializeOffsets() error {
 			foundFlags |= tgidFound
 		}
 
-		if member.Name == "comm" {
-			commOffset = int32(member.Offset.Bytes())
-			foundFlags |= commFound
-		}
 	}
-	if foundFlags != (realParentFound | tgidFound | commFound) {
-		return fmt.Errorf("failed to find real_parent, tgid or comm in task_struct")
+	if foundFlags != (realParentFound | tgidFound) {
+		return fmt.Errorf("failed to find real_parent or tgid in task_struct")
 	}
 	tp.realParentOffset = &realParentOffset
 	tp.tgidOffset = &tgidOffset
-	tp.commOffset = &commOffset
 	return nil
 }

--- a/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_helpers.go
+++ b/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_helpers.go
@@ -31,7 +31,7 @@ func getPodContainerUUIDFor(pid int32) (string, string, error) {
 	if err != nil {
 		return "", "", fmt.Errorf("failed to open %s: %w", cgroupPath, err)
 	}
-	defer utils.ShouldStdErr(file.Close())
+	defer utils.ShouldStdErr(file.Close)
 	scanner := bufio.NewScanner(file)
 	var out string
 	for scanner.Scan() {
@@ -76,7 +76,7 @@ func getPodNameFromUUID(ctx context.Context, uid string) (string, string, error)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to connect to CRI socket: %w", err)
 	}
-	defer utils.ShouldStdErr(cri.Close())
+	defer utils.ShouldStdErr(cri.Close)
 	criClient := runtimeapi.NewRuntimeServiceClient(cri)
 	pods, err := criClient.ListPodSandbox(ctx, &runtimeapi.ListPodSandboxRequest{})
 	if err != nil {

--- a/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_program.go
+++ b/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_program.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	ExitLabel    = "exit"
-	CleanupLabel = "cleanup"
-	PayloadSize  = 8 // [bytes]
+	ExitLabel           = "exit"
+	CleanupLabel        = "cleanup"
+	PayloadSize  uint32 = 8 // [bytes]
 )
 
 // https://stackoverflow.com/questions/9305992/if-threads-share-the-same-pid-how-can-they-be-identified
@@ -136,12 +136,12 @@ func ringBufReserve(fd int) asm.Instructions {
 	// R2: size of the event to reserve (24 bytes)
 	// R3: flags (must be 0)
 	return asm.Instructions{
-		asm.LoadMapPtr(asm.R1, fd),        // FD of ring buffer map
-		asm.Mov.Imm(asm.R2, PayloadSize),  // Size of the event to reserve (8 bytes)
-		asm.Mov.Imm(asm.R3, 0),            // Flags must be 0
-		asm.FnRingbufReserve.Call(),       // Reserve space in the ring buffer
-		asm.JEq.Imm(asm.R0, 0, ExitLabel), // If reserve fails, exit
-		asm.Mov.Reg(asm.R7, asm.R0),       // The address of the reserved space is stored in R7
+		asm.LoadMapPtr(asm.R1, fd),              // FD of ring buffer map
+		asm.Mov.Imm(asm.R2, int32(PayloadSize)), // Size of the event to reserve (8 bytes)
+		asm.Mov.Imm(asm.R3, 0),                  // Flags must be 0
+		asm.FnRingbufReserve.Call(),             // Reserve space in the ring buffer
+		asm.JEq.Imm(asm.R0, 0, ExitLabel),       // If reserve fails, exit
+		asm.Mov.Reg(asm.R7, asm.R0),             // The address of the reserved space is stored in R7
 	}
 }
 

--- a/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_program.go
+++ b/controllers/enoexecevent/daemon/internal/tracepoint/tracepoint_program.go
@@ -2,9 +2,57 @@ package tracepoint
 
 import (
 	"fmt"
-
 	"github.com/cilium/ebpf/asm"
 )
+
+const (
+	ExitLabel    = "exit"
+	CleanupLabel = "cleanup"
+)
+
+// https://stackoverflow.com/questions/9305992/if-threads-share-the-same-pid-how-can-they-be-identified
+//                          USER VIEW
+//                         vvvv vvvv
+//              |
+//<-- PID 43 -->|<----------------- PID 42 ----------------->
+//              |                           |
+//              |      +---------+          |
+//              |      | process |          |
+//              |     _| pid=42  |_         |
+//         __(fork) _/ | tgid=42 | \_ (new thread) _
+//        /     |      +---------+          |       \
+//+---------+   |                           |    +---------+
+//| process |   |                           |    | process |
+//| pid=43  |   |                           |    | pid=44  |
+//| tgid=43 |   |                           |    | tgid=42 |
+//+---------+   |                           |    +---------+
+//              |                           |
+//<-- PID 43 -->|<--------- PID 42 -------->|<--- PID 44 --->
+//              |                           |
+//                        ^^^^^^ ^^^^
+//                        KERNEL VIEW
+
+// https://www.kernel.org/doc/html/latest/trace/events.html
+// Load syscall return value (args->ret)
+// └ # cat /sys/kernel/debug/tracing/events/syscalls/sys_exit_execve/format
+//  name: sys_exit_execve
+//  ID: 869
+//  format:
+//        field:unsigned short common_type;       	offset:0;       size:2; signed:0;
+//        field:unsigned char common_flags;       	offset:2;       size:1; signed:0;
+//        field:unsigned char common_preempt_count; offset:3;       size:1; signed:0;
+//        field:int common_pid;   					offset:4;       size:4; signed:1;
+//
+//        field:int __syscall_nr; 					offset:8;       size:4; signed:1;
+//        field:long ret; 							offset:16;      size:8; signed:1;
+//                                V
+//print fmt: "0x%lx", REC->ret    V
+
+// https://www.kernel.org/doc/html/v5.17/bpf/instruction-set.html
+// R0: return value from function calls, and exit value for eBPF programs
+// R1 - R5: arguments for function calls
+// R6 - R9: callee saved registers that function calls will preserve
+// R10: read-only frame pointer to access stack
 
 // initializeProgSpec initializes the eBPF program for the tracepoint.
 // It must be called after the offsets are set.
@@ -18,43 +66,171 @@ func (tp *Tracepoint) initializeProgSpec() error {
 		return fmt.Errorf("tgidOffset or realParentOffset is not set")
 	}
 
-	tp.progSpec.Instructions = asm.Instructions{
-		// https://www.kernel.org/doc/html/v5.17/bpf/instruction-set.html
-		// R0: return value from function calls, and exit value for eBPF programs
-		// R1 - R5: arguments for function calls
-		// R6 - R9: callee saved registers that function calls will preserve
-		// R10: read-only frame pointer to access stack
-
-		// https://www.kernel.org/doc/html/latest/trace/events.html
-		// Load syscall return value (args->ret)
-		// └ # cat /sys/kernel/debug/tracing/events/syscalls/sys_exit_execve/format
-		//  name: sys_exit_execve
-		//  ID: 869
-		//  format:
-		//        field:unsigned short common_type;       	offset:0;       size:2; signed:0;
-		//        field:unsigned char common_flags;       	offset:2;       size:1; signed:0;
-		//        field:unsigned char common_preempt_count; offset:3;       size:1; signed:0;
-		//        field:int common_pid;   					offset:4;       size:4; signed:1;
-		//
-		//        field:int __syscall_nr; 					offset:8;       size:4; signed:1;
-		//        field:long ret; 							offset:16;      size:8; signed:1;
-		//                                V
-		//print fmt: "0x%lx", REC->ret    V
-
+	tp.progSpec.Instructions = asm.Instructions{}
+	for _, ins := range []asm.Instructions{
 		// Registers mapping:
 		// R6: current task's task_struct
 		// R7: ring buffer event pointer
 		// R8: real_parent task_struct
+		jExitIfNoENOEXEC(),
+		getCurrentTask(),
+		// *** R6 = current task_struct
+		ringBufReserve(tp.events.FD()),
+		// *** R7 = ring buffer event pointer (reserved space)
 
-		// Verify that the syscall returned ENOEXEC (-8) or jump to exit
-		asm.LoadMem(asm.R0, asm.R1, 16, asm.DWord),
-		asm.JNE.Imm(asm.R0, -8, "exit"),
+		// Load the TGID of the current task (a 4 bytes word)
+		// from R6 + tgidOffset into the ring buffer's second 4 bytes
+		loadIntoRingBufEvent(asm.R6, *tp.tgidOffset, 4, 4),
 
-		// TODO: implement the logic to handle the event
+		loadRealParent(*tp.realParentOffset),
+		// *** R8 = real_parent task_struct pointer
 
-		// exit
-		asm.Mov.Imm(asm.R0, 0).WithSymbol("exit"),
-		asm.Return(),
+		// Load the TGID of the real_parent task (a 4 bytes word)
+		// from R8 + tgidOffset into the ring buffer's first 4 bytes
+		loadIntoRingBufEvent(asm.R8, *tp.tgidOffset, 4, 0),
+
+		// Load process name (comm) into ring buffer event at offset 8
+		loadIntoRingBufEvent(asm.R6, *tp.commOffset, 16, 8),
+
+		submitEvent(),
+		// Discard the reserved space in the ring buffer if submit failed.
+		// rollbackEvent() is skipped if submit succeeded with a jump to exit().
+		rollbackEvent(),
+		// Exit the eBPF program with a return value of 0.
+		exit(),
+	} {
+		tp.progSpec.Instructions = append(tp.progSpec.Instructions, ins...)
 	}
 	return nil
+}
+
+// jExitIfNoENOEXEC checks if the syscall return value is ENOEXEC (-8).
+// if it is not, it jumps to the exit label.
+// https://www.kernel.org/doc/man-pages/online/pages/man2/execve.2.html
+func jExitIfNoENOEXEC() asm.Instructions {
+	return asm.Instructions{
+		asm.LoadMem(asm.R0, asm.R1, 16, asm.DWord),
+		asm.JNE.Imm(asm.R0, -8, "exit"),
+	}
+}
+
+// getCurrentTask retrieves the current task's task_struct pointer.
+// The address of the current task_struct is stored in R6.
+// https://docs.ebpf.io/linux/helper-function/bpf_get_current_task/
+func getCurrentTask() asm.Instructions {
+	return asm.Instructions{
+		asm.FnGetCurrentTask.Call(),
+		// Storing address of the current task_struct in R6
+		asm.Mov.Reg(asm.R6, asm.R0),
+	}
+}
+
+// ringBufReserve reserves space in the ring buffer for the event.
+// It reserves space for the real_parent's TGID, current task's TGID, and the process name.
+// https://docs.ebpf.io/linux/helper-function/bpf_ringbuf_reserve/
+// The reserved space is 24 bytes:
+// sizeof(int32) * 2 [bytes] + 16 [bytes] (for process name)
+// [ real_parent->tgid ][ current->tgid     ]
+// [------4 bytes------][------4 bytes------]
+// [         process name - 16 bytes        ]
+// [---------------- 8 bytes ---------------]
+// [---------------- 8 bytes ---------------]
+func ringBufReserve(fd int) asm.Instructions {
+	// R1: pointer to the ring buffer map
+	// R2: size of the event to reserve (24 bytes)
+	// R3: flags (must be 0)
+	return asm.Instructions{
+		asm.LoadMapPtr(asm.R1, fd), // FD of ring buffer map
+
+		asm.Mov.Imm(asm.R2, 24), // size of the event to reserve (24 bytes)
+		asm.Mov.Imm(asm.R3, 0),  // flags must be 0
+
+		asm.FnRingbufReserve.Call(), // Reserve space in the ring buffer
+
+		asm.JEq.Imm(asm.R0, 0, ExitLabel), // if reserve fails, exit
+		asm.Mov.Reg(asm.R7, asm.R0),       // the address of the reserved space is stored in R7
+	}
+}
+
+// loadIntoRingBufEvent loads data from the source pointer and stores it into the ring buffer event.
+// It reads `size` bytes of data from the Kernel memory address at `srcReg` + `srcOffset`, and
+// writes it to the ring buffer event using the address at R7 with `dstOffset` offset.
+// srcReg is the register containing the source pointer (current task_struct or real_parent task_struct).
+// srcOffset is the offset in the source pointer to read from.
+// size is the number of bytes to read (4 bytes for TGID).
+// dstOffset is the offset in the ring buffer event (R7) to write to.
+// https://docs.ebpf.io/linux/helper-function/bpf_probe_read_kernel/
+func loadIntoRingBufEvent(srcReg asm.Register, srcOffset, size, dstOffset int32) asm.Instructions {
+	// R1: destination pointer (ring buffer)
+	// R2: size of the data to read (4 bytes for TGID)
+	// R3: source pointer (current task_struct)
+	return asm.Instructions{
+		asm.Mov.Reg(asm.R1, asm.R7),    // R7 is the ring buffer event pointer
+		asm.Add.Imm(asm.R1, dstOffset), // Move to the destination offset in the ring buffer
+		asm.Mov.Imm(asm.R2, size),      // Size of data to read
+		asm.Mov.Reg(asm.R3, srcReg),    // Pointer to current task task_struct
+		asm.Add.Imm(asm.R3, srcOffset), // Offset to the data to read in the source
+		asm.FnProbeReadKernel.Call(),
+		// jump to cleanup if bpf_probe_read_kernel failed
+		asm.JNE.Imm(asm.R0, 0, CleanupLabel),
+	}
+}
+
+// loadRealParent loads the real_parent pointer from the current task's task_struct.
+// It reads the real_parent pointer from the task_struct and stores it in R8
+func loadRealParent(offset int32) asm.Instructions {
+	// Load real_parent pointer from task_struct
+	// https://docs.ebpf.io/linux/helper-function/bpf_probe_read_kernel/
+	return asm.Instructions{
+		// Load real_parent pointer into the stack
+		// R1: destination pointer (stack)
+		// R2: size of the data to read (8 bytes for pointer)
+		// R3: source pointer (current task_struct)
+		asm.Mov.Reg(asm.R1, asm.R10), // R10 is the frame pointer to access the stack. dst for bpf_probe_read_kernel
+		asm.Add.Imm(asm.R1, -8),      // offset to the last 8 bytes of the stack
+		asm.Mov.Imm(asm.R2, 8),       // sizeof pointer (__u32 size)
+		asm.Mov.Reg(asm.R3, asm.R6),  // pointer to current task task_struct (unsafe_ptr)
+		asm.Add.Imm(asm.R3, offset),  // offset to real_parent
+		asm.FnProbeReadKernel.Call(),
+		// jump to cleanup if bpf_probe_read_kernel failed
+		asm.JNE.Imm(asm.R0, 0, CleanupLabel),
+		// Load real_parent pointer from stack into R8
+		asm.LoadMem(asm.R8, asm.R10, -8, asm.DWord),
+		// safety check real_parent != NULL
+		asm.JEq.Imm(asm.R8, 0, CleanupLabel),
+	}
+}
+
+// submitEvent submits the event to the ring buffer. This is where the event is sent to the user space
+// after it has been reserved and populated with data from the current task and its real parent.
+func submitEvent() asm.Instructions {
+	// R1: ring buffer event pointer (R7)
+	// R2: flags (must be 0)
+	return asm.Instructions{
+		asm.Mov.Reg(asm.R1, asm.R7),
+		asm.Mov.Imm(asm.R2, 0),
+		asm.FnRingbufSubmit.Call(),
+		asm.Ja.Label(ExitLabel), // jump past cleanup if success
+	}
+}
+
+// rollbackEvent is used to discard the reserved space in the ring buffer when any error occurs while
+// running the eBPF program after the event space has been reserved.
+func rollbackEvent() asm.Instructions {
+	// If the event submission failed, we need to discard the reserved space in the ring buffer.
+	// R1: ring buffer event pointer (R7)
+	// R2: flags (must be 0)
+	return asm.Instructions{
+		asm.Mov.Reg(asm.R1, asm.R7).WithSymbol(CleanupLabel),
+		asm.Mov.Imm(asm.R2, 0),
+		asm.FnRingbufDiscard.Call(),
+	}
+}
+
+// exit exits the eBPF program with a return value of 0.
+func exit() asm.Instructions {
+	return asm.Instructions{
+		asm.Mov.Imm(asm.R0, 0).WithSymbol(ExitLabel), // Set return value to 0
+		asm.Return(),
+	}
 }

--- a/controllers/enoexecevent/daemon/internal/types/event.go
+++ b/controllers/enoexecevent/daemon/internal/types/event.go
@@ -15,7 +15,6 @@ type ENOEXECInternalEvent struct {
 	PodName      string `yaml:"podName,omitempty"`
 	PodNamespace string `yaml:"podNamespace,omitempty"`
 	ContainerID  string `yaml:"containerID,omitempty"`
-	ProcessName  string `yaml:"processName,omitempty"`
 }
 
 // ToENoExecEvent converts the ENOEXECInternalEvent to a multiarchv1beta1.ENOExecEvent that can be stored in Kubernetes.
@@ -30,7 +29,6 @@ func (e *ENOEXECInternalEvent) ToENoExecEvent(namespace string, nodeName string)
 			PodName:      e.PodName,
 			PodNamespace: e.PodNamespace,
 			ContainerID:  e.ContainerID,
-			Command:      "",
 		},
 	}, nil
 }

--- a/docs/enhancements/MTO-0004-enoexec-monitoring.md
+++ b/docs/enhancements/MTO-0004-enoexec-monitoring.md
@@ -244,6 +244,8 @@ In large-scale deployments spanning many nodes, the architecture is intentionall
 
 ### Open Questions
 
+- Is it actually possible to retrieve the name of the process' command that fails to run?
+
 ### Test Plan
 
 #### Unit Testing and Integration Test Suites
@@ -290,14 +292,8 @@ A new section will be added to the Multiarch Tuning Operator documentation to ex
 
 ## Implementation History
 
-In progress:
-  - ENoExecEvent CRD definition: https://github.com/openshift/multiarch-tuning-operator/pull/612, MULTIARCH-5416[^7]
-  - Exec Format Error plugin: https://github.com/openshift/multiarch-tuning-operator/pull/602, MULTIARCH-5420[^8]
-Not Started:
-  - Core controller and implementation logic: MULTIARCH-5417[^9], MULTIARCH-5419[^10], MULTIARCH-5421[^11]
-  - Metrics for ENoExecEvent: MULTIARCH-5418[^12]
-  - Integration and e2e tests: MULTIARCH-5422[^13]
-  - Documentation of feature: MULTIARCH-5423[^14]
+- Started
+- 2025/07/21: The initial implementation will not include the command name. It's still unsure if we can get this information in a reliable way for an already-dead process.
 
 ## Infrastructure Needed
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -29,8 +29,8 @@ func Buckets() []float64 {
 	}
 }
 
-func ShouldStdErr(err error) {
-	if err != nil {
+func ShouldStdErr(fn func() error) {
+	if err := fn(); err != nil {
 		_, _ = os.Stderr.WriteString(err.Error() + "\n")
 	}
 }


### PR DESCRIPTION
This PR implements the eBPF program to catch exec format errors and minor fixes from the initial manual testing.

This is related to, but not blocked by, MULTIARCH-5602.

The command is not being caught because it usually is the name of the process running the command that leads to failure. Therefore, we do not retrieve the failing command name itself, but rather its caller.

Minor fixes and optimizations are also proposed.
