### PR TITLE
MULTIARCH-5366: Deny local PodPlacementConfig creation if ClusterPodPlacementConfig is missing

### DIFF
--- a/internal/controller/operator/clusterpodplacementconfig_controller_test.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller_test.go
@@ -665,6 +665,32 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 			Expect(d.Finalizers).To(ContainElement(utils.ExecFormatErrorFinalizerName))
 		})
 	})
+	Context("the webhook shoud deny PodPlacementConfig creation", func() {
+		It("when the ClusterPodPlacementConfig doesn't exsit", func() {
+			By("Ensure the ClusterPodPlacementConfig doesn't exist")
+			cppc := &v1beta1.ClusterPodPlacementConfig{}
+			err := k8sClient.Get(ctx, crclient.ObjectKey{Name: common.SingletonResourceObjectName}, cppc)
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "the ClusterPodPlacementConfig should not exist", err)
+			By("Create an ephemeral namespace")
+			ns := framework.NewEphemeralNamespace()
+			err = k8sClient.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer k8sClient.Delete(ctx, ns)
+			By("Creating a local PodPlacementConfig")
+			err = k8sClient.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			Expect(err).To(HaveOccurred(), "the PodPlacementConfig should not be accepted", err)
+		})
+	})
 })
 
 func patchDeploymentStatus(name string, g Gomega, patch func(*appsv1.Deployment)) {

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/multiarch-tuning-operator/api/v1alpha1"
 	"github.com/openshift/multiarch-tuning-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -820,6 +821,32 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			err = client.Delete(ctx, enee)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(framework.ValidateDeletion(client, ctx, framework.MainPlugin, framework.ENoExecPlugin)).Should(Succeed())
+		})
+	})
+	Context("the webhook shoud deny local PodPlacementConfig creation", func() {
+		It("when the ClusterPodPlacementConfig doesn't exsit", func() {
+			By("Ensure the ClusterPodPlacementConfig doesn't exist")
+			cppc := &v1beta1.ClusterPodPlacementConfig{}
+			err := client.Get(ctx, runtimeclient.ObjectKey{Name: common.SingletonResourceObjectName}, cppc)
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "the ClusterPodPlacementConfig should not exist", err)
+			By("Create an ephemeral namespace")
+			ns := framework.NewEphemeralNamespace()
+			err = client.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, ns)
+			By("Creating a local PodPlacementConfig")
+			err = client.Create(ctx,
+				NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			Expect(err).To(HaveOccurred(), "the PodPlacementConfig should not be accepted", err)
 		})
 	})
 })


### PR DESCRIPTION
Add webhook validating for local podplacementconfig, deny local PodPlacementConfig creation if ClusterPodPlacementConfig is missing.