### PR TITLE
MULTIARCH-5792: Change the runtime image to UBI minimal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ GOLINT_VERSION = v2.0.2
 
 # TODO: We'd need an upstream builder image that includes gpgme-devel (libgpgme-dev)
 BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19
-RUNTIME_IMAGE ?= quay.io/centos/centos:stream9-minimal
+RUNTIME_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 NO_DOCKER ?= 0
 

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,5 +1,6 @@
 # TODO: delete this Dockerfile when https://issues.redhat.com/browse/KONFLUX-2361
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as builder
+ARG TARGETOS
 ARG TARGETARCH
 ENV GOEXPERIMENT=strictfipsruntime
 
@@ -26,7 +27,7 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o enoexec-daemon cmd/enoexec-daemon/main.go
 
-FROM registry.redhat.io/rhel9-2-els/rhel:9.2
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/enoexec-daemon .


### PR DESCRIPTION
Update the runtime base image from CentOS Stream 9 minimal to Red Hat Universal Base Image (UBI) 9 minimal. The change improves compatibility with OpenShift/Red Hat ecosystems and ensures we're using a supported base image for production deployments.

All Required Shared Libraries:
  1. /lib64/ld-linux-x86-64.so.2 - Dynamic linker/loader
  2. libc.so.6 - GNU C Library (standard C library)
  3. libresolv.so.2 - DNS resolver functions
  4. libgpgme.so.11 - GPG Made Easy library (manager only)
  5. libassuan.so.0 - IPC library for GPG (manager only)
  6. libgpg-error.so.0 - GPG error codes (manager only)

UBI Minimal Package Requirements:
-   glibc
-   glibc-common
-   gpgme
-   libassuan
-   libgpg-error


Note: The multiarch-tuning-operator uses the containers/image library for inspecting container images, which requires libgpgme and its dependencies. These libraries are NOT included in UBI Micro.
