### PR TITLE
MULTIARCH-5541: Improve error message clarity

### DIFF
--- a/internal/controller/podplacement/events.go
+++ b/internal/controller/podplacement/events.go
@@ -25,9 +25,13 @@ const (
 	ArchitecturePreferredAffinityAllDuplicatesMsg  = "Skipped all architecture preferences from configuration; all were already set"
 	ArchitecturePreferredPredicateSkippedMsg       = "Skipped configuration; no architecture preferences were provided"
 
-	ImageArchitectureInspectionErrorMsg = "Failed to retrieve the supported architectures: "
+	ImageArchitectureInspectionErrorMsg = "The operator encountered an error while inspecting the container image to determine its supported architectures. " +
+		"This is typically caused by the image registry being unreachable, returning an error, or a misconfiguration. " +
+		"Registry error: "
 	NoSupportedArchitecturesFoundMsg    = "Pod cannot be scheduled due to incompatible image architectures; container images have no supported architectures in common"
 	ArchitectureAwareGatedPodIgnoredMsg = "The gated pod has been modified and is no longer eligible for architecture-aware scheduling"
-	ImageInspectionErrorMaxRetriesMsg   = "Failed to retrieve the supported architectures after multiple retries"
-	ArchitectureFallbackSetupMsg        = "Image inspection failed; setting the nodeAffinity to the fallback architecture: "
+	ImageInspectionErrorMaxRetriesMsg   = "The operator was unable to determine the supported architectures after multiple retries. " +
+		"This is typically caused by the image registry being unreachable, returning an error, or a misconfiguration in the cluster's pull secrets or network. " +
+		"Registry error"
+	ArchitectureFallbackSetupMsg = "Image inspection failed; setting the nodeAffinity to the fallback architecture: "
 )


### PR DESCRIPTION
## Summary

Improve the clarity of image inspection error event messages to clarify that registry pull errors are likely not caused by the Multiarch Tuning Operator

### Background

Users encountering registry errors (e.g. `403 Forbidden`, `unauthorized`) during MTO's image architecture inspection are presented with error messages that are not clear enough on the actual origin of the issue. This leads them to assume that the errors originated from MTO itself, while the issue was unrelated to MTO.

### Changes

Updated the event message constants in internal/controller/podplacement/events.go:

**Before:**
-  `Failed to retrieve the supported architectures: <error>`
-  `Failed to retrieve the supported architectures after multiple retries: <error>`

**After:**

```
The operator encountered an error while inspecting the container image to determine
its supported architectures. This is typically caused by the image registry being
unreachable, returning an error, or a misconfiguration. Registry error: <error>
```

### Test plan

  - [x] Built and deployed to an AWS OpenShift 4.22 cluster via `operator-sdk` run bundle
  - [x] Created a `ClusterPodPlacementConfig` with logVerbosity: Trace
  - [x] Deployed a pod referencing a non-existing image (quay.io/non-existing/image:latest)
  - [x] Verified the per-retry ArchAwareInspectionError event shows the new message
  - [x] Verified the max-retries ArchAwareInspectionError event shows the new message
  - [x] Verified the kubelet subsequently fails with the same registry error, confirming the issue is not MTO-related
  - [x] Unit tests pass (go test ./internal/controller/podplacement/...)