### PR TITLE
MULTIARCH-5369: Add PodPlacementConfig plugin detection

### DIFF
--- a/api/v1beta1/podplacementconfig_types.go
+++ b/api/v1beta1/podplacementconfig_types.go
@@ -33,16 +33,17 @@ type PodPlacementConfigSpec struct {
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 
 	// Plugins defines the configurable plugins for this component.
-	// This field is optional and will be omitted from the output if not set.
-	// +optional
-	Plugins *plugins.LocalPlugins `json:"plugins,omitempty"`
+	// This field is required.
+	// +kubebuilder:validation:Required
+	Plugins *plugins.LocalPlugins `json:"plugins"`
 
 	// Priority defines the priority of the PodPlacementConfig and only accepts values in the range 0-255.
 	// This field is optional and will default to 0 if not set.
 	// +optional
+	// +kubebuilder:default:=0
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=255
-	Priority uint8 `json:"priority,omitempty"`
+	Priority uint8 `json:"priority"`
 }
 
 // PodPlacementConfig defines the configuration for the architecture aware pod placement operand in a given namespace for a subset of its pods based on the provided labelSelector.
@@ -54,7 +55,7 @@ type PodPlacementConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   PodPlacementConfigSpec   `json:"spec,omitempty"`
+	Spec   PodPlacementConfigSpec   `json:"spec"`
 	Status PodPlacementConfigStatus `json:"status,omitempty"`
 }
 

--- a/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiarch-tuning-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     categories: OpenShift Optional, Other
     console.openshift.io/disable-operand-delete: "false"
     containerImage: registry.ci.openshift.org/origin/multiarch-tuning-operator:main
-    createdAt: "2026-01-14T07:07:10Z"
+    createdAt: "2026-01-28T21:24:08Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/multiarch.openshift.io_podplacementconfigs.yaml
+++ b/bundle/manifests/multiarch.openshift.io_podplacementconfigs.yaml
@@ -92,7 +92,7 @@ spec:
               plugins:
                 description: |-
                   Plugins defines the configurable plugins for this component.
-                  This field is optional and will be omitted from the output if not set.
+                  This field is required.
                 properties:
                   nodeAffinityScoring:
                     description: NodeAffinityScoring is the plugin that implements
@@ -137,16 +137,21 @@ spec:
                     type: object
                 type: object
               priority:
+                default: 0
                 description: |-
                   Priority defines the priority of the PodPlacementConfig and only accepts values in the range 0-255.
                   This field is optional and will default to 0 if not set.
                 maximum: 255
                 minimum: 0
                 type: integer
+            required:
+            - plugins
             type: object
           status:
             description: PodPlacementConfigStatus defines the observed state of PodPlacementConfig
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/config/crd/bases/multiarch.openshift.io_podplacementconfigs.yaml
+++ b/config/crd/bases/multiarch.openshift.io_podplacementconfigs.yaml
@@ -92,7 +92,7 @@ spec:
               plugins:
                 description: |-
                   Plugins defines the configurable plugins for this component.
-                  This field is optional and will be omitted from the output if not set.
+                  This field is required.
                 properties:
                   nodeAffinityScoring:
                     description: NodeAffinityScoring is the plugin that implements
@@ -137,16 +137,21 @@ spec:
                     type: object
                 type: object
               priority:
+                default: 0
                 description: |-
                   Priority defines the priority of the PodPlacementConfig and only accepts values in the range 0-255.
                   This field is optional and will default to 0 if not set.
                 maximum: 255
                 minimum: 0
                 type: integer
+            required:
+            - plugins
             type: object
           status:
             description: PodPlacementConfigStatus defines the observed state of PodPlacementConfig
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -396,6 +396,14 @@ func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context,
 			log.Error(err, "Deletion blocked due to existing PodPlacementConfig resources")
 			return err
 		}
+		// All PPCs are gone, remove the finalizer
+		log.V(1).Info("No PodPlacementConfig resources found, removing no-pod-placement-config finalizer")
+		controllerutil.RemoveFinalizer(clusterPodPlacementConfig, utils.CPPCNoPPCObjectFinalizer)
+		if err := r.Update(ctx, clusterPodPlacementConfig); err != nil {
+			log.Error(err, "Unable to remove no-pod-placement-config finalizer from ClusterPodPlacementConfig")
+			return err
+		}
+		return nil
 	}
 
 	log.Info("Looking for pods with the scheduling gate")

