### PR TITLE
MULTIARCH-5602 Update validation rules for the ENoExecEvent  nodename status

### DIFF
--- a/apis/multiarch/v1beta1/enoexecevent_types.go
+++ b/apis/multiarch/v1beta1/enoexecevent_types.go
@@ -27,13 +27,17 @@ type ENoExecEventSpec struct {
 
 // ENoExecEventStatus defines the observed state of ENoExecEvent
 type ENoExecEventStatus struct {
-	// NodeName must follow the RFC 1123 DNS label format:
-	// - Max length: 63 characters
-	// - Characters: lowercase letters, digits, and hyphens (`-`)
+	// For validating the fields of NodeName and PodName we mimic the functionality of IsDNS1123Subdomain (https://github.com/kubernetes/kubernetes/blob/5be5fd022920e0aa77e29792fffbb5f3690547b3/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L219)
+	// For validating the fields of PodNamespace we  mimic the functionality of IsDNS1123Label (https://github.com/kubernetes/kubernetes/blob/5be5fd022920e0aa77e29792fffbb5f3690547b3/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L188)
+
+	// NodeName must follow the RFC 1123 DNS subdomain format.
+	// - Max length: 253 characters
+	// - Consists of lowercase letters, digits, hyphens (`-`), and dots (`.`)
 	// - Must start and end with an alphanumeric character
-	// Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+	//      https://github.com/kubernetes/kubernetes/blob/b4de8bc1b1095d8f465995521a6986e201812342/pkg/apis/core/validation/validation.go#L273
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	NodeName string `json:"nodeName,omitempty"`
 
 	// PodName must follow the RFC 1123 DNS subdomain format:
@@ -41,17 +45,19 @@ type ENoExecEventStatus struct {
 	// - Characters: lowercase letters, digits, hyphens (`-`), and dots (`.`)
 	// - Must start and end with an alphanumeric character
 	// Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+	//      https://github.com/kubernetes/kubernetes/blob/b4de8bc1b1095d8f465995521a6986e201812342/pkg/apis/core/validation/validation.go#L257
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	PodName string `json:"podName,omitempty"`
 
-	// PodNamespace must follow the RFC 1123 DNS subdomain format (same as PodName)
-	// - Max length: 253 characters
-	// - Characters: lowercase letters, digits, hyphens (`-`), and dots (`.`)
+	// PodNamespace must follow the RFC 1123 DNS label format.
+	// - Max length: 63 characters
+	// - Characters: lowercase letters, digits, and hyphens ('-')
 	// - Must start and end with an alphanumeric character
-	// Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+	//      https://github.com/kubernetes/kubernetes/blob/5be5fd022920e0aa77e29792fffbb5f3690547b3/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go#L63
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	PodNamespace string `json:"podNamespace,omitempty"`
 
 	// ContainerID must be a runtime-prefixed 64-character hexadecimal string.

--- a/bundle/manifests/multiarch.openshift.io_enoexecevents.yaml
+++ b/bundle/manifests/multiarch.openshift.io_enoexecevents.yaml
@@ -54,13 +54,14 @@ spec:
                 type: string
               nodeName:
                 description: |-
-                  NodeName must follow the RFC 1123 DNS label format:
-                  - Max length: 63 characters
-                  - Characters: lowercase letters, digits, and hyphens (`-`)
+                  NodeName must follow the RFC 1123 DNS subdomain format.
+                  - Max length: 253 characters
+                  - Consists of lowercase letters, digits, hyphens (`-`), and dots (`.`)
                   - Must start and end with an alphanumeric character
-                  Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-                maxLength: 63
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+                       https://github.com/kubernetes/kubernetes/blob/b4de8bc1b1095d8f465995521a6986e201812342/pkg/apis/core/validation/validation.go#L273
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               podName:
                 description: |-
@@ -69,18 +70,20 @@ spec:
                   - Characters: lowercase letters, digits, hyphens (`-`), and dots (`.`)
                   - Must start and end with an alphanumeric character
                   Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+                       https://github.com/kubernetes/kubernetes/blob/b4de8bc1b1095d8f465995521a6986e201812342/pkg/apis/core/validation/validation.go#L257
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               podNamespace:
                 description: |-
-                  PodNamespace must follow the RFC 1123 DNS subdomain format (same as PodName)
-                  - Max length: 253 characters
-                  - Characters: lowercase letters, digits, hyphens (`-`), and dots (`.`)
+                  PodNamespace must follow the RFC 1123 DNS label format.
+                  - Max length: 63 characters
+                  - Characters: lowercase letters, digits, and hyphens ('-')
                   - Must start and end with an alphanumeric character
-                  Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-                maxLength: 253
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                       https://github.com/kubernetes/kubernetes/blob/5be5fd022920e0aa77e29792fffbb5f3690547b3/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go#L63
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             type: object
         type: object

--- a/config/crd/bases/multiarch.openshift.io_enoexecevents.yaml
+++ b/config/crd/bases/multiarch.openshift.io_enoexecevents.yaml
@@ -54,13 +54,14 @@ spec:
                 type: string
               nodeName:
                 description: |-
-                  NodeName must follow the RFC 1123 DNS label format:
-                  - Max length: 63 characters
-                  - Characters: lowercase letters, digits, and hyphens (`-`)
+                  NodeName must follow the RFC 1123 DNS subdomain format.
+                  - Max length: 253 characters
+                  - Consists of lowercase letters, digits, hyphens (`-`), and dots (`.`)
                   - Must start and end with an alphanumeric character
-                  Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-                maxLength: 63
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+                       https://github.com/kubernetes/kubernetes/blob/b4de8bc1b1095d8f465995521a6986e201812342/pkg/apis/core/validation/validation.go#L273
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               podName:
                 description: |-
@@ -69,18 +70,20 @@ spec:
                   - Characters: lowercase letters, digits, hyphens (`-`), and dots (`.`)
                   - Must start and end with an alphanumeric character
                   Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+                       https://github.com/kubernetes/kubernetes/blob/b4de8bc1b1095d8f465995521a6986e201812342/pkg/apis/core/validation/validation.go#L257
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               podNamespace:
                 description: |-
-                  PodNamespace must follow the RFC 1123 DNS subdomain format (same as PodName)
-                  - Max length: 253 characters
-                  - Characters: lowercase letters, digits, hyphens (`-`), and dots (`.`)
+                  PodNamespace must follow the RFC 1123 DNS label format.
+                  - Max length: 63 characters
+                  - Characters: lowercase letters, digits, and hyphens ('-')
                   - Must start and end with an alphanumeric character
-                  Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-                maxLength: 253
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                       https://github.com/kubernetes/kubernetes/blob/5be5fd022920e0aa77e29792fffbb5f3690547b3/staging/src/k8s.io/apimachinery/pkg/api/validation/generic.go#L63
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
             type: object
         type: object

--- a/controllers/enoexecevent/handler/enoexecevent_controller_test.go
+++ b/controllers/enoexecevent/handler/enoexecevent_controller_test.go
@@ -306,6 +306,14 @@ var _ = Describe("Controllers/ENoExecEvent/Reconciler", func() {
 					}, &v1beta1.ENoExecEvent{})
 				}).Should(MatchError(ContainSubstring("not found")), "the ENoExecEvent should be deleted")
 			})
