### PR TITLE
MULTIARCH-5381:Implement new fallbackArchitecture field in the API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,9 @@ Only one mode can be active at a time. Each mode has its own leader election ID.
 1. Webhook adds scheduling gate to pod, preventing scheduling
 2. PodReconciler watches gated pods
 3. Inspects container images to determine supported architectures
-4. Adds nodeAffinity requirement for kubernetes.io/arch
-5. Removes scheduling gate, allowing scheduler to place pod
+4. If image inspection fails and `fallbackArchitecture` is configured, uses the fallback architecture
+5. Adds nodeAffinity requirement for kubernetes.io/arch
+6. Removes scheduling gate, allowing scheduler to place pod
 
 **Image Inspection** (pkg/image/):
 - Supports multi-arch manifests (OCI, Docker v2.2)
@@ -237,6 +238,7 @@ The operator binary runs in four mutually exclusive modes (controlled by flags i
   - `logVerbosity`: Normal, Debug, Trace, TraceAll
   - `namespaceSelector`: Label selector for processed namespaces
   - `plugins`: Optional plugins configuration (e.g., NodeAffinityScoring for preferred scheduling)
+  - `fallbackArchitecture`: Architecture to use when image inspector cannot determine image architecture (arm64, amd64, ppc64le, s390x, or empty string)
 - Status conditions: Available, Progressing, Degraded, Deprovisioning, PodPlacementControllerNotRolledOut, PodPlacementWebhookNotRolledOut, MutatingWebhookConfigurationNotAvailable
 
 

--- a/api/v1beta1/clusterpodplacementconfig_types.go
+++ b/api/v1beta1/clusterpodplacementconfig_types.go
@@ -48,6 +48,14 @@ type ClusterPodPlacementConfigSpec struct {
 	// This field is optional and will be omitted from the output if not set.
 	// +optional
 	Plugins *plugins.Plugins `json:"plugins,omitempty"`
+
+	// FallbackArchitecture defines the architecture to use if the image inspector cannot determine the image's architecture.
+	// If configured, the PodPlacementController will set the node affinity of the pod to the fallback architecture
+	// if the image inspector cannot determine the image's architecture.
+	// +optional
+	// +kubebuilder:default=""
+	// +kubebuilder:validation:Enum=arm64;amd64;ppc64le;s390x;""
+	FallbackArchitecture string `json:"fallbackArchitecture,omitempty"`
 }
 
 // ClusterPodPlacementConfigStatus defines the observed state of ClusterPodPlacementConfig

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2026-01-16T03:19:24Z"
+    createdAt: "2026-01-14T07:07:10Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/multiarch.openshift.io_clusterpodplacementconfigs.yaml
+++ b/bundle/manifests/multiarch.openshift.io_clusterpodplacementconfigs.yaml
@@ -239,6 +239,19 @@ spec:
             description: ClusterPodPlacementConfigSpec defines the desired state of
               ClusterPodPlacementConfig
             properties:
+              fallbackArchitecture:
+                default: ""
+                description: |-
+                  FallbackArchitecture defines the architecture to use if the image inspector cannot determine the image's architecture.
+                  If configured, the PodPlacementController will set the node affinity of the pod to the fallback architecture
+                  if the image inspector cannot determine the image's architecture.
+                enum:
+                - arm64
+                - amd64
+                - ppc64le
+                - s390x
+                - ""
+                type: string
               logVerbosity:
                 default: Normal
                 description: |-

--- a/config/crd/bases/multiarch.openshift.io_clusterpodplacementconfigs.yaml
+++ b/config/crd/bases/multiarch.openshift.io_clusterpodplacementconfigs.yaml
@@ -219,6 +219,19 @@ spec:
             description: ClusterPodPlacementConfigSpec defines the desired state of
               ClusterPodPlacementConfig
             properties:
+              fallbackArchitecture:
+                default: ""
+                description: |-
+                  FallbackArchitecture defines the architecture to use if the image inspector cannot determine the image's architecture.
+                  If configured, the PodPlacementController will set the node affinity of the pod to the fallback architecture
+                  if the image inspector cannot determine the image's architecture.
+                enum:
+                - arm64
+                - amd64
+                - ppc64le
+                - s390x
+                - ""
+                type: string
               logVerbosity:
                 default: Normal
                 description: |-

--- a/pkg/testing/builder/clusterpodplacementconfig.go
+++ b/pkg/testing/builder/clusterpodplacementconfig.go
@@ -75,3 +75,8 @@ func (p *ClusterPodPlacementConfigBuilder) WithNodeAffinityScoringTerm(architect
 	})
 	return p
 }
+
+func (p *ClusterPodPlacementConfigBuilder) WithFallbackArchitecture(architecture string) *ClusterPodPlacementConfigBuilder {
+	p.Spec.FallbackArchitecture = architecture
+	return p
+}


### PR DESCRIPTION
Add `fallbackArchitecture` field to ClusterPodPlacementConfig.
- Type: string  
- Optional, default: ""  
- Allowed values: "arm64", "amd64", "ppc64le", "s390x", or empty string  