### PR TITLE
MULTIARCH-5382: Complete fallbackArchitecture validation and handling logic

### DIFF
--- a/internal/controller/podplacement/events.go
+++ b/internal/controller/podplacement/events.go
@@ -12,6 +12,7 @@ const (
 	ArchitectureAwareSchedulingGateRemovalSuccess = "ArchAwareSchedGateRemovalSuccess"
 	NoSupportedArchitecturesFound                 = "NoSupportedArchitecturesFound"
 	ArchitecturePreferredAffinityDuplicates       = "ArchAwarePreferredAffinityDuplicates"
+	ArchitectureAwareFallbackNodeAffinitySet      = "ArchAwareFallbackPredicateSet"
 
 	SchedulingGateAddedMsg            = "Successfully gated with the " + utils.SchedulingGateName + " scheduling gate"
 	SchedulingGateRemovalSuccessMsg   = "Successfully removed the " + utils.SchedulingGateName + " scheduling gate"
@@ -28,4 +29,5 @@ const (
 	NoSupportedArchitecturesFoundMsg    = "Pod cannot be scheduled due to incompatible image architectures; container images have no supported architectures in common"
 	ArchitectureAwareGatedPodIgnoredMsg = "The gated pod has been modified and is no longer eligible for architecture-aware scheduling"
 	ImageInspectionErrorMaxRetriesMsg   = "Failed to retrieve the supported architectures after multiple retries"
+	ArchitectureFallbackSetupMsg        = "Image inspection failed; setting the nodeAffinity to the fallback architecture: "
 )

--- a/internal/controller/podplacement/pod_model_test.go
+++ b/internal/controller/podplacement/pod_model_test.go
@@ -651,6 +651,38 @@ func TestPod_SetPreferredArchNodeAffinity(t *testing.T) {
 	}
 }
 
+func TestPod_setRequiredNodeAffinityToFallbackArchitecture(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		architecture string
+		want         *v1.Pod
+	}{
+		{
+			name:         "pod with no affinity, sets fallback arch",
+			pod:          NewPod().Build(),
+			architecture: utils.ArchitectureAmd64,
+			want: NewPod().WithNodeSelectorTermsMatchExpressions(
+				[]v1.NodeSelectorRequirement{
+					{
+						Key:      utils.ArchLabel,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{utils.ArchitectureAmd64},
+					},
+				},
+			).Build(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := newPod(tt.pod, ctx, nil)
+			pod.setRequiredNodeAffinityToFallbackArchitecture(tt.architecture)
+			g := NewGomegaWithT(t)
+			g.Expect(pod.Spec.Affinity).Should(Equal(tt.want.Spec.Affinity))
+		})
+	}
+}
+
 func TestPod_SetNodeAffinityArchRequirement(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/internal/controller/podplacement/pod_reconciler.go
+++ b/internal/controller/podplacement/pod_reconciler.go
@@ -150,6 +150,11 @@ func (r *PodReconciler) processPod(ctx context.Context, pod *Pod) {
 		// Publish this event and remove the scheduling gate.
 		log.Info("Max retries Reached. The pod will not have the nodeAffinity set.")
 		pod.PublishEvent(corev1.EventTypeWarning, ImageArchitectureInspectionError, fmt.Sprintf("%s: %s", ImageInspectionErrorMaxRetriesMsg, err.Error()))
+
+		if cppc != nil && cppc.Spec.FallbackArchitecture != "" {
+			log.Info("Setting the nodeAffinity to the fallback architecture", "fallbackArchitecture", cppc.Spec.FallbackArchitecture)
+			pod.setRequiredNodeAffinityToFallbackArchitecture(cppc.Spec.FallbackArchitecture)
+		}
 	}
 	// If the pod has been processed successfully or the max retries have been reached, remove the scheduling gate.
 	if err == nil || pod.maxRetries() {

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -60,6 +60,7 @@ const (
 	SingleArchLabel                        = "multiarch.openshift.io/single-arch"
 	MultiArchLabel                         = "multiarch.openshift.io/multi-arch"
 	NoSupportedArchLabel                   = "multiarch.openshift.io/no-supported-arch"
+	FallbackArchitectureLabel              = "multiarch.openshift.io/fallback-arch"
 	ImageInspectionErrorLabel              = "multiarch.openshift.io/image-inspect-error"
 	ImageInspectionErrorCountLabel         = "multiarch.openshift.io/image-inspect-error-count"
 	LabelGroup                             = "multiarch.openshift.io"


### PR DESCRIPTION
The node affinity will be set to the configured `fallbackArchitecture` when image
inspection repeatedly fails and the `fallbackArchitecture` field is not empty.

This PR also includes the following changes:
- Add the `multiarch.openshift.io/fallback-arch` label to the Pod
- Introduce the `ArchAwareFallbackPredicateSet` event along with the corresponding
  event message