### PR TITLE
MULTIARCH-5655: Add DELETE permission to enoexec-event-daemon role for rollback functionality

### DIFF
--- a/controllers/operator/enoexecevent_objects.go
+++ b/controllers/operator/enoexecevent_objects.go
@@ -95,7 +95,7 @@ func buildRoleENoExecEventDaemonSet() *rbacv1.Role {
 			{
 				APIGroups: []string{v1beta1.GroupVersion.Group},
 				Resources: []string{v1beta1.ENoExecEventResource},
-				Verbs:     []string{GET, CREATE},
+				Verbs:     []string{GET, CREATE, DELETE},
 			},
 			{
 				APIGroups: []string{v1beta1.GroupVersion.Group},


### PR DESCRIPTION
This PR fixes the following:

- Add DELETE permission to the enoexec-event-daemon role
- Fix pod nodeSelector to correctly use the passed parameter in DescribeTable("it should create an ENoExecEvent CR when a pod triggers an ENOEXEC error on ...")
- Add an e2e test case to ensure no leftover ENoExecEvent CRs
- Add pod logs collection for enoexec when tests fail