--- a/internal/controller/operator/clusterpodplacementconfig_controller_test.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller_test.go
@@ -451,7 +451,7 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 					framework.NewConditionTypeStatusTuple(v1beta1.DegradedType, corev1.ConditionTrue),
 					framework.NewConditionTypeStatusTuple(v1beta1.PodPlacementControllerNotRolledOutType, corev1.ConditionTrue),
 					framework.NewConditionTypeStatusTuple(v1beta1.PodPlacementWebhookNotRolledOutType, corev1.ConditionFalse),
-					framework.NewConditionTypeStatusTuple(v1beta1.MutatingWebhookConfigurationNotAvailable, corev1.ConditionFalse),
+					framework.NewConditionTypeStatusTuple(v1beta1.MutatingWebhookConfigurationNotAvailable, corev1.ConditionTrue),
 					framework.NewConditionTypeStatusTuple(v1beta1.DeprovisioningType, corev1.ConditionFalse),
 				)).Should(Succeed(), "the ClusterPodPlacementConfig should have the correct conditions")
 				By("Verify no mutating webhook configuration is not available")

--- a/internal/controller/operator/podplacement_objects.go
+++ b/internal/controller/operator/podplacement_objects.go
@@ -195,6 +195,11 @@ func buildClusterRoleWebhook() *rbacv1.ClusterRole {
 			Verbs:     []string{LIST, WATCH, GET},
 		},
 		{
+			APIGroups: []string{v1beta1.GroupVersion.Group},
+			Resources: []string{v1beta1.PodPlacementConfigResource},
+			Verbs:     []string{LIST, WATCH, GET},
+		},
+		{
 			APIGroups: []string{""},
 			Resources: []string{"pods"},
 			Verbs:     []string{LIST, WATCH, GET},

--- a/internal/controller/podplacement/pod_model_test.go
+++ b/internal/controller/podplacement/pod_model_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -1065,7 +1066,7 @@ func TestPod_shouldIgnorePod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := newPod(tt.fields.Pod, tt.fields.ctx, tt.fields.recorder)
-			if got := pod.shouldIgnorePod(&v1beta1.ClusterPodPlacementConfig{}); got != tt.want {
+			if got := pod.shouldIgnorePod(&v1beta1.ClusterPodPlacementConfig{}, []v1beta1.PodPlacementConfig{}); got != tt.want {
 				t.Errorf("shouldIgnorePod() = %v, want %v", got, tt.want)
 			}
 		})
@@ -1124,6 +1125,7 @@ func TestPod_shouldIgnorePodWithPluginsEnabledInCPPC(t *testing.T) {
 				WithName(common.SingletonResourceObjectName).
 				WithNodeAffinityScoring(true).
 				WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 1).Build(),
+				[]v1beta1.PodPlacementConfig{},
 			); got != tt.want {
 				t.Errorf("shouldIgnorePod() = %v, want %v", got, tt.want)
 			}
@@ -1164,7 +1166,8 @@ func TestPod_shouldIgnorePodWithPluginsDisabledInCPPC(t *testing.T) {
 			if got := pod.shouldIgnorePod(NewClusterPodPlacementConfig().
 				WithName(common.SingletonResourceObjectName).
 				WithNodeAffinityScoring(false).
-				WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 1).Build()); got != tt.want {
+				WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 1).Build(),
+				[]v1beta1.PodPlacementConfig{}); got != tt.want {
 				t.Errorf("shouldIgnorePod() = %v, want %v", got, tt.want)
 			}
 		})
