### PR TITLE
MULTIARCH-5345: Add missing e2e tests

### DIFF
--- a/pkg/testing/framework/namespace.go
+++ b/pkg/testing/framework/namespace.go
@@ -6,8 +6,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewEphemeralNamespace() *corev1.Namespace {
-	name := NormalizeNameString("t-" + uuid.NewString())
+func NewEphemeralNamespace(prefix ...string) *corev1.Namespace {
+	base := "t-" + uuid.NewString()
+	if len(prefix) > 0 {
+		base = prefix[0] + base
+	}
+	name := NormalizeNameString(base)
+
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,


### PR DESCRIPTION
adding missing e2e tests for `func (pod *Pod) shouldIgnorePod`

For the below list from [MULTIARCH-5345](https://issues.redhat.com//browse/MULTIARCH-5345) description:
Newly covered in this update:

- Pod in the same namespace as the operator
- Pod in a namespace with kube- prefix

Already covered previously:

- Pod with controlPlaneNodeSelector - also added prefered node affinity checkpoint
- DaemonSet pod