### PR TITLE
MULTIARCH-5368: add validate webhook for local podplacementconfig priority

### DIFF
--- a/apis/multiarch/common/plugins/base_plugin.go
+++ b/apis/multiarch/common/plugins/base_plugin.go
@@ -26,6 +26,23 @@ type LocalPlugins struct {
 	NodeAffinityScoring *NodeAffinityScoring `json:"nodeAffinityScoring,omitempty"`
 }
 
+// localPluginChecks is a map that associates a plugin name with a function that can
+// safely check if that specific plugin is enabled on a LocalPlugins struct.
+var localPluginChecks = map[common.Plugin]func(lp *LocalPlugins) bool{
+	common.NodeAffinityScoringPluginName: func(lp *LocalPlugins) bool {
+		return lp.NodeAffinityScoring != nil && lp.NodeAffinityScoring.IsEnabled()
+	},
+}
+
+// PluginEnabled provides a generic and safe way to check if a specific plugin is enabled.
+// It handles the case where the LocalPlugins struct itself is nil.
+func (lp *LocalPlugins) PluginEnabled(plugin common.Plugin) bool {
+	if checkFunc, found := localPluginChecks[plugin]; found {
+		return checkFunc(lp)
+	}
+	return false
+}
+
 // Plugins represents the plugins configuration for cluster pod placement config.
 // +kubebuilder:object:generate=true
 type Plugins struct {

--- a/apis/multiarch/common/plugins/nodeaffinityscoring_plugin.go
+++ b/apis/multiarch/common/plugins/nodeaffinityscoring_plugin.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package plugins
 
+import "fmt"
+
 const (
 	// PluginName for NodeAffinityScoring.
 	NodeAffinityScoringPluginName = "NodeAffinityScoring"
@@ -28,6 +30,19 @@ type NodeAffinityScoring struct {
 	// Platforms is a required field and must contain at least one entry.
 	// +kubebuilder:validation:MinItems=1
 	Platforms []NodeAffinityScoringPlatformTerm `json:"platforms" protobuf:"bytes,2,opt,name=platforms"`
+}
+
+// ValidateArchitecturesSet checks whether duplicate architectures are set in NodeAffinityScoring
+func (n *NodeAffinityScoring) ValidateArchitecturesSet() (bool, error) {
+	seen := make(map[string]struct{})
+	for _, term := range n.Platforms {
+		if _, exists := seen[term.Architecture]; exists {
+			return false, fmt.Errorf("duplicate architecture %q found in nodeAffinityScoring.platforms", term.Architecture)
+		}
+
+		seen[term.Architecture] = struct{}{}
+	}
+	return true, nil
 }
 
 // NodeAffinityScoringPlatformTerm holds configuration for specific platforms, with required fields validated.

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2025-07-31T08:25:31Z"
+    createdAt: "2025-08-15T11:13:45Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -244,6 +244,7 @@ spec:
           resources:
           - clusterpodplacementconfigs
           - enoexecevents
+          - podplacementconfigs
           verbs:
           - create
           - delete
@@ -257,6 +258,7 @@ spec:
           resources:
           - clusterpodplacementconfigs/finalizers
           - enoexecevents/finalizers
+          - podplacementconfigs/finalizers
           verbs:
           - update
         - apiGroups:
@@ -264,6 +266,7 @@ spec:
           resources:
           - clusterpodplacementconfigs/status
           - enoexecevents/status
+          - podplacementconfigs/status
           verbs:
           - get
           - patch
@@ -520,3 +523,24 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-multiarch-openshift-io-v1beta1-clusterpodplacementconfig
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: multiarch-tuning-operator-controller-manager
+    failurePolicy: Fail
+    generateName: validate-podplacementconfig.multiarch.openshift.io
+    rules:
+    - apiGroups:
+      - multiarch.openshift.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      - DELETE
+      resources:
+      - podplacementconfigs
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-multiarch-openshift-io-v1beta1-podplacementconfig

--- a/cmd/main-binary/main.go
+++ b/cmd/main-binary/main.go
@@ -67,6 +67,7 @@ import (
 	enoexeceventhandler "github.com/openshift/multiarch-tuning-operator/controllers/enoexecevent/handler"
 	"github.com/openshift/multiarch-tuning-operator/controllers/operator"
 	"github.com/openshift/multiarch-tuning-operator/controllers/podplacement"
+	"github.com/openshift/multiarch-tuning-operator/controllers/podplacementconfig"
 	"github.com/openshift/multiarch-tuning-operator/pkg/informers/clusterpodplacementconfig"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
@@ -187,6 +188,7 @@ func main() {
 
 	if enableOperator {
 		RunOperator(mgr)
+		RunPodPlacementConfigWebHook(mgr)
 	}
 	if enableClusterPodPlacementConfigOperandControllers {
 		RunClusterPodPlacementConfigOperandControllers(mgr)
@@ -269,6 +271,11 @@ func RunClusterPodPlacementConfigOperandWebHook(mgr ctrl.Manager) {
 	handler := podplacement.NewPodSchedulingGateMutatingWebHook(mgr.GetClient(), clientset, mgr.GetScheme(),
 		mgr.GetEventRecorderFor(utils.OperatorName), pool)
 	mgr.GetWebhookServer().Register("/add-pod-scheduling-gate", &webhook.Admission{Handler: handler})
+}
+
+func RunPodPlacementConfigWebHook(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/validate-multiarch-openshift-io-v1beta1-podplacementconfig",
+		&webhook.Admission{Handler: podplacementconfig.NewPodPlacementConfigWebhook(mgr.GetAPIReader(), mgr.GetScheme())})
 }
 
 func RunENoExecEventControllers(mgr ctrl.Manager) {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -139,6 +139,7 @@ rules:
   resources:
   - clusterpodplacementconfigs
   - enoexecevents
+  - podplacementconfigs
   verbs:
   - create
   - delete
@@ -152,6 +153,7 @@ rules:
   resources:
   - clusterpodplacementconfigs/finalizers
   - enoexecevents/finalizers
+  - podplacementconfigs/finalizers
   verbs:
   - update
 - apiGroups:
@@ -159,6 +161,7 @@ rules:
   resources:
   - clusterpodplacementconfigs/status
   - enoexecevents/status
+  - podplacementconfigs/status
   verbs:
   - get
   - patch

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -12,7 +12,11 @@ patches:
       - op: replace
         path: /webhooks/0/clientConfig/service/name
         value: controller-manager-service
+      - op: replace
+        path: /webhooks/1/clientConfig/service/name
+        value: controller-manager-service
       - op: add
         path: /metadata/annotations
         value:
           "service.beta.openshift.io/inject-cabundle": "true"
+

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -24,3 +24,24 @@ webhooks:
     resources:
     - clusterpodplacementconfigs
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-multiarch-openshift-io-v1beta1-podplacementconfig
+  failurePolicy: Fail
+  name: validate-podplacementconfig.multiarch.openshift.io
+  rules:
+  - apiGroups:
+    - multiarch.openshift.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - podplacementconfigs
+  sideEffects: None

--- a/controllers/podplacementconfig/podplacementconfig_controller.go
+++ b/controllers/podplacementconfig/podplacementconfig_controller.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podplacementconfig
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+)
+
+// PodPlacementConfigReconciler reconciles a PodPlacementConfig object
+type PodPlacementConfigReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=multiarch.openshift.io,resources=podplacementconfigs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=multiarch.openshift.io,resources=podplacementconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=multiarch.openshift.io,resources=podplacementconfigs/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the PodPlacementConfig object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
+func (r *PodPlacementConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = log.FromContext(ctx)
+
+	// TODO(user): your logic here
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *PodPlacementConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&multiarchv1beta1.PodPlacementConfig{}).
+		Complete(r)
+}

--- a/controllers/podplacementconfig/podplacementconfig_controller_test.go
+++ b/controllers/podplacementconfig/podplacementconfig_controller_test.go
@@ -28,10 +28,11 @@ import (
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
 	"github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/framework"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 )
 
-var _ = Describe("Controllers/PodPlacementConfig/PodPlacementConfigReconciler", Serial, Ordered, func() {
+var _ = Describe("Controllers/PodPlacementConfig/PodPlacementConfigReconciler", Serial, func() {
 	When("Creating a local podplacementconfig", func() {
 		Context("with invalid values in the plugins.nodeAffinityScoring and invalid priority stanza", func() {
 			DescribeTable("The request should fail with", func(object *v1beta1.PodPlacementConfig) {
@@ -97,6 +98,172 @@ var _ = Describe("Controllers/PodPlacementConfig/PodPlacementConfigReconciler", 
 				By("Ensure the PodPlacementConfig is deleted")
 				err := k8sClient.Delete(ctx, builder.NewPodPlacementConfig().WithName(common.SingletonResourceObjectName).WithNamespace(testNamespace).Build())
 				Expect(crclient.IgnoreNotFound(err)).NotTo(HaveOccurred(), "failed to delete PodPlacementConfig", err)
+			})
+		})
+		Context("the weebhook shoud deny creation", func() {
+			It("when multiple items for the same architecture in the plugins.nodeAffinityScoring.Platforms list", func() {
+				By("Create an ephemeral namespace")
+				ns := framework.NewEphemeralNamespace()
+				err := k8sClient.Create(ctx, ns)
+				Expect(err).NotTo(HaveOccurred())
+				//nolint:errcheck
+				defer k8sClient.Delete(ctx, ns)
+				By("Creating a local PodPlacementConfig with the same architecture")
+				err = k8sClient.Create(ctx,
+					builder.NewPodPlacementConfig().
+						WithName("test-ppc").
+						WithNamespace(ns.Name).
+						WithPlugins().
+						WithNodeAffinityScoring(true).
+						WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+						WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 100).
+						Build(),
+				)
+				Expect(err).To(HaveOccurred(), "the PodPlacementConfig should not be accepted", err)
+			})
+			It("when there is an existing ppc with the same priority in the same namespace", func() {
+				By("Create an ephemeral namespace")
+				ns := framework.NewEphemeralNamespace()
+				err := k8sClient.Create(ctx, ns)
+				Expect(err).NotTo(HaveOccurred())
+				//nolint:errcheck
+				defer k8sClient.Delete(ctx, ns)
+				By("Creating a local PodPlacementConfig with a Prioriry setting")
+				err = k8sClient.Create(ctx,
+					builder.NewPodPlacementConfig().
+						WithName("test-ppc").
+						WithNamespace(ns.Name).
+						WithPriority(50).
+						WithPlugins().
+						WithNodeAffinityScoring(true).
+						WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+						Build(),
+				)
+				Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+				By("Check the PodPlacementConfig is created and priority is 50")
+				Eventually(func(g Gomega) {
+					ppc := &v1beta1.PodPlacementConfig{}
+					err := k8sClient.Get(ctx, crclient.ObjectKey{
+						Name:      "test-ppc",
+						Namespace: ns.Name,
+					}, ppc)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get podplacementconfig", err)
+					g.Expect(ppc.Spec.Priority).To(Equal(uint8(50)), "the ppc Priority should equal 50")
+				}).Should(Succeed(), "the PodPlacementConfig should be created")
+				By("Creating another local PodPlacementConfig with the same Prioriry")
+				err = k8sClient.Create(ctx,
+					builder.NewPodPlacementConfig().
+						WithName("test-ppc-2").
+						WithNamespace(ns.Name).
+						WithPriority(50).
+						WithPlugins().
+						WithNodeAffinityScoring(true).
+						WithNodeAffinityScoringTerm(utils.ArchitectureArm64, 50).
+						Build(),
+				)
+				Expect(err).To(HaveOccurred(), "the PodPlacementConfig should not be accepted", err)
+			})
+			It("when update a local ppc priority to an exsiting one", func() {
+				By("Create an ephemeral namespace")
+				ns := framework.NewEphemeralNamespace()
+				err := k8sClient.Create(ctx, ns)
+				Expect(err).NotTo(HaveOccurred())
+				//nolint:errcheck
+				defer k8sClient.Delete(ctx, ns)
+				By("Creating a local PodPlacementConfig with priority 30")
+				err = k8sClient.Create(ctx,
+					builder.NewPodPlacementConfig().
+						WithName("test-ppc").
+						WithNamespace(ns.Name).
+						WithPriority(30).
+						WithPlugins().
+						WithNodeAffinityScoring(true).
+						WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+						Build(),
+				)
+				Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+				By("Creating another local PodPlacementConfig with priority 50")
+				err = k8sClient.Create(ctx,
+					builder.NewPodPlacementConfig().
+						WithName("test-ppc-2").
+						WithNamespace(ns.Name).
+						WithPriority(50).
+						WithPlugins().
+						WithNodeAffinityScoring(true).
+						WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+						Build(),
+				)
+				Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+				By("Check the PodPlacementConfig is created and priority is 50")
+				Eventually(func(g Gomega) {
+					ppc2 := &v1beta1.PodPlacementConfig{}
+					err := k8sClient.Get(ctx, crclient.ObjectKey{
+						Name:      "test-ppc-2",
+						Namespace: ns.Name,
+					}, ppc2)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get podplacementconfig", err)
+					g.Expect(ppc2.Spec.Priority).To(Equal(uint8(50)), "the ppc Priority should equal 50")
+				}).Should(Succeed(), "the PodPlacementConfig should be created")
+				By("Update the first local PodPlacementConfig priority to 50")
+				ppc1 := &v1beta1.PodPlacementConfig{}
+				err = k8sClient.Get(ctx, crclient.ObjectKey{
+					Name:      "test-ppc",
+					Namespace: ns.Name,
+				}, ppc1)
+				Expect(err).NotTo(HaveOccurred())
+				ppc1.Spec.Priority = 50
+				err = k8sClient.Update(ctx, ppc1)
+				Expect(err).To(HaveOccurred(), "the PodPlacementConfig update should not be accepted", err)
+			})
+		})
+		Context("the weebhook shoud allow creation", func() {
+			It("when the ppc is recreated with the same priority after delation", func() {
+				By("Create an ephemeral namespace")
+				ns := framework.NewEphemeralNamespace()
+				err := k8sClient.Create(ctx, ns)
+				Expect(err).NotTo(HaveOccurred())
+				//nolint:errcheck
+				defer k8sClient.Delete(ctx, ns)
+				By("Creating a local PodPlacementConfig with priority 50")
+				err = k8sClient.Create(ctx,
+					builder.NewPodPlacementConfig().
+						WithName("test-ppc").
+						WithNamespace(ns.Name).
+						WithPriority(50).
+						WithPlugins().
+						WithNodeAffinityScoring(true).
+						WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+						Build(),
+				)
+				By("Check it can be created")
+				Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+				By("Deleting above created PodPlacementConfig")
+				err = k8sClient.Delete(ctx, builder.NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).Build())
+				Expect(err).NotTo(HaveOccurred())
+				By("Check the PodPlacementConfig is deleted")
+				Eventually(func(g Gomega) {
+					ppc := &v1beta1.PodPlacementConfig{}
+					err := k8sClient.Get(ctx, crclient.ObjectKey{
+						Name:      "test-ppc",
+						Namespace: ns.Name,
+					}, ppc)
+					Expect(errors.IsNotFound(err)).To(BeTrue(), "failed to delete podplacementconfig", err)
+				}).Should(Succeed(), "the PodPlacementConfig should be deleted")
+				By("Creating the PodPlacementConfig with the same priority 50 again")
+				err = k8sClient.Create(ctx,
+					builder.NewPodPlacementConfig().
+						WithName("test-ppc").
+						WithNamespace(ns.Name).
+						WithPriority(50).
+						WithPlugins().
+						WithNodeAffinityScoring(true).
+						WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+						Build(),
+				)
+				By("Check it can be created again")
+				Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
 			})
 		})
 	})

--- a/controllers/podplacementconfig/podplacementconfig_webhook.go
+++ b/controllers/podplacementconfig/podplacementconfig_webhook.go
@@ -1,0 +1,85 @@
+package podplacementconfig
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
+	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	"github.com/openshift/multiarch-tuning-operator/controllers/podplacement/metrics"
+)
+
+// +kubebuilder:webhook:path=/validate-multiarch-openshift-io-v1beta1-podplacementconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=multiarch.openshift.io,resources=podplacementconfigs,verbs=create;update;delete,versions=v1beta1,name=validate-podplacementconfig.multiarch.openshift.io,admissionReviewVersions=v1
+
+type PodPlacementConfigWebhook struct {
+	apiReader client.Reader
+	decoder   admission.Decoder
+	once      sync.Once
+	scheme    *runtime.Scheme
+}
+
+func (w *PodPlacementConfigWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	w.once.Do(func() {
+		w.decoder = admission.NewDecoder(w.scheme)
+	})
+
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		// Decode new object
+		newPPC := &multiarchv1beta1.PodPlacementConfig{}
+		if err := w.decoder.Decode(req, newPPC); err != nil {
+			return admission.Errored(http.StatusBadRequest,
+				fmt.Errorf("failed to decode new PodPlacementConfig: %w", err))
+		}
+
+		// Check for duplicate architectures in NodeAffinityScoring
+		if newPPC.PluginsEnabled(common.NodeAffinityScoringPluginName) {
+			if ok, err := newPPC.Spec.Plugins.NodeAffinityScoring.ValidateArchitecturesSet(); !ok {
+				return admission.Denied(err.Error())
+			}
+		}
+
+		// List existing PodPlacementConfigs in the same namespace
+		existingPPCs := &multiarchv1beta1.PodPlacementConfigList{}
+		if err := w.apiReader.List(ctx, existingPPCs, client.InNamespace(req.Namespace)); err != nil {
+			return admission.Errored(http.StatusInternalServerError,
+				fmt.Errorf("failed to list existing PodPlacementConfigs in namespace %q: %w", req.Namespace, err))
+		}
+
+		if req.Operation == admissionv1.Create {
+			if ok, err := newPPC.ValidatePriorityNew(existingPPCs); !ok {
+				return admission.Denied(err.Error())
+			}
+		} else { // admissionv1.Update
+			oldPPC := &multiarchv1beta1.PodPlacementConfig{}
+			if err := w.decoder.DecodeRaw(req.OldObject, oldPPC); err != nil {
+				return admission.Errored(http.StatusBadRequest,
+					fmt.Errorf("failed to decode old PodPlacementConfig: %w", err))
+			}
+			if ok, err := newPPC.ValidatePriorityUpdate(oldPPC, existingPPCs); !ok {
+				return admission.Denied(err.Error())
+			}
+		}
+
+		return admission.Allowed("valid PodPlacementConfig")
+
+	default:
+		return admission.Allowed("operation not explicitly handled")
+	}
+}
+
+func NewPodPlacementConfigWebhook(apiReader client.Reader, scheme *runtime.Scheme) *PodPlacementConfigWebhook {
+	a := &PodPlacementConfigWebhook{
+		apiReader: apiReader,
+		scheme:    scheme,
+	}
+	metrics.InitWebhookMetrics()
+	return a
+}

--- a/controllers/podplacementconfig/suite_test.go
+++ b/controllers/podplacementconfig/suite_test.go
@@ -25,7 +25,10 @@ import (
 	"time"
 
 	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
+	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
 
+	v1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -37,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -118,6 +122,9 @@ func startTestEnv() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			ValidatingWebhooks: []*v1.ValidatingWebhookConfiguration{getPodPlacementConfigValidatingWebHook()},
+		},
 	}
 	var err error
 	// cfg is defined in this file globally.
@@ -135,14 +142,24 @@ func startTestEnv() {
 
 func runManager() {
 	By("Creating the manager")
+	webhookServer := webhook.NewServer(webhook.Options{
+		Port:    testEnv.WebhookInstallOptions.LocalServingPort,
+		Host:    testEnv.WebhookInstallOptions.LocalServingHost,
+		CertDir: testEnv.WebhookInstallOptions.LocalServingCertDir,
+	})
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                 scheme.Scheme,
 		HealthProbeBindAddress: ":4980",
 		Logger:                 suiteLog,
+		WebhookServer:          webhookServer,
 	})
 	Expect(err).NotTo(HaveOccurred())
 
 	suiteLog.Info("Manager created")
+
+	By("Setting up PodPlacement controller")
+	mgr.GetWebhookServer().Register("/validate-multiarch-openshift-io-v1beta1-podplacementconfig", &webhook.Admission{
+		Handler: NewPodPlacementConfigWebhook(mgr.GetAPIReader(), mgr.GetScheme())})
 
 	err = mgr.AddReadyzCheck("readyz", healthz.Ping)
 	Expect(err).NotTo(HaveOccurred())
@@ -163,4 +180,41 @@ func runManager() {
 	}).MustPassRepeatedly(3).Should(
 		Succeed(), "manager is not ready yet")
 	suiteLog.Info("Manager is ready")
+}
+
+func getPodPlacementConfigValidatingWebHook() *v1.ValidatingWebhookConfiguration {
+	return &v1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "validating-webhook-configuration",
+		},
+		Webhooks: []v1.ValidatingWebhook{
+			{
+				Name:                    "validate-podplacementconfig.multiarch.openshift.io",
+				AdmissionReviewVersions: []string{"v1"},
+				ClientConfig: v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Name:      "webhook-service",
+						Namespace: "system",
+						Path:      utils.NewPtr("/validate-multiarch-openshift-io-v1beta1-podplacementconfig"),
+					},
+				},
+				FailurePolicy: utils.NewPtr(v1.Fail),
+				SideEffects:   utils.NewPtr(v1.SideEffectClassNone),
+				Rules: []v1.RuleWithOperations{
+					{
+						Operations: []v1.OperationType{
+							v1.Create,
+							v1.Update,
+							v1.Delete,
+						},
+						Rule: v1.Rule{
+							APIGroups:   []string{"multiarch.openshift.io"},
+							APIVersions: []string{"v1beta1"},
+							Resources:   []string{"podplacementconfigs"},
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/e2e/podplacementconfig/e2e_test.go
+++ b/pkg/e2e/podplacementconfig/e2e_test.go
@@ -1,0 +1,35 @@
+package podplacementconfig_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/multiarch-tuning-operator/pkg/e2e"
+)
+
+var (
+	client    runtimeclient.Client
+	clientset *kubernetes.Clientset
+	ctx       context.Context
+	suiteLog  = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	e2e.CommonInit()
+}
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Multiarch Tuning Operator Suite (podplacementconfig E2E)", Label("e2e", "podplacementconfig"))
+}
+
+var _ = BeforeSuite(func() {
+	client, clientset, ctx, suiteLog = e2e.CommonBeforeSuite()
+})

--- a/pkg/e2e/podplacementconfig/pod_placement_config_test.go
+++ b/pkg/e2e/podplacementconfig/pod_placement_config_test.go
@@ -1,0 +1,181 @@
+package podplacementconfig_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/builder"
+	"github.com/openshift/multiarch-tuning-operator/pkg/testing/framework"
+	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
+)
+
+var _ = Describe("The Multiarch Tuning Operator", func() {
+	Context("When a pod placement config is created", func() {
+		It("should fail creating the PPC with multiple items for the same architecture in the plugins.nodeAffinityScoring.Platforms list", func() {
+			By("Create an ephemeral namespace")
+			ns := framework.NewEphemeralNamespace()
+			err := client.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, ns)
+			By("Creating a local PodPlacementConfig with the same architecture")
+			err = client.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 100).
+					Build(),
+			)
+			Expect(err).To(HaveOccurred(), "the PodPlacementConfig should not be accepted", err)
+		})
+		It("The webhook should deny creation when a PodPlacementConfig with the same priority already exists in the same namespace", func() {
+			By("Create an ephemeral namespace")
+			ns := framework.NewEphemeralNamespace()
+			err := client.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, ns)
+			By("Creating a local PodPlacementConfig with a Prioriry setting")
+			err = client.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+			By("Check the PodPlacementConfig is created and priority is 50")
+			Eventually(func(g Gomega) {
+				ppc := &v1beta1.PodPlacementConfig{}
+				err := client.Get(ctx, crclient.ObjectKey{
+					Name:      "test-ppc",
+					Namespace: ns.Name,
+				}, ppc)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get podplacementconfig", err)
+				g.Expect(ppc.Spec.Priority).To(Equal(uint8(50)), "the ppc Priority should equal 50")
+			}).Should(Succeed(), "the PodPlacementConfig should be created")
+			By("Creating another local PodPlacementConfig with the same Prioriry")
+			err = client.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc-2").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureArm64, 50).
+					Build(),
+			)
+			Expect(err).To(HaveOccurred(), "the PodPlacementConfig should not be accepted", err)
+		})
+		It("The webhook should deny creation when update a local ppc priority to an exsiting one", func() {
+			By("Create an ephemeral namespace")
+			ns := framework.NewEphemeralNamespace()
+			err := client.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, ns)
+			By("Creating a local PodPlacementConfig with priority 30")
+			err = client.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPriority(30).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+			By("Creating another local PodPlacementConfig with priority 50")
+			err = client.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc-2").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+			By("Check the PodPlacementConfig is created and priority is 50")
+			Eventually(func(g Gomega) {
+				ppc2 := &v1beta1.PodPlacementConfig{}
+				err := client.Get(ctx, crclient.ObjectKey{
+					Name:      "test-ppc-2",
+					Namespace: ns.Name,
+				}, ppc2)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get podplacementconfig", err)
+				g.Expect(ppc2.Spec.Priority).To(Equal(uint8(50)), "the ppc Priority should equal 50")
+			}).Should(Succeed(), "the PodPlacementConfig should be created")
+			By("Update the first local PodPlacementConfig priority to 50")
+			ppc1 := &v1beta1.PodPlacementConfig{}
+			err = client.Get(ctx, crclient.ObjectKey{
+				Name:      "test-ppc",
+				Namespace: ns.Name,
+			}, ppc1)
+			Expect(err).NotTo(HaveOccurred())
+			ppc1.Spec.Priority = 50
+			err = client.Update(ctx, ppc1)
+			Expect(err).To(HaveOccurred(), "the PodPlacementConfig update should not be accepted", err)
+		})
+		It("The webhook should allow creation when the ppc is recreated with the same priority after delation", func() {
+			By("Create an ephemeral namespace")
+			ns := framework.NewEphemeralNamespace()
+			err := client.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, ns)
+			By("Creating a local PodPlacementConfig with priority 50")
+			err = client.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			By("Check it can be created")
+			Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+			By("Deleting above created PodPlacementConfig")
+			err = client.Delete(ctx, builder.NewPodPlacementConfig().
+				WithName("test-ppc").
+				WithNamespace(ns.Name).Build())
+			Expect(err).NotTo(HaveOccurred())
+			By("Check the PodPlacementConfig is deleted")
+			Eventually(func(g Gomega) {
+				ppc := &v1beta1.PodPlacementConfig{}
+				err := client.Get(ctx, crclient.ObjectKey{
+					Name:      "test-ppc",
+					Namespace: ns.Name,
+				}, ppc)
+				Expect(errors.IsNotFound(err)).To(BeTrue(), "failed to delete podplacementconfig", err)
+			}).Should(Succeed(), "the PodPlacementConfig should be deleted")
+			By("Creating the PodPlacementConfig with the same priority 50 again")
+			err = client.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			By("Check it can be created again")
+			Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+		})
+	})
+})


### PR DESCRIPTION
The pr implement the following:
- add validate webhook for local podplacementconfig `priority` filed
- add validate webhook for `NodeAffinityScoring` field