### PR TITLE
MULTIARCH-5971: Add maintainer to fix konflux warnings

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -52,3 +52,4 @@ LABEL summary="The Multiarch Tuning Operator enhances the user experience for ad
                    migrate from single-arch to multi-arch OpenShift"
 LABEL io.k8s.display-name="Multiarch Tuning Operator"
 LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"
+LABEL maintainer="tzivkovi@redhat.com"

--- a/hack/patch-bundle-dockerfile.sh
+++ b/hack/patch-bundle-dockerfile.sh
@@ -21,7 +21,9 @@ LABEL summary="The Multiarch Tuning Operator enhances the user experience for ad
                    clusters with multi-architecture compute nodes or Site Reliability Engineers willing to \
                    migrate from single-arch to multi-arch OpenShift"
 LABEL io.k8s.display-name="Multiarch Tuning Operator"
-LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"'
+LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"
+LABEL maintainer="tzivkovi@redhat.com"'
+
 
 # Remove the content of the bundle.konflux.Dockerfile starting from the line with the comment "# Labels from hack/patch-bundle-dockerfile.sh"
 if [[ "$(uname)" == "Darwin" ]]; then

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -54,6 +54,7 @@ LABEL summary="The Multiarch Tuning Operator enhances the user experience for ad
                    migrate from single-arch to multi-arch OpenShift"
 LABEL io.k8s.display-name="Multiarch Tuning Operator"
 LABEL io.openshift.tags="openshift,operator,multiarch,scheduling"
+LABEL maintainer="tzivkovi@redhat.com"
 
 ENTRYPOINT ["/manager"]
 


### PR DESCRIPTION
Warning from EC
 ```
[Warning] labels.optional_labels
    ImageRef: quay.io/redhat-user-workloads/multiarch-tuning-ope-tenant/multiarch-tuning-operator-v1-x/multiarch-tuning-operator-bundle-v1-x@sha256:01875bce717be71b1ae81b2895f3d3deaf441c4183405865e11e55e4faec7de0
    Reason: The optional "maintainer" label is missing. Label description: The name and email of the maintainer (usually the
    submitter). Should contain `@redhat.com` or `Red Hat`.
    Term: maintainer
    Title: Optional labels
    Description: Check the image for the presence of labels that are recommended, but not required. Use the rule data
    `optional_labels` key to set the list of labels to check, or the `fbc_optional_labels` key for fbc images.
    Solution: Update the image build process to set the optional labels.
```

