### PR TITLE
Add check to see if gpgme is already installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ ARG TARGETARCH
 # This only affects the builder stage (used during compilation) and does not impact the
 # security of the final runtime image, which runs as USER 65532:65532 (non-root).
 USER 0
-RUN if which apt-get; then apt-get update && apt-get install -y libgpgme-dev && apt-get -y clean autoclean; \
-    elif which dnf; then dnf install -y gpgme-devel && dnf clean all -y; fi;
+RUN if ! pkg-config --exists gpgme 2>/dev/null; then \
+        if which apt-get; then apt-get update && apt-get install -y libgpgme-dev && apt-get -y clean autoclean; \
+        elif which dnf; then dnf install -y gpgme-devel && dnf clean all -y; fi; \
+    fi
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Issue with running `make docker-build` as `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21` already has gpme installed.

```
Error: building at STEP "RUN if which apt-get; then apt-get update && apt-get install -y libgpgme-dev && apt-get -y clean autoclean;     elif which dnf; then dnf install -y gpgme-devel && dnf clean all -y; fi;": while running runtime: exit status 1
make: *** [Makefile:212: docker-build] Error 1

```

Added a check to see if gpgme is already installed before attempting to install it. This prevents the dnf repository error you were seeing when using CI build images that already have gpgme-devel but lack configured yum/dnf repositories.