### PR TITLE
MULTIARCH-5370: Add/remove ClusterPodPlacementConfig finalizer on PodPlacementConfig changes

### DIFF
--- a/internal/controller/operator/clusterpodplacementconfig_controller_test.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller_test.go
@@ -733,10 +733,89 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 				WithName("test-ppc").
 				WithNamespace(ns.Name).Build())
 			Expect(err).NotTo(HaveOccurred(), "failed to delete PodPlacementConfig")
+			By("Verifying the cppc removing the no-pod-placement-config finalizer")
+			Eventually(func(g Gomega) {
+				cppc := &v1beta1.ClusterPodPlacementConfig{}
+				err = k8sClient.Get(ctx, crclient.ObjectKey{
+					Name: common.SingletonResourceObjectName,
+				}, cppc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cppc.Finalizers).NotTo(ContainElement(utils.CPPCNoPPCObjectFinalizer))
+			}).Should(Succeed(), "the ClusterPodPlacementConfig should remove the no-pod-placement-config finalizer")
 			By("Deleting ClusterPodPlacementConfig after local configs are removed")
 			err = k8sClient.Delete(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
 			Expect(err).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
 			Eventually(framework.ValidateDeletion(k8sClient, ctx)).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
+		})
+	})
+	Context("when managing the no-pod-placement-config finalizer", func() {
+		BeforeEach(func() {
+			By("Creating the ClusterPodPlacementConfig")
+			err := k8sClient.Create(ctx, builder.NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				Build())
+			Expect(err).NotTo(HaveOccurred(), "failed to create ClusterPodPlacementConfig", err)
+			validateReconcile()
+		})
+		AfterEach(func() {
+			By("Deleting the ClusterPodPlacementConfig")
+			err := k8sClient.Delete(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
+			Expect(crclient.IgnoreNotFound(err)).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
+			Eventually(framework.ValidateDeletion(k8sClient, ctx)).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
+		})
+		It("should add the finalizer when a namespaced PodPlacementConfig exists and remove it when none exist", func() {
+			By("Create an ephemeral namespace")
+			ns := framework.NewEphemeralNamespace()
+			err := k8sClient.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer k8sClient.Delete(ctx, ns)
+			By("Creating a local PodPlacementConfig with a Priority setting")
+			err = k8sClient.Create(ctx,
+				builder.NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+			//nolint:errcheck
+			defer k8sClient.Delete(ctx, builder.NewPodPlacementConfig().WithName("test-ppc").WithNamespace(ns.Name).Build())
+			By("Verifying the cppc adding the no-pod-placement-config finalizer")
+			Eventually(func(g Gomega) {
+				cppc := &v1beta1.ClusterPodPlacementConfig{}
+				err = k8sClient.Get(ctx, crclient.ObjectKey{
+					Name: common.SingletonResourceObjectName,
+				}, cppc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cppc.Finalizers).To(ContainElement(utils.CPPCNoPPCObjectFinalizer))
+			}).Should(Succeed(), "the ClusterPodPlacementConfig should have the correct finalizer")
+			By("Deleting above created PodPlacementConfig")
+			err = k8sClient.Delete(ctx, builder.NewPodPlacementConfig().
+				WithName("test-ppc").
+				WithNamespace(ns.Name).Build())
+			Expect(err).NotTo(HaveOccurred())
+			By("Check the PodPlacementConfig is deleted")
+			Eventually(func(g Gomega) {
+				ppc := &v1beta1.PodPlacementConfig{}
+				err := k8sClient.Get(ctx, crclient.ObjectKey{
+					Name:      "test-ppc",
+					Namespace: ns.Name,
+				}, ppc)
+				Expect(errors.IsNotFound(err)).To(BeTrue(), "failed to delete podplacementconfig", err)
+			}).Should(Succeed(), "the PodPlacementConfig should be deleted")
+			By("Verifying the cppc removing the no-pod-placement-config finalizer")
+			Eventually(func(g Gomega) {
+				cppc := &v1beta1.ClusterPodPlacementConfig{}
+				err = k8sClient.Get(ctx, crclient.ObjectKey{
+					Name: common.SingletonResourceObjectName,
+				}, cppc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cppc.Finalizers).NotTo(ContainElement(utils.CPPCNoPPCObjectFinalizer))
+			}).Should(Succeed(), "the ClusterPodPlacementConfig should remove the no-pod-placement-config finalizer")
 		})
 	})
 })

