### PR TITLE
MULTIARCH-5584: Support image references with both tag and digest

### DIFF
--- a/pkg/e2e/const.go
+++ b/pkg/e2e/const.go
@@ -20,6 +20,7 @@ const (
 	MyFakeICSPAllowContactSourceTestSourceRegistry = "my-fake-icsp-allow-contact-source-source-registry.io"
 	HelloopenshiftPublicMultiarchImage             = "quay.io/openshifttest/hello-openshift:1.2.0"
 	HelloopenshiftPublicMultiarchImageDigest       = "quay.io/openshifttest/hello-openshift@sha256:4200f438cf2e9446f6bcff9d67ceea1f69ed07a2f83363b7fb52529f7ddd8a83"
+	HelloopenshiftPublicMultiarchImageTagDigest    = "quay.io/openshifttest/hello-openshift:1.2.0@sha256:4200f438cf2e9446f6bcff9d67ceea1f69ed07a2f83363b7fb52529f7ddd8a83"
 	SleepPublicMultiarchImage                      = "quay.io/openshifttest/sleep:1.2.0"
 	RedisPublicMultiarchImage                      = "gcr.io/google_containers/redis:v1"
 	PausePublicMultiarchImage                      = "gcr.io/google_containers/pause:3.2"


### PR DESCRIPTION
The image inspector now supports inspecting image references that specify both a tag and digest. When mirroring images that are frequently updated under the same tag (e.g., operator catalogs), there's a risk of pulling a different image version than intended if the tag is updated during the mirroring process. 
This code follows https://github.com/openshift/oc-mirror/pull/911 and will default to the digest if both digest and tag are present. 
