### PR TITLE
MULTIARCH-5605: Safe removal of the ENoExec plugin objects

### DIFF
--- a/controllers/enoexecevent/handler/enoexecevent_controller.go
+++ b/controllers/enoexecevent/handler/enoexecevent_controller.go
@@ -96,7 +96,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		logger.Info("Deleted ENoExecEvent resource after successful reconciliation", "name", enoExecEvent.Name)
 		return ret, nil
 	}
-	return ctrl.Result{}, nil
+	logger.Error(err, "Failed to reconcile ENoExecEvent", "name", enoExecEvent.Name)
+	return ctrl.Result{}, err
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, enoExecEvent *multiarchv1beta1.ENoExecEvent) (ctrl.Result, error) {

--- a/controllers/operator/clusterpodplacementconfig_controller_test.go
+++ b/controllers/operator/clusterpodplacementconfig_controller_test.go
@@ -317,7 +317,7 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 					g.Expect(mw.Webhooks[0].NamespaceSelector).To(Equal(ppc.Spec.NamespaceSelector))
 				}).Should(Succeed(), "the deployment "+utils.PodPlacementControllerName+" should be updated")
 			})
-			It("Should have finalizers", func() {
+			It("Should have ClusterPodPlacementConfig finalizers", func() {
 				ppc := &v1beta1.ClusterPodPlacementConfig{}
 				err := k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
 					ObjectMeta: metav1.ObjectMeta{
@@ -631,6 +631,40 @@ var _ = Describe("Controllers/ClusterPodPlacementConfig/ClusterPodPlacementConfi
 			})
 		})
 	})
+	Context("is handling the cleanup lifecycle of the ClusterPodPlacementConfig with the ExecFormatErrorMonitor enabled", func() {
+		BeforeEach(func() {
+			By("Creating the ClusterPodPlacementConfig with ExecFormatErrorMonitor enabled")
+			err := k8sClient.Create(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).
+				WithExecFormatErrorMonitor(true).Build())
+			Expect(err).NotTo(HaveOccurred(), "failed to create ClusterPodPlacementConfig", err)
+			validateReconcile(framework.MainPlugin, framework.ENoExecPlugin)
+		})
+		AfterEach(func() {
+			By("Deleting the ClusterPodPlacementConfig")
+			err := k8sClient.Delete(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
+			Expect(err).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
+			Eventually(framework.ValidateDeletion(k8sClient, ctx, framework.MainPlugin, framework.ENoExecPlugin)).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
+		})
+		It("ensure the finalizers exist", func() {
+			By("Verifying the cppc has the correct finalizer")
+			cppc := &v1beta1.ClusterPodPlacementConfig{}
+			err := k8sClient.Get(ctx, crclient.ObjectKey{
+				Name: common.SingletonResourceObjectName,
+			}, cppc)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cppc.Finalizers).To(ContainElement(utils.ExecFormatErrorFinalizerName))
+			By("Verifying the enoexec Deployment has the correct finalizer")
+			d := appsv1.Deployment{}
+			err = k8sClient.Get(ctx, crclient.ObjectKeyFromObject(&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      utils.EnoexecControllerName,
+					Namespace: utils.Namespace(),
+				},
+			}), &d)
+			Expect(err).NotTo(HaveOccurred(), "failed to get deployment "+utils.EnoexecControllerName, err)
+			Expect(d.Finalizers).To(ContainElement(utils.ExecFormatErrorFinalizerName))
+		})
+	})
 })
 
 func patchDeploymentStatus(name string, g Gomega, patch func(*appsv1.Deployment)) {
@@ -659,12 +693,12 @@ func setDeploymentReady(name string, g Gomega) {
 
 // validateReconcile
 // NOTE: this can be used only in integratoin tests as it changes the status of deployments
-func validateReconcile() {
+func validateReconcile(pluginObjectsSet ...framework.PluginObjectsSet) {
 	for _, name := range []string{utils.PodPlacementControllerName, utils.PodPlacementWebhookName} {
 		Eventually(func(g Gomega) {
 			setDeploymentReady(name, g)
 		}).Should(Succeed(), "the deployment "+name+" should be ready")
 	}
-	Eventually(framework.ValidateCreation(k8sClient, ctx)).Should(Succeed(), "the ClusterPodPlacementConfig should be created")
+	Eventually(framework.ValidateCreation(k8sClient, ctx, pluginObjectsSet...)).Should(Succeed(), "the ClusterPodPlacementConfig should be created")
 	By("The ClusterPodPlacementConfig is ready")
 }

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -54,13 +54,14 @@ const (
 )
 
 const (
-	ExecFormatErrorLabelKey    = "multiarch.openshift.io/exec-format-error"
-	True                       = "true"
-	False                      = "false"
-	ExecFormatErrorEventReason = "ExecFormatError"
-	UnknownContainer           = "unknown-container" // Used when the container name is not known or not provided
-	EnoexecControllerName      = "enoexec-event-handler-controller"
-	EnoexecDaemonSet           = "enoexec-event-daemon"
+	ExecFormatErrorFinalizerName = "finalizers.multiarch.openshift.io/enoexec-events"
+	ExecFormatErrorLabelKey      = "multiarch.openshift.io/exec-format-error"
+	True                         = "true"
+	False                        = "false"
+	ExecFormatErrorEventReason   = "ExecFormatError"
+	UnknownContainer             = "unknown-container" // Used when the container name is not known or not provided
+	EnoexecControllerName        = "enoexec-event-handler-controller"
+	EnoexecDaemonSet             = "enoexec-event-daemon"
 )
 
 func AllSupportedArchitecturesSet() sets.Set[string] {


### PR DESCRIPTION
Introducing two finalizers to the `enoexec-event-handler-controller` Deployment to ensure a robust, ordered, and safe shutdown of the ENoExecEvent components.

Previously, when the ExecFormatErrorMonitor plugin was disabled or the operator was uninstalled, there was no guarantee on the deletion order of the enoexec components. This could lead to two potential issues:

1. The Deployment could be deleted before its associated DaemonSet.
2. The Deployment and DaemonSet could be deleted while ENoExecEvent custom resources still existed, preventing those events from ever being processed by the controller.