@@ -1352,6 +1355,754 @@ func TestIsNodeSelectorConfiguredForArchitecture(t *testing.T) {
 			result := pod.isNodeSelectorConfiguredForArchitecture()
 			if result != test.expected {
 				t.Errorf("expected %v, got %v", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestPod_filterMatchingPPCs(t *testing.T) {
+	tests := []struct {
+		name      string
+		podLabels map[string]string
+		ppcList   *v1beta1.PodPlacementConfigList
+		wantLen   int
+		wantNames []string // names of PPCs expected in result
+	}{
+		{
+			name:      "empty PPC list returns empty slice",
+			podLabels: map[string]string{"app": "test"},
+			ppcList:   &v1beta1.PodPlacementConfigList{Items: []v1beta1.PodPlacementConfig{}},
+			wantLen:   0,
+			wantNames: []string{},
+		},
+		{
+			name:      "single PPC with matching label selector",
+			podLabels: map[string]string{"app": "test", "env": "prod"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("matching-ppc").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						}).
+						Build(),
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"matching-ppc"},
+		},
+		{
+			name:      "single PPC with non-matching label selector",
+			podLabels: map[string]string{"app": "test"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("non-matching-ppc").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "other"},
+						}).
+						Build(),
+				},
+			},
+			wantLen:   0,
+			wantNames: []string{},
+		},
+		{
+			name:      "multiple PPCs - some match, some don't",
+			podLabels: map[string]string{"app": "test", "tier": "backend"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("match-1").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						}).
+						Build(),
+					*NewPodPlacementConfig().
+						WithName("no-match").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "other"},
+						}).
+						Build(),
+					*NewPodPlacementConfig().
+						WithName("match-2").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{"tier": "backend"},
+						}).
+						Build(),
+				},
+			},
+			wantLen:   2,
+			wantNames: []string{"match-1", "match-2"},
+		},
+		{
+			name:      "PPC with invalid label selector is skipped",
+			podLabels: map[string]string{"app": "test"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("valid-ppc").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						}).
+						Build(),
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "invalid-ppc",
+							Namespace: "test-ns",
+						},
+						Spec: v1beta1.PodPlacementConfigSpec{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "invalid~key", // Invalid key with special char
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"valid-ppc"},
+		},
+		{
+			name:      "PPC with nil label selector matches pod",
+			podLabels: map[string]string{"app": "test"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("nil-selector-ppc").
+						WithNamespace("test-ns").
+						Build(),
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"nil-selector-ppc"},
+		},
+		{
+			name:      "pod with no labels - PPC with empty selector matches",
+			podLabels: map[string]string{},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("empty-selector-ppc").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{}).
+						Build(),
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"empty-selector-ppc"},
+		},
+		{
+			name:      "PPC with MatchExpressions selector",
+			podLabels: map[string]string{"app": "test", "version": "v1"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("match-expr-ppc").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test", "prod"},
+								},
+							},
+						}).
+						Build(),
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"match-expr-ppc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build pod with specified labels
+			podBuilder := NewPod()
+			for k, v := range tt.podLabels {
+				podBuilder = podBuilder.WithLabels(k, v)
+			}
+			pod := newPod(podBuilder.Build(), ctx, nil)
+
+			g := NewGomegaWithT(t)
+			result := pod.filterMatchingPPCs(tt.ppcList)
+
+			// Check length
+			g.Expect(result).To(HaveLen(tt.wantLen), "unexpected number of matching PPCs")
+
+			// Check that expected PPCs are in the result
+			if len(tt.wantNames) > 0 {
+				resultNames := make([]string, len(result))
+				for i, ppc := range result {
+					resultNames[i] = ppc.Name
+				}
+				for _, wantName := range tt.wantNames {
+					g.Expect(resultNames).To(ContainElement(wantName),
+						"expected PPC %s to be in results", wantName)
+				}
+			}
+		})
+	}
+}
+
+func TestPod_hasMatchingPPCWithPlugin(t *testing.T) {
+	tests := []struct {
+		name         string
+		matchingPPCs []v1beta1.PodPlacementConfig
+		want         bool
+	}{
+		{
+			name:         "empty PPC list returns false",
+			matchingPPCs: []v1beta1.PodPlacementConfig{},
+			want:         false,
+		},
+		{
+			name: "single PPC with NodeAffinityScoring enabled returns true",
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				*NewPodPlacementConfig().
+					WithName("ppc-with-plugin").
+					WithNamespace("test-ns").
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			},
+			want: true,
+		},
+		{
+			name: "single PPC with NodeAffinityScoring disabled returns false",
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				*NewPodPlacementConfig().
+					WithName("ppc-no-plugin").
+					WithNamespace("test-ns").
+					WithNodeAffinityScoring(false).
+					Build(),
+			},
+			want: false,
+		},
+		{
+			name: "single PPC with nil Plugins returns false",
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ppc-nil-plugins",
+						Namespace: "test-ns",
+					},
+					Spec: v1beta1.PodPlacementConfigSpec{
+						Plugins: &plugins.LocalPlugins{},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple PPCs - none with plugin returns false",
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				*NewPodPlacementConfig().
+					WithName("ppc-1").
+					WithNamespace("test-ns").
+					WithNodeAffinityScoring(false).
+					Build(),
+				*NewPodPlacementConfig().
+					WithName("ppc-2").
+					WithNamespace("test-ns").
+					WithNodeAffinityScoring(false).
+					Build(),
+			},
+			want: false,
+		},
+		{
+			name: "multiple PPCs - at least one with plugin returns true",
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				*NewPodPlacementConfig().
+					WithName("ppc-no-plugin").
+					WithNamespace("test-ns").
+					WithNodeAffinityScoring(false).
+					Build(),
+				*NewPodPlacementConfig().
+					WithName("ppc-with-plugin").
+					WithNamespace("test-ns").
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureArm64, 30).
+					Build(),
+			},
+			want: true,
+		},
+		{
+			name: "multiple PPCs - all with plugin returns true",
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				*NewPodPlacementConfig().
+					WithName("ppc-1").
+					WithNamespace("test-ns").
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+				*NewPodPlacementConfig().
+					WithName("ppc-2").
+					WithNamespace("test-ns").
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureArm64, 30).
+					Build(),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := newPod(NewPod().Build(), ctx, nil)
+			g := NewGomegaWithT(t)
+			result := pod.hasMatchingPPCWithPlugin(tt.matchingPPCs)
+			g.Expect(result).To(Equal(tt.want), "unexpected result from hasMatchingPPCWithPlugin")
+		})
+	}
+}
+
+func TestPod_filterMatchingPPCs_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		podLabels map[string]string
+		ppcList   *v1beta1.PodPlacementConfigList
+		wantLen   int
+		wantNames []string
+	}{
+		{
+			name:      "pod with no labels - PPC with MatchExpressions requiring labels",
+			podLabels: map[string]string{},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("requires-labels-ppc").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpExists,
+								},
+							},
+						}).
+						Build(),
+				},
+			},
+			wantLen:   0,
+			wantNames: []string{},
+		},
+		{
+			name:      "pod with labels - PPC with NotIn operator",
+			podLabels: map[string]string{"env": "prod", "tier": "frontend"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("exclude-dev-ppc").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "env",
+									Operator: metav1.LabelSelectorOpNotIn,
+									Values:   []string{"dev", "staging"},
+								},
+							},
+						}).
+						Build(),
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"exclude-dev-ppc"},
+		},
+		{
+			name:      "pod with labels - PPC with DoesNotExist operator",
+			podLabels: map[string]string{"app": "test"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("no-debug-ppc").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "debug",
+									Operator: metav1.LabelSelectorOpDoesNotExist,
+								},
+							},
+						}).
+						Build(),
+				},
+			},
+			wantLen:   1,
+			wantNames: []string{"no-debug-ppc"},
+		},
+		{
+			name:      "pod with labels - multiple PPCs with complex selectors",
+			podLabels: map[string]string{"app": "myapp", "env": "prod", "version": "v2"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					*NewPodPlacementConfig().
+						WithName("match-app-and-env").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "myapp"},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "env",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"prod", "staging"},
+								},
+							},
+						}).
+						Build(),
+					*NewPodPlacementConfig().
+						WithName("match-version-not-v1").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "version",
+									Operator: metav1.LabelSelectorOpNotIn,
+									Values:   []string{"v1"},
+								},
+							},
+						}).
+						Build(),
+					*NewPodPlacementConfig().
+						WithName("no-match").
+						WithNamespace("test-ns").
+						WithLabelSelector(&metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "otherapp"},
+						}).
+						Build(),
+				},
+			},
+			wantLen:   2,
+			wantNames: []string{"match-app-and-env", "match-version-not-v1"},
+		},
+		{
+			name:      "multiple PPCs with all invalid selectors",
+			podLabels: map[string]string{"app": "test"},
+			ppcList: &v1beta1.PodPlacementConfigList{
+				Items: []v1beta1.PodPlacementConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "invalid-1",
+							Namespace: "test-ns",
+						},
+						Spec: v1beta1.PodPlacementConfigSpec{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "invalid~key1",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"value"},
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "invalid-2",
+							Namespace: "test-ns",
+						},
+						Spec: v1beta1.PodPlacementConfigSpec{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "another-invalid@key",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLen:   0,
+			wantNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podBuilder := NewPod()
+			for k, v := range tt.podLabels {
+				podBuilder = podBuilder.WithLabels(k, v)
+			}
+			pod := newPod(podBuilder.Build(), ctx, nil)
+
+			g := NewGomegaWithT(t)
+			result := pod.filterMatchingPPCs(tt.ppcList)
+
+			g.Expect(result).To(HaveLen(tt.wantLen), "unexpected number of matching PPCs")
+
+			if len(tt.wantNames) > 0 {
+				resultNames := make([]string, len(result))
+				for i, ppc := range result {
+					resultNames[i] = ppc.Name
+				}
+				for _, wantName := range tt.wantNames {
+					g.Expect(resultNames).To(ContainElement(wantName),
+						"expected PPC %s to be in results", wantName)
+				}
+			}
+		})
+	}
+}
+
+func TestPod_shouldIgnorePod_WithMatchingPPCs(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		cppc         *v1beta1.ClusterPodPlacementConfig
+		matchingPPCs []v1beta1.PodPlacementConfig
+		want         bool
+	}{
+		{
+			name: "pod should be processed - CPPC has plugin disabled but matching PPC has it enabled",
+			pod:  NewPod().WithNamespace("test").Build(),
+			cppc: NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				WithNodeAffinityScoring(false).
+				Build(),
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				*NewPodPlacementConfig().
+					WithName("ppc-with-plugin").
+					WithNamespace("test").
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+					Build(),
+			},
+			want: false, // Should NOT ignore - should process
+		},
+		{
+			name: "pod should be ignored - both CPPC and all PPCs have plugin disabled",
+			pod:  NewPod().WithNamespace("test").WithNodeSelectors(utils.ArchLabel, utils.ArchitectureAmd64).Build(),
+			cppc: NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				WithNodeAffinityScoring(false).
+				Build(),
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				*NewPodPlacementConfig().
+					WithName("ppc-no-plugin").
+					WithNamespace("test").
+					WithNodeAffinityScoring(false).
+					Build(),
+			},
+			want: true, // Should ignore - already has arch selector and no plugins enabled
+		},
+		{
+			name: "pod in operator namespace should be ignored",
+			pod:  NewPod().WithNamespace(utils.Namespace()).Build(),
+			cppc: NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				WithNodeAffinityScoring(true).
+				WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+				Build(),
+			matchingPPCs: []v1beta1.PodPlacementConfig{},
+			want:         true, // Should ignore - operator namespace
+		},
+		{
+			name: "pod in kube-system should be ignored",
+			pod:  NewPod().WithNamespace("kube-system").Build(),
+			cppc: NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				WithNodeAffinityScoring(true).
+				WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+				Build(),
+			matchingPPCs: []v1beta1.PodPlacementConfig{},
+			want:         true, // Should ignore - system namespace
+		},
+		{
+			name: "pod with node name set should be ignored",
+			pod:  NewPod().WithNamespace("test").WithNodeName("node-1").Build(),
+			cppc: NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				WithNodeAffinityScoring(true).
+				WithNodeAffinityScoringTerm(utils.ArchitectureAmd64, 50).
+				Build(),
+			matchingPPCs: []v1beta1.PodPlacementConfig{},
+			want:         true, // Should ignore - node name already set
+		},
+		{
+			name: "multiple matching PPCs - at least one with plugin enabled",
+			pod:  NewPod().WithNamespace("test").Build(),
+			cppc: NewClusterPodPlacementConfig().
+				WithName(common.SingletonResourceObjectName).
+				WithNodeAffinityScoring(false).
+				Build(),
+			matchingPPCs: []v1beta1.PodPlacementConfig{
+				*NewPodPlacementConfig().
+					WithName("ppc-no-plugin").
+					WithNamespace("test").
+					WithNodeAffinityScoring(false).
+					Build(),
+				*NewPodPlacementConfig().
+					WithName("ppc-with-plugin").
+					WithNamespace("test").
+					WithNodeAffinityScoring(true).
+					WithNodeAffinityScoringTerm(utils.ArchitectureArm64, 30).
+					Build(),
+			},
+			want: false, // Should NOT ignore - at least one PPC has plugin
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := newPod(tt.pod, ctx, nil)
+			g := NewGomegaWithT(t)
+			result := pod.shouldIgnorePod(tt.cppc, tt.matchingPPCs)
+			g.Expect(result).To(Equal(tt.want), "unexpected result from shouldIgnorePod")
+		})
+	}
+}
+
+func TestPod_trackAffinitySource_AnnotationGrowth(t *testing.T) {
+	tests := []struct {
+		name              string
+		initialAnnotation string
+		trackingCalls     []struct {
+			arch, source string
+			weight       int32
+			applied      bool
+		}
+		expectedEntries      int
+		expectedAnnotationOk func(string) bool // Custom validation function
+	}{
+		{
+			name:              "single tracking entry",
+			initialAnnotation: "",
+			trackingCalls: []struct {
+				arch, source string
+				weight       int32
+				applied      bool
+			}{
+				{arch: utils.ArchitectureAmd64, weight: 50, source: "ClusterPodPlacementConfig", applied: true},
+			},
+			expectedEntries: 1,
+			expectedAnnotationOk: func(annotation string) bool {
+				return annotation == "amd64:50:ClusterPodPlacementConfig"
+			},
+		},
+		{
+			name:              "multiple entries from different sources",
+			initialAnnotation: "",
+			trackingCalls: []struct {
+				arch, source string
+				weight       int32
+				applied      bool
+			}{
+				{arch: utils.ArchitectureAmd64, weight: 50, source: "PodPlacementConfig-high", applied: true},
+				{arch: utils.ArchitectureArm64, weight: 30, source: "PodPlacementConfig-low", applied: true},
+				{arch: utils.ArchitecturePpc64le, weight: 20, source: "ClusterPodPlacementConfig", applied: false},
+			},
+			expectedEntries: 3,
+			expectedAnnotationOk: func(annotation string) bool {
+				return len(annotation) > 50 &&
+					len(strings.Split(annotation, ",")) == 3 &&
+					strings.Contains(annotation, "skipped")
+			},
+		},
+		{
+			name:              "duplicate entry should not be added twice",
+			initialAnnotation: "",
+			trackingCalls: []struct {
+				arch, source string
+				weight       int32
+				applied      bool
+			}{
+				{arch: utils.ArchitectureAmd64, weight: 50, source: "ClusterPodPlacementConfig", applied: true},
+				{arch: utils.ArchitectureAmd64, weight: 50, source: "ClusterPodPlacementConfig", applied: true},
+			},
+			expectedEntries: 1,
+			expectedAnnotationOk: func(annotation string) bool {
+				return len(strings.Split(annotation, ",")) == 1
+			},
+		},
+		{
+			name:              "same arch from different sources",
+			initialAnnotation: "",
+			trackingCalls: []struct {
+				arch, source string
+				weight       int32
+				applied      bool
+			}{
+				{arch: utils.ArchitectureAmd64, weight: 50, source: "PodPlacementConfig-high", applied: true},
+				{arch: utils.ArchitectureAmd64, weight: 30, source: "PodPlacementConfig-low", applied: false},
+			},
+			expectedEntries: 2,
+			expectedAnnotationOk: func(annotation string) bool {
+				entries := strings.Split(annotation, ",")
+				return len(entries) == 2 &&
+					strings.Contains(entries[1], "skipped")
+			},
+		},
+		{
+			name:              "many entries to test annotation size",
+			initialAnnotation: "",
+			trackingCalls: []struct {
+				arch, source string
+				weight       int32
+				applied      bool
+			}{
+				{arch: utils.ArchitectureAmd64, weight: 50, source: "PodPlacementConfig-1", applied: true},
+				{arch: utils.ArchitectureArm64, weight: 40, source: "PodPlacementConfig-2", applied: true},
+				{arch: utils.ArchitecturePpc64le, weight: 30, source: "PodPlacementConfig-3", applied: true},
+				{arch: utils.ArchitectureS390x, weight: 20, source: "PodPlacementConfig-4", applied: true},
+				{arch: utils.ArchitectureAmd64, weight: 10, source: "PodPlacementConfig-5", applied: false},
+				{arch: utils.ArchitectureArm64, weight: 10, source: "PodPlacementConfig-6", applied: false},
+			},
+			expectedEntries: 6,
+			expectedAnnotationOk: func(annotation string) bool {
+				// Should have 6 entries and be a reasonable size (< 500 bytes for this test)
+				return len(strings.Split(annotation, ",")) == 6 && len(annotation) < 500
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := newPod(NewPod().Build(), ctx, nil)
+			g := NewGomegaWithT(t)
+
+			// Set initial annotation if provided
+			if tt.initialAnnotation != "" {
+				pod.EnsureAnnotation(utils.PreferredNodeAffinitySourcesAnnotation, tt.initialAnnotation)
+			}
+
+			// Make all tracking calls
+			for _, call := range tt.trackingCalls {
+				pod.trackAffinitySource(call.arch, call.weight, call.source, call.applied)
+			}
+
+			// Verify annotation exists and has expected structure
+			annotation, ok := pod.Annotations[utils.PreferredNodeAffinitySourcesAnnotation]
+			g.Expect(ok).To(BeTrue(), "annotation should exist")
+
+			// Verify custom validation if provided
+			if tt.expectedAnnotationOk != nil {
+				g.Expect(tt.expectedAnnotationOk(annotation)).To(BeTrue(),
+					"annotation validation failed for: %s", annotation)
+			}
+
+			// Verify entry count
+			if annotation != "" {
+				entries := strings.Split(annotation, ",")
+				g.Expect(len(entries)).To(Equal(tt.expectedEntries),
+					"unexpected number of annotation entries")
 			}
 		})
 	}

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -1029,7 +1029,7 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 			}).Should(Succeed(), "the ClusterPodPlacementConfig should remove the no-pod-placement-config finalizer")
 		})
 	})