--- a/internal/controller/podplacementconfig/podplacementconfig_controller_test.go
+++ b/internal/controller/podplacementconfig/podplacementconfig_controller_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Internal/Controller/PodPlacementConfig/PodPlacementConfigRecon
 				Expect(err).NotTo(HaveOccurred())
 				//nolint:errcheck
 				defer k8sClient.Delete(ctx, ns)
-				By("Creating a local PodPlacementConfig with a Prioriry setting")
+				By("Creating a local PodPlacementConfig with a Priority setting")
 				err = k8sClient.Create(ctx,
 					builder.NewPodPlacementConfig().
 						WithName("test-ppc").
@@ -150,7 +150,7 @@ var _ = Describe("Internal/Controller/PodPlacementConfig/PodPlacementConfigRecon
 					g.Expect(err).NotTo(HaveOccurred(), "failed to get podplacementconfig", err)
 					g.Expect(ppc.Spec.Priority).To(Equal(uint8(50)), "the ppc Priority should equal 50")
 				}).Should(Succeed(), "the PodPlacementConfig should be created")
-				By("Creating another local PodPlacementConfig with the same Prioriry")
+				By("Creating another local PodPlacementConfig with the same Priority")
 				err = k8sClient.Create(ctx,
 					builder.NewPodPlacementConfig().
 						WithName("test-ppc-2").

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -885,11 +885,93 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 				WithName("test-ppc").
 				WithNamespace(ns.Name).Build())
 			Expect(err).NotTo(HaveOccurred(), "failed to delete PodPlacementConfig")
+			By("Verifying the cppc removing the no-pod-placement-config finalizer")
+			Eventually(func(g Gomega) {
+				cppc := &v1beta1.ClusterPodPlacementConfig{}
+				err = client.Get(ctx, runtimeclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: common.SingletonResourceObjectName,
+					},
+				}), cppc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cppc.Finalizers).NotTo(ContainElement(utils.CPPCNoPPCObjectFinalizer))
+			}).Should(Succeed(), "the ClusterPodPlacementConfig should remove the no-pod-placement-config finalizer")
 			By("Deleting ClusterPodPlacementConfig after local configs are removed")
 			err = client.Delete(ctx, NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
 			Expect(err).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
 			Expect(runtimeclient.IgnoreNotFound(err)).NotTo(HaveOccurred())
 			Eventually(framework.ValidateDeletion(client, ctx)).Should(Succeed())
+		})
+	})
+	Context("when managing the no-pod-placement-config finalizer", func() {
+		BeforeEach(func() {
+			err := client.Create(ctx,
+				NewClusterPodPlacementConfig().
+					WithName(common.SingletonResourceObjectName).
+					Build(),
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create the ClusterPodPlacementConfig", err)
+			Eventually(framework.ValidateCreation(client, ctx)).Should(Succeed())
+		})
+		It("should add the finalizer when a namespaced PodPlacementConfig exists and remove it when none exist", func() {
+			By("Create an ephemeral namespace")
+			ns := framework.NewEphemeralNamespace()
+			err := client.Create(ctx, ns)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint:errcheck
+			defer client.Delete(ctx, ns)
+			By("Creating a local PodPlacementConfig with a Priority setting")
+			err = client.Create(ctx,
+				NewPodPlacementConfig().
+					WithName("test-ppc").
+					WithNamespace(ns.Name).
+					WithPriority(50).
+					WithPlugins().
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			)
+			Expect(err).NotTo(HaveOccurred(), "the PodPlacementConfig should be accepted", err)
+			//nolint:errcheck
+			defer client.Delete(ctx, NewPodPlacementConfig().WithName("test-ppc").WithNamespace(ns.Name).Build())
+			By("Verifying the cppc adding the no-pod-placement-config finalizer")
+			Eventually(func(g Gomega) {
+				cppc := &v1beta1.ClusterPodPlacementConfig{}
+				err = client.Get(ctx, runtimeclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: common.SingletonResourceObjectName,
+					},
+				}), cppc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cppc.Finalizers).To(ContainElement(utils.CPPCNoPPCObjectFinalizer))
+			}).Should(Succeed(), "the ClusterPodPlacementConfig should have the correct finalizer")
+			By("Deleting above created PodPlacementConfig")
+			err = client.Delete(ctx, NewPodPlacementConfig().
+				WithName("test-ppc").
+				WithNamespace(ns.Name).Build())
+			Expect(err).NotTo(HaveOccurred())
+			By("Check the PodPlacementConfig is deleted")
+			Eventually(func(g Gomega) {
+				ppc := &v1beta1.PodPlacementConfig{}
+				err := client.Get(ctx, runtimeclient.ObjectKeyFromObject(&v1beta1.PodPlacementConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ppc",
+						Namespace: ns.Name,
+					},
+				}), ppc)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "failed to delete podplacementconfig", err)
+			}).Should(Succeed(), "the PodPlacementConfig should be deleted")
+			By("Verifying the cppc removing the no-pod-placement-config finalizer")
+			Eventually(func(g Gomega) {
+				cppc := &v1beta1.ClusterPodPlacementConfig{}
+				err = client.Get(ctx, runtimeclient.ObjectKeyFromObject(&v1beta1.ClusterPodPlacementConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: common.SingletonResourceObjectName,
+					},
+				}), cppc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cppc.Finalizers).NotTo(ContainElement(utils.CPPCNoPPCObjectFinalizer))
+			}).Should(Succeed(), "the ClusterPodPlacementConfig should remove the no-pod-placement-config finalizer")
 		})
 	})
 })