+			It("should reject a NodeName that exceeds 253 character", func() {
+				By("Updating the ENoExecEvent")
+				enee.Status = v1beta1.ENoExecEventStatus{
+					NodeName: "a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890",
+				}
+				err := k8sClient.Status().Update(ctx, enee)
+				Expect(err).To(HaveOccurred(), "Should not update enne status with NodeName that is longer that 253 characters", err)
+			})
 			It("should reject a NodeName that has an invalid character", func() {
 				By("Updating the ENoExecEvent")
 				enee.Status = v1beta1.ENoExecEventStatus{
@@ -314,7 +322,7 @@ var _ = Describe("Controllers/ENoExecEvent/Reconciler", func() {
 				err := k8sClient.Status().Update(ctx, enee)
 				Expect(err).To(HaveOccurred(), "Should not update enne status with nodeName that contains an invalid character", err)
 				enee.Status = v1beta1.ENoExecEventStatus{
-					NodeName: "test.node-name",
+					NodeName: "test?node-name",
 				}
 				err = k8sClient.Status().Update(ctx, enee)
 				Expect(err).To(HaveOccurred(), "Should not update enne status with nodeName that contains an invalid character", err)
@@ -332,6 +340,14 @@ var _ = Describe("Controllers/ENoExecEvent/Reconciler", func() {
 				}
 				err = k8sClient.Status().Update(ctx, enee)
 				Expect(err).To(HaveOccurred(), "Should not update enne status with nodeName that ends with an invalid character", err)
+			})
+			It("should accept a NodeName that has valid character", func() {
+				By("Updating the ENoExecEvent")
+				enee.Status = v1beta1.ENoExecEventStatus{
+					NodeName: "test.node.name",
+				}
+				err := k8sClient.Status().Update(ctx, enee)
+				Expect(err).NotTo(HaveOccurred(), "Should update enne status with nodeName that starts with an valid character", err)
 			})
 			It("should reject a PodName that exceeds 253 character", func() {
 				By("Updating the ENoExecEvent")
@@ -380,7 +396,7 @@ var _ = Describe("Controllers/ENoExecEvent/Reconciler", func() {
 			It("should reject a PodNamespace that exceeds 253 character", func() {
 				By("Updating the ENoExecEvent")
 				enee.Status = v1beta1.ENoExecEventStatus{
-					PodNamespace: "a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a234567890",
+					PodNamespace: "a234567890.a234567890.a234567890.a234567890.a234567890.a234567890.a23456789",
 				}
 				err := k8sClient.Status().Update(ctx, enee)
 				Expect(err).To(HaveOccurred(), "Should not update enne status with podNamespace that is longer that 253 characters", err)
@@ -398,11 +414,17 @@ var _ = Describe("Controllers/ENoExecEvent/Reconciler", func() {
 				}
 				err = k8sClient.Status().Update(ctx, enee)
 				Expect(err).To(HaveOccurred(), "Should not update enne status with PodNamespace that contains an uppercase character", err)
+				By("Updating the ENoExecEvent")
+				enee.Status = v1beta1.ENoExecEventStatus{
+					PodNamespace: "test.pod.name",
+				}
+				err = k8sClient.Status().Update(ctx, enee)
+				Expect(err).To(HaveOccurred(), "Should not update enne status with PodNamespace that contains an invalid character", err)
 			})
 			It("should accept valid PodNamespace", func() {
 				By("Updating the ENoExecEvent")
 				enee.Status = v1beta1.ENoExecEventStatus{
-					PodNamespace: "valid.pod-namespace-26",
+					PodNamespace: "valid-pod-namespace-26",
 				}
 				err := k8sClient.Status().Update(ctx, enee)
 				Expect(err).NotTo(HaveOccurred(), "Should update enne status with valid podNamespace", err)
@@ -416,7 +438,7 @@ var _ = Describe("Controllers/ENoExecEvent/Reconciler", func() {
 				Expect(err).To(HaveOccurred(), "Should not update enne status with podNamespace that starts with invalid character", err)
 				By("Updating the ENoExecEvent")
 				enee.Status = v1beta1.ENoExecEventStatus{
-					PodNamespace: "test-pod-name.",
+					PodNamespace: "test-pod-name-",
 				}
 				err = k8sClient.Status().Update(ctx, enee)
 				Expect(err).To(HaveOccurred(), "Should not update enne status with podNamespace that ends with invalid character", err)


### PR DESCRIPTION
Update validation rules for the node name in the status of an ENoExecEvent fail to validate OCP node names to include periods (.)