### PR TITLE
NO-JIRA: Prevent webhook panic on partially configured plugins

### DIFF
--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -317,7 +317,7 @@ func (pod *Pod) ensureArchitectureLabels(requirement corev1.NodeSelectorRequirem
 func (pod *Pod) shouldIgnorePod(cppc *v1beta1.ClusterPodPlacementConfig) bool {
 	return utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "kube-") ||
 		pod.Spec.NodeName != "" || pod.HasControlPlaneNodeSelector() || pod.IsFromDaemonSet() ||
-		pod.isNodeSelectorConfiguredForArchitecture() && (cppc.Spec.Plugins == nil ||
+		pod.isNodeSelectorConfiguredForArchitecture() && (cppc.Spec.Plugins == nil || cppc.Spec.Plugins.NodeAffinityScoring == nil ||
 			!cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() || pod.isPreferredAffinityConfiguredForArchitecture())
 }
 

--- a/controllers/podplacement/pod_reconciler.go
+++ b/controllers/podplacement/pod_reconciler.go
@@ -116,7 +116,7 @@ func (r *PodReconciler) processPod(ctx context.Context, pod *Pod) {
 		return
 	}
 
-	if cppc != nil && cppc.Spec.Plugins != nil && cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() {
+	if cppc != nil && cppc.Spec.Plugins != nil && cppc.Spec.Plugins.NodeAffinityScoring != nil && cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() {
 		pod.SetPreferredArchNodeAffinity(cppc)
 	}
 

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -80,7 +80,7 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	log := ctrllog.FromContext(ctx).WithValues("namespace", pod.Namespace, "name", pod.Name)
 
 	cppc := clusterpodplacementconfig.GetClusterPodPlacementConfig()
-	if cppc != nil && cppc.Spec.Plugins != nil && cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() {
+	if cppc != nil && cppc.Spec.Plugins != nil && cppc.Spec.Plugins.NodeAffinityScoring != nil && cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() {
 		pod.EnsureLabel(utils.PreferredNodeAffinityLabel, utils.LabelValueNotSet)
 	}
 	pod.EnsureLabel(utils.NodeAffinityLabel, utils.LabelValueNotSet)


### PR DESCRIPTION
```
message: 'admission webhook "pod-placement-scheduling-gate.multiarch.openshift.io" denied the request: panic: runtime error: invalid memory address or nil pointer dereference [recovered]'
```

A nil pointer dereference could occur in the pod placement webhook when evaluating `cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled()`.

If the ClusterPodPlacementConfig had other plugins enabled but NodeAffinityScoring was nil, the check for cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() would panic.

This commit adds the necessary nil checks to the conditional statement, ensuring the entire struct path is validated before being accessed. This prevents the webhook from panicking and denying pod creation requests.