### PR TITLE
CodeRabbit Review Feedback

### DIFF
--- a/api/v1beta1/clusterpodplacementconfig_webhook.go
+++ b/api/v1beta1/clusterpodplacementconfig_webhook.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openshift/multiarch-tuning-operator/api/common"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -63,6 +65,9 @@ func (v *ClusterPodPlacementConfigValidator) ValidateDelete(ctx context.Context,
 }
 
 func (v *ClusterPodPlacementConfigValidator) validate(cppc *ClusterPodPlacementConfig) (warnings admission.Warnings, err error) {
+	if cppc.Name != common.SingletonResourceObjectName {
+		return nil, fmt.Errorf("ClusterPodPlacementConfig must be named %q", common.SingletonResourceObjectName)
+	}
 	if cppc.Spec.Plugins == nil || cppc.Spec.Plugins.NodeAffinityScoring == nil {
 		return nil, nil
 	}

--- a/cmd/enoexec-daemon/main.go
+++ b/cmd/enoexec-daemon/main.go
@@ -30,16 +30,19 @@ func main() {
 }
 
 func bindFlags() {
-	flag.IntVar(&initialLogLevel, "initial-log-level", 0, "Initial log level. From 0 (Normal) to 5 (TraceAll)")
+	flag.IntVar(&initialLogLevel, "initial-log-level", 0, "Initial log level. From 0 (Normal) to 10 (maximum verbosity)")
 	flag.BoolVar(&logDevMode, "log-dev-mode", false, "Enable development mode for zap logger")
 	flag.Parse()
 }
 
 func initContext() (context.Context, context.CancelFunc) {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	if initialLogLevel < 0 || initialLogLevel > 10 {
+		must(fmt.Errorf("initial-log-level must be in range [0,10], got %d", initialLogLevel), "invalid flag value")
+	}
 	var logImpl *zap.Logger
 	var err error
-	logLevel := zapcore.Level(int8(-initialLogLevel)) // #nosec G115 -- initialLogLevel is constrained to 0-5 range
+	logLevel := zapcore.Level(-initialLogLevel)
 	if logDevMode {
 		cfg := zap.NewDevelopmentConfig()
 		cfg.Level = zap.NewAtomicLevelAt(logLevel)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -298,6 +298,9 @@ func validateFlags() error {
 	if btoi(enableOperator)+btoi(enableClusterPodPlacementConfigOperandControllers)+btoi(enableClusterPodPlacementConfigOperandWebHook)+btoi(enableENoExecEventControllers) > 1 {
 		return errors.New("only one of the following flags can be set: --enable-operator, --enable-ppc-controllers, --enable-ppc-webhook, --enable-enoexec-event-controllers")
 	}
+	if initialLogLevel < 0 || initialLogLevel > 10 {
+		return fmt.Errorf("initial-log-level must be in range [0,10], got %d", initialLogLevel)
+	}
 	return nil
 }
 
@@ -320,11 +323,13 @@ func bindFlags() {
 	// This may be deprecated in the future. It is used to support the current way of setting the log level for operands
 	// If operands will start to support a controller that watches the ClusterPodPlacementConfig, this flag may be removed
 	// and the log level will be set in the ClusterPodPlacementConfig at runtime (with no need for reconciliation)
-	flag.IntVar(&initialLogLevel, "initial-log-level", common.LogVerbosityLevelNormal.ToZapLevelInt(), "Initial log level. Converted to zap")
+	flag.IntVar(&initialLogLevel, "initial-log-level", common.LogVerbosityLevelNormal.ToZapLevelInt(), "Initial log level (0-10). Converted to zap. CRD levels: 0=Normal, 1=Debug, 2=Trace, 3=TraceAll")
 	klog.InitFlags(nil)
 	flag.Parse()
 	// Set the Log Level as AtomicLevel to allow runtime changes
-	utils.AtomicLevel = zapuber.NewAtomicLevelAt(zapcore.Level(int8(-initialLogLevel))) // #nosec G115 -- initialLogLevel is constrained to 0-3 range
+	// Safe to convert: initialLogLevel is validated to be in range [0,10] by validateFlags(),
+	// so -initialLogLevel is in range [-10,0] which fits in int8 range [-128,127]
+	utils.AtomicLevel = zapuber.NewAtomicLevelAt(zapcore.Level(int8(-initialLogLevel))) // #nosec G115 -- conversion is safe, value validated to be in range [0,10]
 	zapLogger := zap.New(zap.Level(utils.AtomicLevel), zap.UseDevMode(false))
 	klog.SetLogger(zapLogger)
 	ctrllog.SetLogger(zapLogger)

--- a/hack/upgrade-automation/README.md
+++ b/hack/upgrade-automation/README.md
@@ -79,11 +79,10 @@ Updates all Go dependencies (smart handling skips incompatible versions):
 
 Re-vendors all dependencies:
 1. `go mod tidy`
-2. `rm -rf vendor/`
-3. `go mod vendor`
-4. Restores go directive if `go mod tidy` upgraded it
+2. `make vendor`
+3. Restores go directive if `go mod tidy` upgraded it
 
-**Commit:** `go mod vendor`
+**Commit:** `make vendor`
 
 ### Step 5: Run code generation
 

--- a/hack/upgrade-automation/README.md
+++ b/hack/upgrade-automation/README.md
@@ -219,7 +219,7 @@ sed_inplace() {
 | `validate_prerequisites()` | All above checks | Exit on any failure |
 
 **Branch naming:**
-```
+```text
 upgrade-ocp-{ocp}-go-{go_minor}-k8s-{k8s_minor}
 
 Example: upgrade-ocp-4.20-go-1.24-k8s-1.34
@@ -276,19 +276,19 @@ hack/upgrade-automation/scripts/upgrade.sh 4.20 1.24 1.34.1
 **Common causes and fixes:**
 
 **API deprecation:**
-```
+```text
 Error: undefined: corev1.SomeOldAPI
 ```
 Solution: Update code to use new API (check K8s release notes)
 
 **Test helper changes:**
-```
+```text
 Error: cannot use X (type Y) as type Z
 ```
 Solution: Update test setup code for new types
 
 **Import path changes:**
-```
+```text
 Error: package X is not in GOROOT
 ```
 Solution: Update import paths (check go.mod for correct versions)

--- a/hack/upgrade-automation/scripts/lib/validations.sh
+++ b/hack/upgrade-automation/scripts/lib/validations.sh
@@ -69,8 +69,8 @@ validate_and_create_branch() {
         read -p "Do you want to delete and recreate it? (y/N) " -n 1 -r >&2
         echo "" >&2
         if [[ $REPLY =~ ^[Yy]$ ]]; then
-            git branch -D "$branch_name"
-            git checkout -b "$branch_name"
+            # Use checkout -B to force recreation (works even if currently checked out)
+            git checkout -B "$branch_name"
         else
             echo "ERROR: Branch '$branch_name' already exists. Please delete it or choose a different version." >&2
             return 1
@@ -124,12 +124,12 @@ validate_k8s_version_consistency() {
     echo "Validating k8s.io version consistency in go.mod..." >&2
 
     local versions_count
-    versions_count=$(grep '^\s*k8s\.io/' go.mod | grep -v '//' | awk '{print $2}' | grep -oP 'v\d+\.\d+' | sort -u | wc -l)
+    versions_count=$(grep '^\s*k8s\.io/' go.mod | grep -v '//' | awk '{print $2}' | sed -E 's/(v[0-9]+\.[0-9]+).*/\1/' | sort -u | wc -l)
 
     if [[ "$versions_count" -gt 1 ]]; then
         echo "⚠️  WARNING: Multiple k8s.io minor versions detected in go.mod" >&2
         echo "   Found versions:" >&2
-        grep '^\s*k8s\.io/' go.mod | grep -v '//' | awk '{print $1, $2}' | grep -oP 'v\d+\.\d+' | sort -u >&2
+        grep '^\s*k8s\.io/' go.mod | grep -v '//' | awk '{print $1, $2}' | sed -E 's/.*(v[0-9]+\.[0-9]+).*/\1/' | sort -u >&2
         echo "   This is expected for packages like k8s.io/klog and k8s.io/utils" >&2
     else
         echo "✅ All k8s.io dependencies at consistent minor version" >&2
@@ -160,7 +160,7 @@ validate_prerequisites() {
     local current_go current_k8s current_ocp
     current_go=$(grep '^go ' go.mod | awk '{print $2}')
     current_k8s=$(grep 'k8s.io/api' go.mod | head -1 | awk '{print $2}')
-    current_ocp=$(grep 'BUILD_IMAGE' Makefile | grep -oP 'openshift-\K[0-9]+\.[0-9]+')
+    current_ocp=$(grep 'BUILD_IMAGE' Makefile | sed -E 's/.*openshift-([0-9]+\.[0-9]+).*/\1/')
 
     echo "Current versions:" >&2
     echo "  Go: $current_go" >&2
@@ -170,6 +170,18 @@ validate_prerequisites() {
     echo "Target versions:" >&2
     echo "  Go: $go_version" >&2
     echo "  Kubernetes: $k8s_version" >&2
+    echo "" >&2
+
+    # Validate golang image exists
+    if ! validate_golang_image_exists "$go_version"; then
+        return 1
+    fi
+
+    echo "" >&2
+
+    # Validate k8s version consistency (warning only)
+    validate_k8s_version_consistency
+
     echo "" >&2
 
     return 0

--- a/hack/upgrade-automation/scripts/lib/version-discovery.sh
+++ b/hack/upgrade-automation/scripts/lib/version-discovery.sh
@@ -23,12 +23,13 @@ discover_k8s_from_ocp_release() {
         echo "$k8s_version"
     else
         # Fallback: discover from openshift/api go.mod
-        local k8s_minor
-        k8s_minor=$(curl -sf "https://raw.githubusercontent.com/openshift/api/release-$ocp_version/go.mod" | \
-            grep 'k8s.io/api ' | awk '{print $2}' | grep -oP 'v0\.\K[0-9]+')
+        local k8s_module_version
+        k8s_module_version=$(curl -sf "https://raw.githubusercontent.com/openshift/api/release-$ocp_version/go.mod" | \
+            grep 'k8s.io/api ' | awk '{print $2}' | sed -E -n '/^v0\.[0-9]+\.[0-9]+$/p')
 
-        if [[ -n "$k8s_minor" ]]; then
-            echo "1.$k8s_minor.0"
+        if [[ -n "$k8s_module_version" ]]; then
+            # Transform v0.X.Y to 1.X.Y (preserving patch version)
+            echo "${k8s_module_version/v0./1.}"
         else
             echo ""
         fi
@@ -74,7 +75,7 @@ discover_required_ocp_version() {
     # Check each branch to find which uses our target K8s version
     for ocp_version in $branches; do
         local openshift_api_k8s
-        openshift_api_k8s=$(curl -sf "https://raw.githubusercontent.com/openshift/api/release-$ocp_version/go.mod" | grep 'k8s.io/api ' | awk '{print $2}' | grep -oP 'v0\.\K[0-9]+')
+        openshift_api_k8s=$(curl -sf "https://raw.githubusercontent.com/openshift/api/release-$ocp_version/go.mod" | grep 'k8s.io/api ' | awk '{print $2}' | sed -E 's/^v0\.([0-9]+).*/\1/')
 
         if [[ "$openshift_api_k8s" == "$k8s_minor" ]]; then
             echo "✅ Found OCP $ocp_version uses K8s 1.$k8s_minor" >&2
@@ -113,7 +114,7 @@ validate_k8s_ocp_compatibility() {
 
     # Check openshift/api release branch for K8s version
     local openshift_api_k8s
-    openshift_api_k8s=$(curl -sf "https://raw.githubusercontent.com/openshift/api/release-$ocp_version/go.mod" | grep 'k8s.io/api ' | awk '{print $2}' | grep -oP 'v0\.\K[0-9]+')
+    openshift_api_k8s=$(curl -sf "https://raw.githubusercontent.com/openshift/api/release-$ocp_version/go.mod" | grep 'k8s.io/api ' | awk '{print $2}' | sed -E 's/^v0\.([0-9]+).*/\1/')
 
     if [[ "$openshift_api_k8s" != "$k8s_minor" ]]; then
         echo "ERROR: K8s version mismatch" >&2
@@ -139,7 +140,7 @@ discover_controller_runtime_version() {
     echo "Discovering compatible controller-runtime version..." >&2
 
     local releases
-    releases=$(curl -s https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases | grep '"tag_name"' | grep -E '"v0\.' | sed -E 's/.*"v([^"]+)".*/\1/')
+    releases=$(curl -s https://api.github.com/repos/kubernetes-sigs/controller-runtime/releases | grep '"tag_name"' | grep -E '"v0\.' | grep -Ev -- '-(alpha|beta|rc)[0-9.]*"' | sed -E 's/.*"v([^"]+)".*/\1/')
 
     for version in $releases; do
         local gomod
@@ -150,7 +151,7 @@ discover_controller_runtime_version() {
         fi
 
         local cr_k8s_minor cr_go_minor
-        cr_k8s_minor=$(echo "$gomod" | grep 'k8s.io/apimachinery' | awk '{print $2}' | grep -oP 'v0\.\K[0-9]+' | head -1)
+        cr_k8s_minor=$(echo "$gomod" | grep 'k8s.io/apimachinery' | awk '{print $2}' | sed -E 's/^v0\.([0-9]+).*/\1/' | head -1)
         cr_go_minor=$(echo "$gomod" | grep '^go ' | awk '{print $2}' | cut -d. -f2)
 
         if [[ "$cr_k8s_minor" == "$k8s_minor" ]] && [[ "$cr_go_minor" -le "$go_minor" ]]; then
@@ -200,13 +201,13 @@ discover_controller_tools_version() {
 
     local k8s_minor go_minor
     # Extract minor version from k8s_version parameter (e.g., "1.34.1" -> "34")
-    k8s_minor=$(echo "$k8s_version" | grep -oP '1\.\K[0-9]+')
+    k8s_minor=$(echo "$k8s_version" | sed -E 's/^1\.([0-9]+).*/\1/')
     go_minor=$(echo "$go_version" | cut -d. -f2)
 
     echo "Discovering compatible controller-tools version..." >&2
 
     local releases
-    releases=$(curl -s https://api.github.com/repos/kubernetes-sigs/controller-tools/releases | grep '"tag_name"' | grep -E '"v0\.' | sed -E 's/.*"v([^"]+)".*/\1/')
+    releases=$(curl -s https://api.github.com/repos/kubernetes-sigs/controller-tools/releases | grep '"tag_name"' | grep -E '"v0\.' | grep -Ev -- '-(alpha|beta|rc)[0-9.]*"' | sed -E 's/.*"v([^"]+)".*/\1/')
 
     for version in $releases; do
         local gomod
@@ -217,7 +218,7 @@ discover_controller_tools_version() {
         fi
 
         local ct_k8s_minor ct_go_minor
-        ct_k8s_minor=$(echo "$gomod" | grep 'k8s.io/apimachinery' | awk '{print $2}' | grep -oP 'v0\.\K[0-9]+' | head -1)
+        ct_k8s_minor=$(echo "$gomod" | grep 'k8s.io/apimachinery' | awk '{print $2}' | sed -E 's/^v0\.([0-9]+).*/\1/' | head -1)
         ct_go_minor=$(echo "$gomod" | grep '^go ' | awk '{print $2}' | cut -d. -f2)
 
         if [[ "$ct_k8s_minor" == "$k8s_minor" ]] && [[ "$ct_go_minor" -le "$go_minor" ]]; then
@@ -292,7 +293,7 @@ discover_golangci_lint_version() {
     echo "Discovering compatible golangci-lint version..." >&2
 
     local releases
-    releases=$(curl -s https://api.github.com/repos/golangci/golangci-lint/releases | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+    releases=$(curl -s https://api.github.com/repos/golangci/golangci-lint/releases | grep '"tag_name"' | grep -Ev -- '-(alpha|beta|rc)[0-9.]*"' | sed -E 's/.*"v([^"]+)".*/\1/')
 
     for version in $releases; do
         local go_req

--- a/hack/upgrade-automation/scripts/upgrade.sh
+++ b/hack/upgrade-automation/scripts/upgrade.sh
@@ -118,13 +118,14 @@ step_update_base_images() {
     echo "" >&2
 
     # Commit changes
-    echo "Committing changes..." >&2
-    # Add updated files (ignore errors if files don't exist)
-    git add .ci-operator.yaml Dockerfile Makefile 2>/dev/null || true
-    git add .tekton/ bundle.konflux.Dockerfile konflux.Dockerfile 2>/dev/null || true
-    git commit -m "Update Makefile and Dockerfiles to use the new Golang version base image to ${go_minor}"
-
-    echo "✅ Step 1 complete" >&2
+    git add .ci-operator.yaml .tekton/ Dockerfile Makefile bundle.konflux.Dockerfile konflux.Dockerfile 2>/dev/null || true
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Committing changes..." >&2
+        git commit -m "Update Makefile and Dockerfiles to use the new Golang version base image to ${go_minor}"
+        echo "✅ Step 1 complete (changes committed)" >&2
+    else
+        echo "✅ Step 1 complete (no changes)" >&2
+    fi
 }
 
 # ==============================================================================
@@ -150,11 +151,14 @@ step_update_tools() {
         "$golint_version"
 
     echo "" >&2
-    echo "Committing changes..." >&2
     git add Makefile
-    git commit -m "Update tools in Makefile"
-
-    echo "✅ Step 2 complete" >&2
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Committing changes..." >&2
+        git commit -m "Update tools in Makefile"
+        echo "✅ Step 2 complete (changes committed)" >&2
+    else
+        echo "✅ Step 2 complete (no changes)" >&2
+    fi
 }
 
 # ==============================================================================
@@ -415,7 +419,8 @@ step_update_go_mod() {
         echo "⚠️  Found $require_count require blocks, consolidating to 2..." >&2
 
         # Create temporary file to rebuild go.mod
-        local temp_gomod=$(mktemp)
+        local temp_gomod
+        temp_gomod=$(mktemp) || { echo "ERROR: Failed to create temporary file" >&2; return 1; }
 
         # Copy everything before first require block
         awk '/^require \(/{exit} {print}' go.mod > "$temp_gomod"
@@ -513,11 +518,8 @@ step_update_vendor() {
 
     echo "" >&2
 
-    echo "Removing existing vendor directory..." >&2
-    rm -rf vendor/
-
-    echo "Running go mod vendor..." >&2
-    go mod vendor
+    echo "Running make vendor..." >&2
+    make vendor
 
     # After vendoring is complete, restore the go directive to match the container version
     # The vendor directory doesn't depend on the go directive - only builds do
@@ -526,10 +528,10 @@ step_update_vendor() {
 
     if [[ "$actual_go_version" != "$go_version" ]]; then
         echo "" >&2
-        echo "⚠️  Go directive was upgraded to $actual_go_version (required by dependencies)" >&2
-        echo "   Restoring to container version $go_version for build compatibility..." >&2
-        update_go_mod_directive "$go_version"
-        echo "✅ Restored go directive to $go_version" >&2
+        echo "❌ ERROR: vendoring resolved dependencies that require Go $actual_go_version" >&2
+        echo "   The selected dependencies require a higher Go version than the container ($go_version)." >&2
+        echo "   Refusing to rewrite go.mod to a lower version." >&2
+        return 1
     else
         echo "✅ go directive is already at container version: $go_version" >&2
     fi
@@ -610,6 +612,14 @@ step_run_tests() {
         return 1
     fi
     echo "✅ build passed" >&2
+
+    echo "" >&2
+    echo "Running code quality auto-fixes..." >&2
+    echo "Running make fmt..." >&2
+    make fmt || true
+    echo "Running make goimports..." >&2
+    make goimports || true
+    echo "✅ auto-fixes complete" >&2
 
     echo "" >&2
     echo "Running make test..." >&2

--- a/internal/controller/enoexecevent/handler/enoexecevent_controller.go
+++ b/internal/controller/enoexecevent/handler/enoexecevent_controller.go
@@ -21,6 +21,7 @@ import (
 	runtime2 "runtime"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -94,11 +95,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Log the ENoExecEvent instance
 	logger.Info("Reconciling ENoExecEvent", "name", eNoExecEvent.Name, "namespace", eNoExecEvent.Namespace)
 	ret, err := r.reconcile(ctx, eNoExecEvent)
-	// If the reconciliation was successful, or one of the objects was not found, we delete the ENoExecEvent resource.
-	if client.IgnoreNotFound(err) == nil {
+
+	// If the reconciliation was successful, delete the ENoExecEvent resource.
+	if err == nil {
 		if err := r.Delete(ctx, &eNoExecEvent.ENoExecEvent); err != nil {
 			logger.Error(err, "Failed to delete ENoExecEvent resource after reconciliation", "name", eNoExecEvent.Name)
-			// Mark as error but return the original error so client.IgnoreNotFound works
 			r.markAsError(ctx, eNoExecEvent, ErrorReasonReconciliation)
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -106,9 +107,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		logger.Info("Deleted ENoExecEvent resource after successful reconciliation", "name", eNoExecEvent.Name)
 		return ret, nil
 	}
+
+	// If pod/node not found, this is a stale event (object was deleted before processing)
+	if apierrors.IsNotFound(err) {
+		if err := r.Delete(ctx, &eNoExecEvent.ENoExecEvent); err != nil {
+			logger.Error(err, "Failed to delete stale ENoExecEvent resource", "name", eNoExecEvent.Name)
+			r.markAsError(ctx, eNoExecEvent, ErrorReasonReconciliation)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		metrics.EnoexecCounterStale.Inc()
+		logger.Info("Deleted stale ENoExecEvent resource (pod/node not found)", "name", eNoExecEvent.Name)
+		return ret, nil
+	}
+
+	// Real reconciliation error that will be retried
 	metrics.EnoexecCounterInvalid.Inc()
 	logger.Error(err, "Failed to reconcile ENoExecEvent", "name", eNoExecEvent.Name)
-	// Mark as error - this is a real reconciliation error that will be retried
 	r.markAsError(ctx, eNoExecEvent, ErrorReasonReconciliation)
 	return ctrl.Result{}, err
 }

--- a/internal/controller/enoexecevent/handler/metrics/metrics.go
+++ b/internal/controller/enoexecevent/handler/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 
 var EnoexecCounter prometheus.Counter
 var EnoexecCounterInvalid prometheus.Counter
+var EnoexecCounterStale prometheus.Counter
 var onceCommon sync.Once
 
 func initMetrics() {
@@ -23,11 +24,18 @@ func initMetrics() {
 		EnoexecCounterInvalid = prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Name: "mto_enoexecevents_invalid_total",
-				Help: "The counter for ENoExecEvents objects that faled the reconciliation and report as pod events",
+				Help: "The counter for ENoExecEvents objects that failed reconciliation and were reported as pod events",
+			},
+		)
+		EnoexecCounterStale = prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "mto_enoexecevents_stale_total",
+				Help: "The counter for ENoExecEvents referencing pods/nodes that no longer exist",
 			},
 		)
 		metrics2.Registry.MustRegister(EnoexecCounter)
 		metrics2.Registry.MustRegister(EnoexecCounterInvalid)
+		metrics2.Registry.MustRegister(EnoexecCounterStale)
 	})
 }
 

--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -643,7 +643,11 @@ func (r *ClusterPodPlacementConfigReconciler) handleEnoexecDelete(ctx context.Co
 	}
 
 	// Delete errored ENoExecEvent resources and count remaining non-errored ones
-	nonErroredCount, _ := r.deleteErroredENoExecEvents(ctx, enoexecEventList)
+	nonErroredCount, _, err := r.deleteErroredENoExecEvents(ctx, enoexecEventList)
+	if err != nil {
+		log.Error(err, "Failed to delete errored ENoExecEvent resources")
+		return err
+	}
 
 	// Only block cleanup if there are non-errored ENoExecEvent resources.
 	// The enoexec-controller deployment is still running at this point so it can
@@ -1079,9 +1083,10 @@ func isDeploymentUpToDate(deployment *appsv1.Deployment) bool {
 }
 
 // deleteErroredENoExecEvents deletes ENoExecEvent resources that are marked with an error label.
-// Returns the count of non-errored and errored events found.
-func (r *ClusterPodPlacementConfigReconciler) deleteErroredENoExecEvents(ctx context.Context, enoexecEventList *multiarchv1beta1.ENoExecEventList) (nonErroredCount, erroredCount int) {
+// Returns the count of non-errored and errored events found, and any delete errors encountered.
+func (r *ClusterPodPlacementConfigReconciler) deleteErroredENoExecEvents(ctx context.Context, enoexecEventList *multiarchv1beta1.ENoExecEventList) (nonErroredCount, erroredCount int, err error) {
 	log := ctrllog.FromContext(ctx)
+	var errs []error
 	for i := range enoexecEventList.Items {
 		enoexecEvent := &enoexecEventList.Items[i]
 		// Check if this ENoExecEvent is marked as errored
@@ -1108,7 +1113,7 @@ func (r *ClusterPodPlacementConfigReconciler) deleteErroredENoExecEvents(ctx con
 	if erroredCount > 0 {
 		log.Info("Deleted errored ENoExecEvent resources during cleanup", "erroredCount", erroredCount)
 	}
-	return nonErroredCount, erroredCount
+	return nonErroredCount, erroredCount, errorutils.NewAggregate(errs)
 }
 
 // cppcUpdatePredicate filters CPPC watch events to only reconcile on meaningful changes:

--- a/internal/controller/operator/clusterpodplacementconfig_controller_test.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller_test.go
@@ -392,7 +392,7 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 						framework.NewConditionTypeStatusTuple(v1beta1.MutatingWebhookConfigurationNotAvailable, corev1.ConditionTrue),
 						framework.NewConditionTypeStatusTuple(v1beta1.DeprovisioningType, corev1.ConditionTrue),
 					)
-				})
+				}).Should(Succeed(), "CPPC should remain in deprovisioning state while gated pod exists")
 				By("Manually delete the gated pod")
 				err = k8sClient.Delete(ctx, pod)
 				Expect(err).NotTo(HaveOccurred(), "failed to delete pod", err)
@@ -1109,7 +1109,8 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 			Expect(k8sClient.List(ctx, enoexecEventList, crclient.InNamespace(utils.Namespace()))).To(Succeed())
 
 			By("Calling deleteErroredENoExecEvents")
-			nonErroredCount, erroredCount := reconciler.deleteErroredENoExecEvents(ctx, enoexecEventList)
+			nonErroredCount, erroredCount, err := reconciler.deleteErroredENoExecEvents(ctx, enoexecEventList)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the counts")
 			Expect(nonErroredCount).To(Equal(2), "should have 2 non-errored events")
@@ -1131,7 +1132,7 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 			}).Should(Succeed())
 
 			By("Verifying non-errored events still exist")
-			err := k8sClient.Get(ctx, crclient.ObjectKey{
+			err = k8sClient.Get(ctx, crclient.ObjectKey{
 				Name:      nonErroredENEE1.Name,
 				Namespace: utils.Namespace(),
 			}, &v1beta1.ENoExecEvent{})
@@ -1150,7 +1151,8 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 
 		It("should handle empty list gracefully", func() {
 			emptyList := &v1beta1.ENoExecEventList{}
-			nonErroredCount, erroredCount := reconciler.deleteErroredENoExecEvents(ctx, emptyList)
+			nonErroredCount, erroredCount, err := reconciler.deleteErroredENoExecEvents(ctx, emptyList)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(nonErroredCount).To(Equal(0))
 			Expect(erroredCount).To(Equal(0))
 		})
@@ -1166,7 +1168,8 @@ var _ = Describe("internal/Controller/ClusterPodPlacementConfig/ClusterPodPlacem
 			enoexecEventList := &v1beta1.ENoExecEventList{}
 			Expect(k8sClient.List(ctx, enoexecEventList, crclient.InNamespace(utils.Namespace()))).To(Succeed())
 
-			nonErroredCount, erroredCount := reconciler.deleteErroredENoExecEvents(ctx, enoexecEventList)
+			nonErroredCount, erroredCount, err := reconciler.deleteErroredENoExecEvents(ctx, enoexecEventList)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(nonErroredCount).To(BeNumerically(">", 0), "should count events with no labels as non-errored")
 			Expect(erroredCount).To(Equal(0))
 

--- a/internal/controller/operator/suite_test.go
+++ b/internal/controller/operator/suite_test.go
@@ -176,7 +176,7 @@ func applyResources(resources resmap.ResMap) error {
 		Expect(err).NotTo(HaveOccurred())
 
 		if len(raw) == 0 {
-			return nil // Nothing to process
+			continue // Skip empty resource, continue processing others
 		}
 
 		// Decode the resource from the buffer

--- a/internal/controller/podplacement/pod_reconciler.go
+++ b/internal/controller/podplacement/pod_reconciler.go
@@ -245,7 +245,11 @@ func (r *PodReconciler) trackSkippedMatchingConfigs(ctx context.Context, pod *Po
 	}
 }
 
-// pullSecretDataList returns the list of secrets data for the given pod given its imagePullSecrets field
+// pullSecretDataList returns the list of secrets data for the given pod given its imagePullSecrets field.
+// This function implements fail-open behavior: it logs errors but does not fail if secrets cannot be
+// retrieved or parsed. The function returns whatever secret data was successfully collected, even if that's
+// an empty list. This allows image inspection to proceed without authentication if necessary, rather than
+// blocking pod scheduling due to transient pull secret issues.
 func (r *PodReconciler) pullSecretDataList(ctx context.Context, pod *Pod) ([][]byte, error) {
 	log := ctrllog.FromContext(ctx)
 	secretAuths := make([][]byte, 0)

--- a/internal/controller/podplacement/pod_reconciler_test.go
+++ b/internal/controller/podplacement/pod_reconciler_test.go
@@ -190,11 +190,11 @@ var _ = Describe("Internal/Controller/Podplacement/PodReconciler", func() {
 			})
 		})
 		Context("with different pull secrets", func() {
-			It("handles images with global pull secrets correctly", func() {
+			PIt("handles images with global pull secrets correctly", func() {
 				// TODO: Test logic for handling a Pod with one container and image using global pull secret
 			})
 
-			It("handles images with local pull secrets correctly", func() {
+			PIt("handles images with local pull secrets correctly", func() {
 				// TODO: Test logic for handling a Pod with one container and image using local pull secret
 			})
 		})
@@ -419,11 +419,11 @@ var _ = Describe("Internal/Controller/Podplacement/PodReconciler", func() {
 	})
 	When("Handling Multi-container Pods", func() {
 		Context("with different image types and different auth credentials sources", func() {
-			It("handles node affinity as the intersection of the compatible architectures of each multi-arch image", func() {
+			PIt("handles node affinity as the intersection of the compatible architectures of each multi-arch image", func() {
 				// TODO: Test logic for handling a Pod with multiple multi-arch image-based containers
 			})
 
-			It("handles node affinity of multi-arch images and single-arch image setting the only one possible", func() {
+			PIt("handles node affinity of multi-arch images and single-arch image setting the only one possible", func() {
 				// TODO: Test logic for handling a Pod with multiple multi-arch image-based containers
 			})
 

--- a/internal/controller/podplacement/pod_reconciler_test.go
+++ b/internal/controller/podplacement/pod_reconciler_test.go
@@ -120,6 +120,20 @@ var _ = Describe("Internal/Controller/Podplacement/PodReconciler", func() {
 				cppc := &v1beta1.ClusterPodPlacementConfig{}
 				err := k8sClient.Get(ctx, crclient.ObjectKey{Name: common.SingletonResourceObjectName}, cppc)
 				Expect(err).NotTo(HaveOccurred(), "failed to get ClusterPodPlacementConfig")
+				originalFallback := cppc.Spec.FallbackArchitecture
+				DeferCleanup(func() {
+					latest := &v1beta1.ClusterPodPlacementConfig{}
+					Expect(k8sClient.Get(ctx, crclient.ObjectKey{Name: common.SingletonResourceObjectName}, latest)).To(Succeed())
+					latest.Spec.FallbackArchitecture = originalFallback
+					Expect(k8sClient.Update(ctx, latest)).To(Succeed())
+					Eventually(func() string {
+						cppc := clusterpodplacementconfig.GetClusterPodPlacementConfig()
+						if cppc == nil {
+							return "nil"
+						}
+						return cppc.Spec.FallbackArchitecture
+					}).Should(Equal(originalFallback), "cache did not update with reverted ClusterPodPlacementConfig")
+				})
 				cppc.Spec.FallbackArchitecture = utils.ArchitectureAmd64
 				err = k8sClient.Update(ctx, cppc)
 				Expect(err).NotTo(HaveOccurred(), "failed to update ClusterPodPlacementConfig")
@@ -173,18 +187,6 @@ var _ = Describe("Internal/Controller/Podplacement/PodReconciler", func() {
 					g.Expect(pod.Labels).To(HaveKeyWithValue(utils.NodeAffinityLabel, utils.NodeAffinityLabelValueSet),
 						"node affinity label not found")
 				}).WithTimeout(e2e.WaitShort).Should(Succeed(), "failed to process fallback architecture")
-
-				// Cleanup: Revert CPPC changes
-				cppc.Spec.FallbackArchitecture = ""
-				err = k8sClient.Update(ctx, cppc)
-				Expect(err).NotTo(HaveOccurred(), "failed to revert ClusterPodPlacementConfig")
-				Eventually(func() string {
-					cppc := clusterpodplacementconfig.GetClusterPodPlacementConfig()
-					if cppc == nil {
-						return "nil"
-					}
-					return cppc.Spec.FallbackArchitecture
-				}).Should(Equal(""), "cache did not update with reverted ClusterPodPlacementConfig")
 			})
 		})
 		Context("with different pull secrets", func() {

--- a/internal/controller/podplacement/suite_test.go
+++ b/internal/controller/podplacement/suite_test.go
@@ -216,8 +216,9 @@ var _ = SynchronizedAfterSuite(func() {}, func() {
 	err := k8sClient.Delete(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
 	Expect(err).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
 	Eventually(testingutils.ValidateDeletion(k8sClient, ctx)).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
-	By("Checking the cache is empty")
-	Expect(clusterpodplacementconfig.GetClusterPodPlacementConfig()).To(BeNil())
+	By("Waiting for the cache to become empty")
+	Eventually(clusterpodplacementconfig.GetClusterPodPlacementConfig).
+		Should(BeNil(), "cache still contains ClusterPodPlacementConfig after deletion")
 
 	By("tearing down the test environment")
 	if stopMgr != nil {

--- a/internal/controller/podplacement/suite_test.go
+++ b/internal/controller/podplacement/suite_test.go
@@ -284,6 +284,7 @@ func startRegistry() {
 		// See https://github.com/distribution/distribution/blob/28c8bc6c0e4b5dfc380e0fa3058d4877fabdfa4a/registry/registry.go#L143
 		resp, err := httpClient.Get(fmt.Sprintf("https://%s/", registryAddress))
 		g.Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close() //nolint:errcheck
 		g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	}).MustPassRepeatedly(3).Should(
 		Succeed(), "registry server is not ready yet")
@@ -405,6 +406,7 @@ func runManager() {
 	Eventually(func(g Gomega) {
 		resp, err := http.Get("http://127.0.0.1:4980/readyz")
 		g.Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close() //nolint:errcheck
 		g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	}).MustPassRepeatedly(3).Should(
 		Succeed(), "manager is not ready yet")

--- a/internal/controller/podplacementconfig/suite_test.go
+++ b/internal/controller/podplacementconfig/suite_test.go
@@ -229,6 +229,7 @@ func runManager() {
 	Eventually(func(g Gomega) {
 		resp, err := http.Get("http://127.0.0.1:4980/readyz")
 		g.Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close() //nolint:errcheck
 		g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	}).MustPassRepeatedly(3).Should(
 		Succeed(), "manager is not ready yet")

--- a/internal/controller/podplacementconfig/suite_test.go
+++ b/internal/controller/podplacementconfig/suite_test.go
@@ -137,8 +137,9 @@ var _ = SynchronizedAfterSuite(func() {}, func() {
 	err := k8sClient.Delete(ctx, builder.NewClusterPodPlacementConfig().WithName(common.SingletonResourceObjectName).Build())
 	Expect(err).NotTo(HaveOccurred(), "failed to delete ClusterPodPlacementConfig", err)
 	Eventually(testingutils.ValidateDeletion(k8sClient, ctx)).Should(Succeed(), "the ClusterPodPlacementConfig should be deleted")
-	By("Checking the cache is empty")
-	Expect(clusterpodplacementconfig.GetClusterPodPlacementConfig()).To(BeNil())
+	By("Waiting for the cache to become empty")
+	Eventually(clusterpodplacementconfig.GetClusterPodPlacementConfig).
+		Should(BeNil(), "cache still contains ClusterPodPlacementConfig after deletion")
 
 	By("tearing down the test environment")
 	if stopMgr != nil {


### PR DESCRIPTION
 ## Address CodeRabbit Review Feedback                                                                                                                                                                                           
                                                                                                                                                                                                                                  
  This PR addresses 20+ issues identified in the CodeRabbit review of PR #183.                                                                                                                                                    
                                                                                                                                                                                                                                  
  Reference: https://github.com/openshift/multiarch-tuning-operator/pull/183#pullrequestreview-4078625034                                                                                                                         
    
  ---                                                                                                                                                                                                                             

  ### 🔧 Critical Fixes                                                                                                                                                                                                           
    
  #### Controller Logic & Error Handling                                                                                                                                                                                          
  - **Fix suite test early return bug** - Changed `return nil` to `continue` in resource processing loop to prevent premature exit when encountering empty resources
  - **Fix PPC list fail-open behavior** - Return unmodified pod when PodPlacementConfig list fails, implementing true fail-open admission control                                                                                 
  - **Propagate ENoExecEvent delete errors** - Changed `deleteErroredENoExecEvents` to return errors and aggregate delete failures for proper cleanup error handling                                                              
  - **Add stale ENoExecEvent metric** - Introduced `EnoexecCounterStale` metric to distinguish events referencing deleted pods/nodes from actual reconciliation failures                                                          
                                                                                                                                                                                                                                  
  #### API Compatibility                                                                                                                                                                                                          
  - **Make PodPlacementConfig.spec.plugins optional** - Removed `+kubebuilder:validation:Required` marker and added `omitempty` for backward compatibility with existing resources                                                
  - **Enforce singleton name validation** - Added webhook validation to ensure ClusterPodPlacementConfig is always named "cluster"                                                                                                
  - **Document pullSecretDataList fail-open** - Added documentation clarifying intentional fail-open behavior when pull secrets cannot be retrieved                                                                               
                                                                                                                                                                                                                                  
  #### Test Reliability                                                                                                                                                                                                           
  - **Fix cache-empty assertion** - Changed synchronous `Expect` to `Eventually` for cache checks to handle eventual consistency                                                                                                  
  - **Use DeferCleanup in tests** - Properly restore CPPC FallbackArchitecture value to prevent state leaks between tests                                                                                                         
  - **Close HTTP response bodies** - Added `defer resp.Body.Close()` in suite test readiness polling loops with appropriate `//nolint:errcheck` comments                                                                          
                                                                                                                                                                                                                                  
  #### Log Level Support                                                                                                                                                                                                          
  - **Add log level validation** - Validate `initial-log-level` is in range [0,10] before casting to `zapcore.Level`                                                                                                              
  - **Support extended log range** - Updated flag documentation to clarify CRD levels (0-3) vs extended range (0-10)                                                                                                              
  - **Add gosec nolint** - Documented safe int to int8 conversion with explanation of validation bounds                                                                                                                           
                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                             
                                                                                                                                                                                                                                  
  ### 🤖 Automation Script Improvements

  #### Version Discovery (macOS Compatible)                                                                                                                                                                                       
  - **Replace GNU-specific grep patterns** - Changed `grep -P` to `sed -E` for POSIX compatibility across Linux and macOS
  - **Preserve Kubernetes patch version** - Fixed fallback discovery to preserve patch version (1.34.1) instead of downgrading to (1.34.0)                                                                                        
  - **Exclude prerelease tags** - Added `grep -Ev '-(alpha|beta|rc)'` to all version discovery queries                                                                                                                            
                                                                                                                                                                                                                                  
  #### Script Robustness                                                                                                                                                                                                          
  - **Add prerequisites validation** - Call `validate_golang_image_exists()` and `validate_k8s_version_consistency()` before branch creation                                                                                      
  - **Conditional git commits** - Added `git status --porcelain` checks in Steps 1-2 to prevent failures on re-runs with no changes                                                                                               
  - **Error on go version mismatch** - Changed script to fail fast when vendoring requires higher Go version instead of silently downgrading                                                                                      
  - **Use make vendor** - Replaced raw `go mod vendor` with `make vendor` to respect repository build workflow                                                                                                                    
                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                             
                                                                                                                                                                                                                                  
  ### 📚 Documentation                                                                                                                                                                                                            

  - **Correct namespace exclusion behavior** - Updated CLAUDE.md to clarify only `kube-*` is hardcoded; `openshift-*` and `hypershift-*` are configurable via namespaceSelector                                                   
  - **Fix vendoring instructions** - Updated upgrade automation README to reference `make vendor` instead of raw commands
  - **Add markdown language tags** - Fixed markdownlint MD040 warnings by adding language tags to fenced code blocks                                                                                                              
                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                             
                                                                                                                                                                                                                                  
  ### 🧹 Minor Fixes

  - **Fix typo in metrics** - Corrected "faled" → "failed" in `EnoexecCounterInvalid` help text                                                                                                                                   
  - **Fix typo in copyright** - Corrected "caCopyright" → "Copyright" in license header
  - **Add nolint comments** - Added `//nolint:errcheck` for deferred `Body.Close()` in test health checks                                                                                                                         
  - **Regenerate bundle manifests** - Ran `make bundle` to sync bundle with plugins optional change                                                                                                                               
                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                             
                                                                                                                                                                                                                                  
  ### 📊 Summary                                                                                                                                                                                                                  
    
  **Files Changed:** ~25                                                                                                                                                                                                          
  **Commits:** 20
  **Issues Addressed:** 21                                                                                                                                                                                                        

  **Categories:**                                                                                                                                                                                                                 
  - 🔴 Critical: 7 fixes
  - 🟠 Major: 8 fixes                                                                                                                                                                                                             
  - 🟡 Minor: 6 fixes
                                                                                                                                                                                                                                  
  All changes improve code quality, test reliability, and cross-platform compatibility without altering core functionality.                                                                                                       
                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                             

  ### ✅ Testing                                                                                                                                                                                                                  ─
    
  - All unit tests pass                                                                                                                                                                                                           
  - Bundle verification passes (`make verify-diff`)
  - Linting passes (`make lint`, `make gosec`)                                                                                                                                                                                    
  - Automation scripts tested on both GNU/Linux and BSD/macOS                                                                                                                                                                     
                                                                                                                                                                                                                                  
  ---   