### PR TITLE
Refactor: Add generic PluginEnabled helper method

### DIFF
--- a/apis/multiarch/common/const.go
+++ b/apis/multiarch/common/const.go
@@ -1,3 +1,12 @@
 package common
 
 const SingletonResourceObjectName = "cluster"
+
+type Plugin int
+
+const (
+	// MainPlugin checks the core pod placement resources.
+	NodeAffinityScoringPluginName Plugin = iota
+	// ENoExecPlugin checks the ENoExecEvent resources.
+	ExecFormatErrorMonitorPluginName
+)

--- a/apis/multiarch/common/plugins/base_plugin.go
+++ b/apis/multiarch/common/plugins/base_plugin.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package plugins
 
+import "github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
+
 // +k8s:deepcopy-gen=package
 
 // LocalPlugins represents the plugins configuration for podplacementconfigs resource.
@@ -30,6 +32,26 @@ type Plugins struct {
 	NodeAffinityScoring *NodeAffinityScoring `json:"nodeAffinityScoring,omitempty"`
 
 	ExecFormatErrorMonitor *ExecFormatErrorMonitor `json:"execFormatErrorMonitor,omitempty"`
+}
+
+// pluginChecks is a map that associates a plugin name with a function that can
+// safely check if that specific plugin is enabled on a Plugins struct.
+var pluginChecks = map[common.Plugin]func(p *Plugins) bool{
+	common.NodeAffinityScoringPluginName: func(p *Plugins) bool {
+		return p.NodeAffinityScoring != nil && p.NodeAffinityScoring.IsEnabled()
+	},
+	common.ExecFormatErrorMonitorPluginName: func(p *Plugins) bool {
+		return p.ExecFormatErrorMonitor != nil && p.ExecFormatErrorMonitor.IsEnabled()
+	},
+}
+
+// PluginEnabled provides a generic and safe way to check if a specific plugin is enabled.
+// It handles the case where the Plugins struct itself is nil.
+func (p *Plugins) PluginEnabled(plugin common.Plugin) bool {
+	if checkFunc, found := pluginChecks[plugin]; found {
+		return checkFunc(p)
+	}
+	return false
 }
 
 // IBasePlugin defines a basic interface for plugins.

--- a/apis/multiarch/v1beta1/clusterpodplacementconfig_types.go
+++ b/apis/multiarch/v1beta1/clusterpodplacementconfig_types.go
@@ -214,6 +214,13 @@ type ClusterPodPlacementConfig struct {
 	Status ClusterPodPlacementConfigStatus `json:"status,omitempty"`
 }
 
+func (c *ClusterPodPlacementConfig) PluginsEnabled(plugin common.Plugin) bool {
+	if c.Spec.Plugins != nil {
+		return c.Spec.Plugins.PluginEnabled(plugin)
+	}
+	return false
+}
+
 //+kubebuilder:object:root=true
 
 // ClusterPodPlacementConfigList contains a list of ClusterPodPlacementConfig

--- a/controllers/operator/clusterpodplacementconfig_controller.go
+++ b/controllers/operator/clusterpodplacementconfig_controller.go
@@ -41,6 +41,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
 	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
 	"github.com/openshift/multiarch-tuning-operator/pkg/testing/framework"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
@@ -487,7 +488,7 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 	}
 
 	execFormatErrorObjects := []client.Object{}
-	if clusterPodPlacementConfig.Spec.Plugins != nil && clusterPodPlacementConfig.Spec.Plugins.ExecFormatErrorMonitor != nil && clusterPodPlacementConfig.Spec.Plugins.ExecFormatErrorMonitor.IsEnabled() {
+	if clusterPodPlacementConfig.PluginsEnabled(common.ExecFormatErrorMonitorPluginName) {
 		execFormatErrorObjects, err = r.buildENoExecEventObjects(ctx, clusterPodPlacementConfig)
 		if err != nil {
 			return err

--- a/controllers/podplacement/pod_model.go
+++ b/controllers/podplacement/pod_model.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
 	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/v1beta1"
 	"github.com/openshift/multiarch-tuning-operator/controllers/podplacement/metrics"
 	"github.com/openshift/multiarch-tuning-operator/pkg/image"
@@ -317,8 +318,8 @@ func (pod *Pod) ensureArchitectureLabels(requirement corev1.NodeSelectorRequirem
 func (pod *Pod) shouldIgnorePod(cppc *v1beta1.ClusterPodPlacementConfig) bool {
 	return utils.Namespace() == pod.Namespace || strings.HasPrefix(pod.Namespace, "kube-") ||
 		pod.Spec.NodeName != "" || pod.HasControlPlaneNodeSelector() || pod.IsFromDaemonSet() ||
-		pod.isNodeSelectorConfiguredForArchitecture() && (cppc.Spec.Plugins == nil || cppc.Spec.Plugins.NodeAffinityScoring == nil ||
-			!cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() || pod.isPreferredAffinityConfiguredForArchitecture())
+		pod.isNodeSelectorConfiguredForArchitecture() &&
+			(!cppc.PluginsEnabled(common.NodeAffinityScoringPluginName) || pod.isPreferredAffinityConfiguredForArchitecture())
 }
 
 // isNodeSelectorConfiguredForArchitecture returns true if the pod has already a nodeSelector for the architecture label

--- a/controllers/podplacement/pod_reconciler.go
+++ b/controllers/podplacement/pod_reconciler.go
@@ -32,6 +32,7 @@ import (
 	ctrl2 "sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
 	"github.com/openshift/multiarch-tuning-operator/controllers/podplacement/metrics"
 	"github.com/openshift/multiarch-tuning-operator/pkg/informers/clusterpodplacementconfig"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
@@ -116,7 +117,7 @@ func (r *PodReconciler) processPod(ctx context.Context, pod *Pod) {
 		return
 	}
 
-	if cppc != nil && cppc.Spec.Plugins != nil && cppc.Spec.Plugins.NodeAffinityScoring != nil && cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() {
+	if cppc != nil && cppc.PluginsEnabled(common.NodeAffinityScoringPluginName) {
 		pod.SetPreferredArchNodeAffinity(cppc)
 	}
 

--- a/controllers/podplacement/scheduling_gate_mutating_webhook.go
+++ b/controllers/podplacement/scheduling_gate_mutating_webhook.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/panjf2000/ants/v2"
 
+	"github.com/openshift/multiarch-tuning-operator/apis/multiarch/common"
 	"github.com/openshift/multiarch-tuning-operator/controllers/podplacement/metrics"
 	"github.com/openshift/multiarch-tuning-operator/pkg/informers/clusterpodplacementconfig"
 	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
@@ -80,7 +81,7 @@ func (a *PodSchedulingGateMutatingWebHook) Handle(ctx context.Context, req admis
 	log := ctrllog.FromContext(ctx).WithValues("namespace", pod.Namespace, "name", pod.Name)
 
 	cppc := clusterpodplacementconfig.GetClusterPodPlacementConfig()
-	if cppc != nil && cppc.Spec.Plugins != nil && cppc.Spec.Plugins.NodeAffinityScoring != nil && cppc.Spec.Plugins.NodeAffinityScoring.IsEnabled() {
+	if cppc != nil && cppc.PluginsEnabled(common.NodeAffinityScoringPluginName) {
 		pod.EnsureLabel(utils.PreferredNodeAffinityLabel, utils.LabelValueNotSet)
 	}
 	pod.EnsureLabel(utils.NodeAffinityLabel, utils.LabelValueNotSet)


### PR DESCRIPTION
Introduced a generic PluginEnabled method on the Plugins struct to provide a centralized and extendable way to check if a specific plugin is enabled.