### PR TITLE
MULTIARCH-5604: Custom columns for oc get enoexecevent

### DIFF
--- a/apis/multiarch/v1beta1/enoexecevent_types.go
+++ b/apis/multiarch/v1beta1/enoexecevent_types.go
@@ -73,6 +73,10 @@ type ENoExecEventStatus struct {
 //+kubebuilder:subresource:status
 
 // ENoExecEvent is the Schema for the enoexecevents API
+// +kubebuilder:printcolumn:name=NodeName,JSONPath=.status.nodeName,type=string
+// +kubebuilder:printcolumn:name=PodName,JSONPath=.status.podName,type=string
+// +kubebuilder:printcolumn:name=PodNamespace,JSONPath=.status.podNamespace,type=string
+// +kubebuilder:printcolumn:name=ContainerID,JSONPath=.status.containerID,type=string
 type ENoExecEvent struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2025-08-15T11:13:45Z"
+    createdAt: "2025-09-02T04:01:03Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/multiarch.openshift.io_enoexecevents.yaml
+++ b/bundle/manifests/multiarch.openshift.io_enoexecevents.yaml
@@ -14,7 +14,20 @@ spec:
     singular: enoexecevent
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.nodeName
+      name: NodeName
+      type: string
+    - jsonPath: .status.podName
+      name: PodName
+      type: string
+    - jsonPath: .status.podNamespace
+      name: PodNamespace
+      type: string
+    - jsonPath: .status.containerID
+      name: ContainerID
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ENoExecEvent is the Schema for the enoexecevents API

--- a/config/crd/bases/multiarch.openshift.io_enoexecevents.yaml
+++ b/config/crd/bases/multiarch.openshift.io_enoexecevents.yaml
@@ -14,7 +14,20 @@ spec:
     singular: enoexecevent
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.nodeName
+      name: NodeName
+      type: string
+    - jsonPath: .status.podName
+      name: PodName
+      type: string
+    - jsonPath: .status.podNamespace
+      name: PodNamespace
+      type: string
+    - jsonPath: .status.containerID
+      name: ContainerID
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ENoExecEvent is the Schema for the enoexecevents API


### PR DESCRIPTION
Add podName, podNamespace and nodeName as additional columns to enoexecevent status. 


```
oc get enoexecevents                                                  
NAME              NODENAME   PODNAME   PODNAMESPACE   CONTAINERID 
test-events-mto   
```                                                  
