### PR TITLE
MULTIARCH-6239: use direct API reader for PPC listing in PodReconciler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -245,6 +245,7 @@ func RunClusterPodPlacementConfigOperandControllers(mgr ctrl.Manager) {
 
 	must((&podplacement.PodReconciler{
 		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
 		Scheme:    mgr.GetScheme(),
 		ClientSet: clientset,
 		Recorder:  mgr.GetEventRecorderFor(utils.OperatorName), //nolint:staticcheck // MULTIARCH-6087: will be fixed with events API migration

--- a/internal/controller/podplacement/pod_reconciler.go
+++ b/internal/controller/podplacement/pod_reconciler.go
@@ -46,6 +46,7 @@ import (
 // PodReconciler reconciles a Pod object
 type PodReconciler struct {
 	client.Client
+	APIReader client.Reader
 	Scheme    *runtime.Scheme
 	ClientSet *kubernetes.Clientset
 	Recorder  record.EventRecorder
@@ -114,6 +115,15 @@ func (r *PodReconciler) processPod(ctx context.Context, pod *Pod) {
 	if err := r.List(ctx, ppcList, client.InNamespace(pod.Namespace)); err != nil {
 		pod.handleError(err, "failed to list existing PodPlacementConfigs in namespace")
 		return
+	}
+	// The informer cache can lag behind the API server. If the cache shows no PPCs,
+	// verify with a direct API read to avoid a race where a just-created PPC is missed
+	// and the pod is permanently ungated without its preferred affinity.
+	if len(ppcList.Items) == 0 {
+		if err := r.APIReader.List(ctx, ppcList, client.InNamespace(pod.Namespace)); err != nil {
+			pod.handleError(err, "failed to list PodPlacementConfigs from API server")
+			return
+		}
 	}
 
 	// Filter to only PPCs that match this pod's labels - do this once for efficiency

--- a/internal/controller/podplacement/suite_test.go
+++ b/internal/controller/podplacement/suite_test.go
@@ -342,6 +342,7 @@ func runManager() {
 	By("Setting up PodPlacement controller")
 	Expect((&PodReconciler{
 		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
 		Scheme:    mgr.GetScheme(),
 		ClientSet: clientset,
 		Recorder:  mgr.GetEventRecorderFor(utils.OperatorName), //nolint:staticcheck // MULTIARCH-6087: will be fixed with events API migration

--- a/pkg/e2e/operator/pod_placement_config_test.go
+++ b/pkg/e2e/operator/pod_placement_config_test.go
@@ -709,11 +709,11 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 						Name: common.SingletonResourceObjectName,
 					},
 				}), cppc)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				By("Disabling the execFormatErrorMonitor plugin")
 				cppc.Spec.Plugins.ExecFormatErrorMonitor.Enabled = false
 				err = client.Update(ctx, cppc)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 			}).Should(Succeed(), "failed to update the ClusterPodPlacementConfig", err)
 			By("Get the v1beta1 version of the CPPC")
 			cppc := &v1beta1.ClusterPodPlacementConfig{}
@@ -783,6 +783,10 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create the ClusterPodPlacementConfig")
 				By("Validate the clusterPodPlacementConfig and eNoExecEvent objects exist")
 				Eventually(framework.ValidateCreation(client, ctx, framework.MainPlugin, framework.ENoExecPlugin)).Should(Succeed())
+				By("Wait for the ENoExecEvent CRD to be serving")
+				Eventually(func(g Gomega) {
+					g.Expect(client.List(ctx, &v1beta1.ENoExecEventList{}, runtimeclient.InNamespace(utils.Namespace()))).To(Succeed())
+				}, e2e.WaitShort).Should(Succeed())
 				By("Create an ephemeral namespace for the test pod")
 				ns := framework.NewEphemeralNamespace()
 				err = client.Create(ctx, ns)
@@ -846,6 +850,10 @@ var _ = Describe("The Multiarch Tuning Operator", Serial, func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create the ClusterPodPlacementConfig")
 				By("Validate the clusterPodPlacementConfig and eNoExecEvent objects exist")
 				Eventually(framework.ValidateCreation(client, ctx, framework.MainPlugin, framework.ENoExecPlugin)).Should(Succeed())
+				By("Wait for the ENoExecEvent CRD to be serving")
+				Eventually(func(g Gomega) {
+					g.Expect(client.List(ctx, &v1beta1.ENoExecEventList{}, runtimeclient.InNamespace(utils.Namespace()))).To(Succeed())
+				}, e2e.WaitShort).Should(Succeed())
 				By("Create an ephemeral namespace for the test pod")
 				ns := framework.NewEphemeralNamespace()
 				err = client.Create(ctx, ns)


### PR DESCRIPTION
The PodReconciler listed PodPlacementConfigs through the informer cache, which has inherent delivery latency (~5-50ms). When a PPC was created right before a pod was reconciled and image inspection completed instantly (cached), the pod could be fully processed and ungated before the PPC appeared in the cache — permanently missing its preferred affinity.

Switch the PPC list call from the cached client (r.List) to a direct API server read (r.APIReader.List) so every reconciliation sees the latest PPCs regardless of informer cache state.