### PR TITLE
MULTIARCH-6269: add direct API reader for cache miss

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -220,6 +220,7 @@ func RunOperator(mgr ctrl.Manager) {
 	// Set up the reconciler
 	must((&operator.ClusterPodPlacementConfigReconciler{
 		Client:        mgr.GetClient(),
+		APIReader:     mgr.GetAPIReader(),
 		Scheme:        mgr.GetScheme(),
 		ClientSet:     clientset,
 		DynamicClient: dynamic.NewForConfigOrDie(config),

--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -61,6 +61,7 @@ import (
 // ClusterPodPlacementConfigReconciler reconciles a ClusterPodPlacementConfig object
 type ClusterPodPlacementConfigReconciler struct {
 	client.Client
+	APIReader     client.Reader
 	DynamicClient *dynamic.DynamicClient
 	Scheme        *runtime.Scheme
 	ClientSet     *kubernetes.Clientset
@@ -163,12 +164,14 @@ func (r *ClusterPodPlacementConfigReconciler) Reconcile(ctx context.Context, req
 	log := ctrllog.FromContext(ctx)
 	log.V(1).Info("+++++++++++++++++++ Reconciling ClusterPodPlacementConfig +++++++++++++++++++")
 	// Lookup the ClusterPodPlacementConfig instance for this reconcile request
-	clusterPodPlacementConfig := &multiarchv1beta1.ClusterPodPlacementConfig{}
+	clusterPodPlacementConfig := &multiarchv1beta1.ClusterPodPlacementConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: common.SingletonResourceObjectName,
+		},
+	}
 	var err error
 
-	if err = r.Get(ctx, client.ObjectKey{
-		Name: req.Name,
-	}, clusterPodPlacementConfig); err != nil {
+	if err = r.getCacheWithAPIFallback(ctx, clusterPodPlacementConfig); err != nil {
 		log.Error(err, "Unable to fetch ClusterPodPlacementConfig")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -180,8 +183,7 @@ func (r *ClusterPodPlacementConfigReconciler) Reconcile(ctx context.Context, req
 	case !clusterPodPlacementConfig.DeletionTimestamp.IsZero():
 		// Only execute deletion if the object is being deleted and the finalizer is present
 		if err := r.handleDelete(ctx, clusterPodPlacementConfig); err != nil {
-			var requeueErr *requeueAfterError
-			if errors.As(err, &requeueErr) {
+			if requeueErr, ok := errors.AsType[*requeueAfterError](err); ok {
 				log.V(1).Info("Requeuing after delay", "reason", requeueErr.msg, "after", requeueErr.duration)
 				return ctrl.Result{RequeueAfter: requeueErr.duration}, nil
 			}
@@ -273,8 +275,7 @@ func (r *ClusterPodPlacementConfigReconciler) Reconcile(ctx context.Context, req
 	}
 
 	if err := r.reconcile(ctx, clusterPodPlacementConfig); err != nil {
-		var requeueErr *requeueAfterError
-		if errors.As(err, &requeueErr) {
+		if requeueErr, ok := errors.AsType[*requeueAfterError](err); ok {
 			log.V(1).Info("Requeuing after delay", "reason", requeueErr.msg, "after", requeueErr.duration)
 			return ctrl.Result{RequeueAfter: requeueErr.duration}, nil
 		}
@@ -501,11 +502,13 @@ func (r *ClusterPodPlacementConfigReconciler) handleDelete(ctx context.Context,
 	// The pods have been ungated and no other errors occurred, so we can remove the finalizer
 	log.Info("Pods have been ungated")
 	log = log.WithValues("finalizer", utils.PodPlacementFinalizerName)
-	ppcDeployment := &appsv1.Deployment{}
-	err = r.Get(ctx, client.ObjectKey{
-		Name:      utils.PodPlacementControllerName,
-		Namespace: utils.Namespace(),
-	}, ppcDeployment)
+	ppcDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.PodPlacementControllerName,
+			Namespace: utils.Namespace(),
+		},
+	}
+	err = r.getCacheWithAPIFallback(ctx, ppcDeployment)
 	if client.IgnoreNotFound(err) != nil {
 		log.Error(err, "Unable to fetch the deployment")
 		return err
@@ -620,11 +623,13 @@ func (r *ClusterPodPlacementConfigReconciler) handleEnoexecDelete(ctx context.Co
 		log.Error(err, "Unable to delete DaemonSet resources")
 		return err
 	}
-	ds := &appsv1.DaemonSet{}
-	err = r.Get(ctx, client.ObjectKey{
-		Name:      utils.EnoexecDaemonSet,
-		Namespace: utils.Namespace(),
-	}, ds)
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.EnoexecDaemonSet,
+			Namespace: utils.Namespace(),
+		},
+	}
+	err = r.getCacheWithAPIFallback(ctx, ds)
 	if err == nil {
 		log.Info("Waiting for the eNoExecEvent DaemonSet to be fully deleted...")
 		// Return an error to force requeue. This is a common pattern for waiting.
@@ -654,11 +659,13 @@ func (r *ClusterPodPlacementConfigReconciler) handleEnoexecDelete(ctx context.Co
 	}
 
 	log.Info("No non-errored ENoExecEvent resources found in the cluster. Removing the ExecEvent finalizer from the ENoExec Deployment")
-	deployment := &appsv1.Deployment{}
-	err = r.Get(ctx, client.ObjectKey{
-		Name:      utils.EnoexecControllerName,
-		Namespace: utils.Namespace(),
-	}, deployment)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.EnoexecControllerName,
+			Namespace: utils.Namespace(),
+		},
+	}
+	err = r.getCacheWithAPIFallback(ctx, deployment)
 	if client.IgnoreNotFound(err) != nil {
 		log.Error(err, "Could not fetch ENoExecEvent Deployment")
 		return err
@@ -1109,6 +1116,34 @@ func (r *ClusterPodPlacementConfigReconciler) deleteErroredENoExecEvents(ctx con
 		log.Info("Deleted errored ENoExecEvent resources during cleanup", "erroredCount", erroredCount)
 	}
 	return nonErroredCount, erroredCount
+}
+
+// getCacheWithAPIFallback fetches obj from the informer cache first. If Get returns
+// NotFound or the object is empty (no UID), it falls back to APIReader. ApplyResources
+// can create dependents before the informer observes them; a cache-only Get would skip
+// finalizer removal and leave the object stuck Terminating after CPPC is gone.
+func (r *ClusterPodPlacementConfigReconciler) getCacheWithAPIFallback(ctx context.Context, obj client.Object) error {
+	return getCacheWithAPIFallback(ctx, r.Client, r.APIReader, obj)
+}
+
+func getCacheWithAPIFallback(ctx context.Context, cache, api client.Reader, obj client.Object) error {
+	key := client.ObjectKeyFromObject(obj)
+	err := cache.Get(ctx, key, obj)
+	if err == nil && obj.GetUID() != "" {
+		return nil
+	}
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if api == nil {
+		if err != nil {
+			return err
+		}
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "objects"}, key.Name)
+	}
+	ctrllog.FromContext(ctx).V(1).Info("cache Get empty, falling back to APIReader",
+		"name", key.Name, "namespace", key.Namespace)
+	return api.Get(ctx, key, obj)
 }
 
 // cppcUpdatePredicate filters CPPC watch events to only reconcile on meaningful changes:

--- a/internal/controller/operator/get_cache_with_api_fallback_test.go
+++ b/internal/controller/operator/get_cache_with_api_fallback_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/multiarch-tuning-operator/api/common"
+	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/api/v1beta1"
+	"github.com/openshift/multiarch-tuning-operator/pkg/utils"
+)
+
+// getStub implements client.Reader.Get only. The helper under test never calls other methods.
+type getStub struct {
+	client.Reader
+	obj    client.Object
+	err    error
+	called *bool
+	gotKey *client.ObjectKey
+}
+
+func (g getStub) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if g.called != nil {
+		*g.called = true
+	}
+	if g.gotKey != nil {
+		*g.gotKey = key
+	}
+	if g.err != nil {
+		return g.err
+	}
+	if g.obj == nil {
+		return apierrors.NewNotFound(appsv1.Resource("deployments"), obj.GetName())
+	}
+	switch dst := obj.(type) {
+	case *appsv1.Deployment:
+		src, ok := g.obj.(*appsv1.Deployment)
+		if !ok {
+			return apierrors.NewBadRequest("expected Deployment")
+		}
+		*dst = *src
+	case *multiarchv1beta1.ClusterPodPlacementConfig:
+		src, ok := g.obj.(*multiarchv1beta1.ClusterPodPlacementConfig)
+		if !ok {
+			return apierrors.NewBadRequest("expected ClusterPodPlacementConfig")
+		}
+		*dst = *src
+	default:
+		return apierrors.NewBadRequest("unsupported object type")
+	}
+	return nil
+}
+
+func testDeployment(from string, uid types.UID) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.PodPlacementControllerName,
+			Namespace: utils.Namespace(),
+			UID:       uid,
+			Labels:    map[string]string{"from": from},
+		},
+	}
+}
+
+func testCPPC(from string, uid types.UID) *multiarchv1beta1.ClusterPodPlacementConfig {
+	return &multiarchv1beta1.ClusterPodPlacementConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   common.SingletonResourceObjectName,
+			UID:    uid,
+			Labels: map[string]string{"from": from},
+		},
+	}
+}
+
+func TestGetCacheWithAPIFallback(t *testing.T) {
+	ctx := context.Background()
+	key := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.PodPlacementControllerName,
+			Namespace: utils.Namespace(),
+		},
+	}
+
+	t.Run("returns from cache when Get finds an object with a UID", func(t *testing.T) {
+		apiCalled := false
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx,
+			getStub{obj: testDeployment("cache", "uid-cache")},
+			getStub{obj: testDeployment("api", "uid-api"), called: &apiCalled},
+			obj)
+		if err != nil {
+			t.Fatalf("expected cache hit, got error: %v", err)
+		}
+		if apiCalled {
+			t.Fatal("APIReader should not be called on cache hit")
+		}
+		if obj.Labels["from"] != "cache" {
+			t.Fatalf("expected cached object, got labels %v", obj.Labels)
+		}
+	})
+
+	t.Run("does not fall back when cache has a UID even if APIReader has a different object", func(t *testing.T) {
+		// A populated cache hit is trusted. Stale-but-present objects (for example a
+		// missing deletionTimestamp) are not detected by this helper.
+		apiCalled := false
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx,
+			getStub{obj: testDeployment("cache", "uid-stale")},
+			getStub{obj: testDeployment("api", "uid-fresh"), called: &apiCalled},
+			obj)
+		if err != nil {
+			t.Fatalf("expected cache hit, got error: %v", err)
+		}
+		if apiCalled {
+			t.Fatal("APIReader should not be called on a cache hit with a UID")
+		}
+		if obj.UID != "uid-stale" {
+			t.Fatalf("expected cached UID, got %q", obj.UID)
+		}
+	})
+
+	t.Run("falls back to APIReader when cache Get is NotFound", func(t *testing.T) {
+		cacheCalled := false
+		apiCalled := false
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx,
+			getStub{called: &cacheCalled},
+			getStub{obj: testDeployment("api", "uid-api"), called: &apiCalled},
+			obj)
+		if err != nil {
+			t.Fatalf("expected APIReader fallback, got error: %v", err)
+		}
+		if !cacheCalled {
+			t.Fatal("cache Get should be called first")
+		}
+		if !apiCalled {
+			t.Fatal("APIReader should be called on cache NotFound")
+		}
+		if obj.Labels["from"] != "api" {
+			t.Fatalf("expected APIReader object, got labels %v", obj.Labels)
+		}
+	})
+
+	t.Run("falls back to APIReader when cache Get is empty (no UID)", func(t *testing.T) {
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx,
+			getStub{obj: testDeployment("cache", "")},
+			getStub{obj: testDeployment("api", "uid-api")},
+			obj)
+		if err != nil {
+			t.Fatalf("expected APIReader fallback for empty cache object, got error: %v", err)
+		}
+		if obj.Labels["from"] != "api" {
+			t.Fatalf("expected APIReader object, got labels %v", obj.Labels)
+		}
+	})
+
+	t.Run("looks up the object using Name and Namespace set on obj", func(t *testing.T) {
+		var cacheKey, apiKey client.ObjectKey
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx,
+			getStub{gotKey: &cacheKey},
+			getStub{obj: testDeployment("api", "uid-api"), gotKey: &apiKey},
+			obj)
+		if err != nil {
+			t.Fatalf("expected APIReader fallback, got error: %v", err)
+		}
+		want := client.ObjectKey{Name: utils.PodPlacementControllerName, Namespace: utils.Namespace()}
+		if cacheKey != want {
+			t.Fatalf("cache Get key = %#v, want %#v", cacheKey, want)
+		}
+		if apiKey != want {
+			t.Fatalf("APIReader Get key = %#v, want %#v", apiKey, want)
+		}
+	})
+
+	t.Run("returns NotFound when missing from cache and APIReader", func(t *testing.T) {
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx, getStub{}, getStub{}, obj)
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected NotFound, got %v", err)
+		}
+	})
+
+	t.Run("returns APIReader error when fallback Get fails", func(t *testing.T) {
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx,
+			getStub{},
+			getStub{err: apierrors.NewServiceUnavailable("api unavailable")},
+			obj)
+		if !apierrors.IsServiceUnavailable(err) {
+			t.Fatalf("expected ServiceUnavailable from APIReader, got %v", err)
+		}
+	})
+
+	t.Run("does not fall back on unexpected cache errors", func(t *testing.T) {
+		apiCalled := false
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx,
+			getStub{err: apierrors.NewServiceUnavailable("cache unavailable")},
+			getStub{obj: testDeployment("api", "uid-api"), called: &apiCalled},
+			obj)
+		if !apierrors.IsServiceUnavailable(err) {
+			t.Fatalf("expected ServiceUnavailable, got %v", err)
+		}
+		if apiCalled {
+			t.Fatal("APIReader should not be called on unexpected cache error")
+		}
+	})
+
+	t.Run("returns cache NotFound when APIReader is nil", func(t *testing.T) {
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx, getStub{}, nil, obj)
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected NotFound, got %v", err)
+		}
+	})
+
+	t.Run("returns NotFound when cache object has no UID and APIReader is nil", func(t *testing.T) {
+		obj := key.DeepCopy()
+		err := getCacheWithAPIFallback(ctx, getStub{obj: testDeployment("cache", "")}, nil, obj)
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected NotFound, got %v", err)
+		}
+	})
+
+	t.Run("falls back for ClusterPodPlacementConfig singleton cache miss", func(t *testing.T) {
+		obj := &multiarchv1beta1.ClusterPodPlacementConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: common.SingletonResourceObjectName,
+			},
+		}
+		var cacheKey client.ObjectKey
+		err := getCacheWithAPIFallback(ctx,
+			getStub{gotKey: &cacheKey},
+			getStub{obj: testCPPC("api", "uid-api")},
+			obj)
+		if err != nil {
+			t.Fatalf("expected APIReader fallback, got error: %v", err)
+		}
+		if cacheKey != (client.ObjectKey{Name: common.SingletonResourceObjectName}) {
+			t.Fatalf("cache Get key = %#v, want name %q", cacheKey, common.SingletonResourceObjectName)
+		}
+		if obj.Labels["from"] != "api" {
+			t.Fatalf("expected APIReader object, got labels %v", obj.Labels)
+		}
+	})
+}

--- a/internal/controller/operator/suite_test.go
+++ b/internal/controller/operator/suite_test.go
@@ -241,6 +241,7 @@ func runManager() {
 	}
 	Expect((&ClusterPodPlacementConfigReconciler{
 		Client:        mgr.GetClient(),
+		APIReader:     mgr.GetAPIReader(),
 		Scheme:        mgr.GetScheme(),
 		ClientSet:     clientset,
 		DynamicClient: dynamic.NewForConfigOrDie(cfg),


### PR DESCRIPTION
The ClusterPodPlacementConfigReconciler read the CPPC from the informer cache at the top of Reconcile. When a CPPC was deleted immediately after creation, the cache could return a stale version without DeletionTimestamp, causing the reconciler to enter the normal path instead of handleDelete. The operand resources were created, then the controller lost track of the object when the cache caught up — leaving the CPPC stuck with a finalizer.

Add an APIReader field and use it for the initial Get in Reconcile so the reconciler always sees the current DeletionTimestamp from the API server, bypassing informer cache lag.