-	Context("when CPPC has NodeAffinityScoring disabled but PPC has it enabled", func() {
+	Context("when CPPC has NodeAffinityScoring disabled ebut PPC has it enabled", func() {
 		It("should apply PPC preferred affinity to pods matching the PPC label selector", func() {
 			By("Creating a ClusterPodPlacementConfig with NodeAffinityScoring disabled")
 			err := client.Create(ctx,


### PR DESCRIPTION
 Fix PodPlacementConfig plugin detection and eliminate code duplication                                                                                                                                                          
                                                                                                                                                                                                                                  Problem                                                                                                                                                                                                                         
                                                                                                                                                                                                                                  The namespace-scoped PodPlacementConfig resources with the NodeAffinityScoring plugin enabled would be ignored if the cluster-scoped ClusterPodPlacementConfig had the plugin disabled.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                  
  Bug scenario:                                                                                                                                                                                                                   
  1. ClusterPodPlacementConfig has NodeAffinityScoring disabled                                                                                                                                                                   
  2. Namespace-scoped PodPlacementConfig has NodeAffinityScoring enabled                                                                                                                                                          
  3. Pod matching the PPC's label selector is created                                                                                                                                                                             
  4. Expected: Pod gets preferred node affinity from the PPC                                                                                                                                                                      
  5. Actual: Pod's preferred affinity is skipped entirely because the system only checked CPPC's plugin status                                                                                                                    
                            