### PR TITLE
MULTIARCH-5764: Fix short-name e2e test failures on 4.21

### DIFF
--- a/pkg/e2e/podplacement/e2e_test.go
+++ b/pkg/e2e/podplacement/e2e_test.go
@@ -209,7 +209,7 @@ func createRegistryConfigTestData() {
 	image.Spec.RegistrySources.BlockedRegistries = append(image.Spec.RegistrySources.BlockedRegistries, framework.GetImageRepository(e2e.PausePublicMultiarchImage))
 	By("Configuring containerRuntimeSearchRegistries in image.config")
 	image.Spec.RegistrySources.ContainerRuntimeSearchRegistries = append(image.Spec.RegistrySources.ContainerRuntimeSearchRegistries,
-		"quay.io", "registry.access.redhat.com", "docker.io")
+		"quay.io")
 	err = client.Update(ctx, image)
 	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
Starting with [CRI-O 1.34](https://github.com/cri-o/cri-o/releases/tag/v1.34.0), short-name enforcement is enabled. If multiple registries are configured in `unqualified-search-registries`, image short names must be unambiguous. The e2e test cases are updated to comply with this behavior.

We haven’t added the 4.21 jobs yet, but I’ve tested it locally.