--- a/pkg/e2e/podplacementconfig/pod_placement_config_test.go
+++ b/pkg/e2e/podplacementconfig/pod_placement_config_test.go
@@ -44,7 +44,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 			Expect(err).NotTo(HaveOccurred())
 			//nolint:errcheck
 			defer client.Delete(ctx, ns)
-			By("Creating a local PodPlacementConfig with a Prioriry setting")
+			By("Creating a local PodPlacementConfig with a Priority setting")
 			err = client.Create(ctx,
 				builder.NewPodPlacementConfig().
 					WithName("test-ppc").
@@ -68,7 +68,7 @@ var _ = Describe("The Multiarch Tuning Operator", func() {
 				g.Expect(err).NotTo(HaveOccurred(), "failed to get podplacementconfig", err)
 				g.Expect(ppc.Spec.Priority).To(Equal(uint8(50)), "the ppc Priority should equal 50")
 			}).Should(Succeed(), "the PodPlacementConfig should be created")
-			By("Creating another local PodPlacementConfig with the same Prioriry")
+			By("Creating another local PodPlacementConfig with the same Priority")
 			err = client.Create(ctx,
 				builder.NewPodPlacementConfig().
 					WithName("test-ppc-2").

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -31,6 +31,7 @@ const (
 	SchedulingGateLabelValueGated   = "gated"
 	SchedulingGateLabelValueRemoved = "removed"
 	PodPlacementFinalizerName       = "finalizers.multiarch.openshift.io/pod-placement"
+	CPPCNoPPCObjectFinalizer        = "finalizers.multiarch.openshift.io/no-pod-placement-config"
 	SingleArchLabel                 = "multiarch.openshift.io/single-arch"
 	MultiArchLabel                  = "multiarch.openshift.io/multi-arch"
 	NoSupportedArchLabel            = "multiarch.openshift.io/no-supported-arch"


### PR DESCRIPTION
Add the finalizer finalizers.multiarch.openshift.io/no-pod-placement-config when the first PodPlacementConfig is created and remove it when the last pod placement config is removed.