### PR TITLE
MULTIARCH-6271: OLM CSV lifecycle cycling prevents operator convergence and blocks CPPC finalizer processing 

### DIFF
--- a/hack/deploy-and-e2e.sh
+++ b/hack/deploy-and-e2e.sh
@@ -50,11 +50,38 @@ oc wait pods -n ${NAMESPACE} \
   --for=condition=Ready=True
 
 if [ "${USE_OLM:-}" == "true" ]; then
-  echo "Waiting for CSV to reach Succeeded phase..."
-  oc wait csv -n "${NAMESPACE}" \
-    -l "operators.coreos.com/multiarch-tuning-operator.${NAMESPACE}=" \
-    --for=jsonpath='{.status.phase}'=Succeeded \
-    --timeout=5m || echo "[WARN] CSV wait timed out, proceeding with tests"
+  echo "Waiting for CSV to exist..."
+  CSV_NAME=""
+  retries=0
+  while [ -z "${CSV_NAME}" ] && [ "${retries}" -lt 60 ]; do
+    set +e
+    csv_get_output=$(oc get csv -n "${NAMESPACE}" \
+      -l "operators.coreos.com/multiarch-tuning-operator.${NAMESPACE}=" \
+      -o custom-columns=NAME:.metadata.name --no-headers \
+      --request-timeout=30s 2>&1)
+    csv_get_rc=$?
+    set -e
+    if [ "${csv_get_rc}" -eq 0 ]; then
+      CSV_NAME=$(printf '%s\n' "${csv_get_output}" | awk 'NF { print $1; exit }')
+    elif echo "${csv_get_output}" | grep -qiE "forbidden|unauthorized"; then
+      echo "[ERROR] oc get csv failed (auth): ${csv_get_output}"
+      exit 1
+    fi
+    if [ -z "${CSV_NAME}" ]; then
+      sleep 5
+      retries=$((retries + 1))
+    fi
+  done
+  if [ -z "${CSV_NAME}" ]; then
+    echo "[WARN] No CSV found after 5 minutes, proceeding with tests"
+  else
+    echo "Waiting for CSV ${CSV_NAME} to reach Succeeded phase..."
+    if ! oc wait "csv/${CSV_NAME}" -n "${NAMESPACE}" \
+        --for=jsonpath='{.status.phase}'=Succeeded \
+        --timeout=5m; then
+      echo "[WARN] CSV did not reach Succeeded within 5m, proceeding with tests"
+    fi
+  fi
   echo "Waiting for operator to stabilize..."
   sleep 10
 fi

--- a/hack/deploy-and-e2e.sh
+++ b/hack/deploy-and-e2e.sh
@@ -49,6 +49,16 @@ oc wait pods -n ${NAMESPACE} \
   -l control-plane=controller-manager \
   --for=condition=Ready=True
 
+if [ "${USE_OLM:-}" == "true" ]; then
+  echo "Waiting for CSV to reach Succeeded phase..."
+  oc wait csv -n "${NAMESPACE}" \
+    -l "operators.coreos.com/multiarch-tuning-operator.${NAMESPACE}=" \
+    --for=jsonpath='{.status.phase}'=Succeeded \
+    --timeout=5m || echo "[WARN] CSV wait timed out, proceeding with tests"
+  echo "Waiting for operator to stabilize..."
+  sleep 10
+fi
+
 make e2e
 
 if [ "${CLEANUP:-false}" == "false" ]; then

--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -814,11 +814,10 @@ func (r *ClusterPodPlacementConfigReconciler) updateStatus(ctx context.Context, 
 		log.Error(err, "Unable to update conditions in the ClusterPodPlacementConfig")
 		return err
 	}
-	var err error = nil
 	if progressing {
-		err = errors.New(clusterPodPlacementConfigNotReady)
+		return newRequeueAfterError(5*time.Second, clusterPodPlacementConfigNotReady)
 	}
-	return err
+	return nil
 }
 
 func (r *ClusterPodPlacementConfigReconciler) buildPodPlacementConfigObjects(clusterPodPlacementConfig *multiarchv1beta1.ClusterPodPlacementConfig, ctx context.Context) ([]client.Object, error) {
@@ -1062,10 +1061,11 @@ func (r *ClusterPodPlacementConfigReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&corev1.ServiceAccount{}).
-		Owns(&admissionv1.MutatingWebhookConfiguration{})
+		Owns(&admissionv1.MutatingWebhookConfiguration{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 	if utils.IsResourceAvailable(context.Background(), r.DynamicClient,
 		monitoringv1.SchemeGroupVersion.WithResource("servicemonitors")) {
-		c = c.Owns(&monitoringv1.ServiceMonitor{}).Owns(&monitoringv1.PrometheusRule{})
+		c = c.Owns(&monitoringv1.ServiceMonitor{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			Owns(&monitoringv1.PrometheusRule{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 	}
 	return c.Complete(r)
 }

--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -1038,27 +1038,36 @@ func (r *ClusterPodPlacementConfigReconciler) deleteErroredENoExecEvents(ctx con
 	return nonErroredCount, erroredCount
 }
 
+// cppcUpdatePredicate filters CPPC watch events to only reconcile on meaningful changes:
+// spec changes (generation bump), deletion (deletionTimestamp), and finalizer updates.
+// Status-only and label/annotation-only updates are intentionally filtered because
+// this controller is spec-driven, and status updates from r.Status().Update() would
+// otherwise re-trigger reconciliation, nullifying the 5s requeueAfter.
+func cppcUpdatePredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+			if !e.ObjectOld.GetDeletionTimestamp().Equal(e.ObjectNew.GetDeletionTimestamp()) {
+				return true
+			}
+			if !slices.Equal(e.ObjectOld.GetFinalizers(), e.ObjectNew.GetFinalizers()) {
+				return true
+			}
+			return false
+		},
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterPodPlacementConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c := ctrl.NewControllerManagedBy(mgr).
 		For(&multiarchv1beta1.ClusterPodPlacementConfig{},
-			builder.WithPredicates(predicate.Funcs{
-				CreateFunc: func(e event.CreateEvent) bool { return true },
-				DeleteFunc: func(e event.DeleteEvent) bool { return true },
-				UpdateFunc: func(e event.UpdateEvent) bool {
-					if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
-						return true
-					}
-					if !e.ObjectOld.GetDeletionTimestamp().Equal(e.ObjectNew.GetDeletionTimestamp()) {
-						return true
-					}
-					if !slices.Equal(e.ObjectOld.GetFinalizers(), e.ObjectNew.GetFinalizers()) {
-						return true
-					}
-					return false
-				},
-				GenericFunc: func(e event.GenericEvent) bool { return true },
-			}),
+			builder.WithPredicates(cppcUpdatePredicate()),
 		).
 		// Watch PodPlacementConfig to reconcile ClusterPodPlacementConfig only on create/delete events.
 		// Updates to PodPlacementConfig are intentionally ignored.

--- a/internal/controller/operator/clusterpodplacementconfig_controller.go
+++ b/internal/controller/operator/clusterpodplacementconfig_controller.go
@@ -19,6 +19,7 @@ package operator
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -79,6 +80,19 @@ func (e *requeueAfterError) Error() string { return e.msg }
 
 func newRequeueAfterError(d time.Duration, msg string) error {
 	return &requeueAfterError{duration: d, msg: msg}
+}
+
+// mergeWithStatusErr combines primary reconcile errors with the result of
+// updateStatus. If statusErr is a *requeueAfterError it takes priority so that
+// errors.As in Reconcile() can unwrap it for a clean requeue instead of falling
+// through to exponential backoff. Primary errors are already logged at their
+// call sites.
+func mergeWithStatusErr(statusErr error, primaryErrs ...error) error {
+	var requeueErr *requeueAfterError
+	if errors.As(statusErr, &requeueErr) {
+		return statusErr
+	}
+	return errorutils.NewAggregate(append(primaryErrs, statusErr))
 }
 
 const (
@@ -730,7 +744,7 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 	}
 	if err := r.ensureNamespaceLabels(ctx); err != nil {
 		log.Error(err, "Unable to ensure namespace labels")
-		return errorutils.NewAggregate([]error{err, r.updateStatus(ctx, clusterPodPlacementConfig)})
+		return mergeWithStatusErr(r.updateStatus(ctx, clusterPodPlacementConfig), err)
 	}
 	clusterPodPlacementConfigObjects, err := r.buildPodPlacementConfigObjects(clusterPodPlacementConfig, ctx)
 	if err != nil {
@@ -783,12 +797,12 @@ func (r *ClusterPodPlacementConfigReconciler) reconcile(ctx context.Context, clu
 	}
 
 	if len(errs) > 0 {
-		return errorutils.NewAggregate(append(errs, r.updateStatus(ctx, clusterPodPlacementConfig)))
+		return mergeWithStatusErr(r.updateStatus(ctx, clusterPodPlacementConfig), errs...)
 	}
 
 	if err := utils.ApplyResources(ctx, r.ClientSet, r.DynamicClient, r.Recorder, objects); err != nil {
 		log.Error(err, "Unable to apply resources")
-		return errorutils.NewAggregate([]error{err, r.updateStatus(ctx, clusterPodPlacementConfig)})
+		return mergeWithStatusErr(r.updateStatus(ctx, clusterPodPlacementConfig), err)
 	}
 
 	return r.updateStatus(ctx, clusterPodPlacementConfig)
@@ -1027,7 +1041,25 @@ func (r *ClusterPodPlacementConfigReconciler) deleteErroredENoExecEvents(ctx con
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterPodPlacementConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c := ctrl.NewControllerManagedBy(mgr).
-		For(&multiarchv1beta1.ClusterPodPlacementConfig{}).
+		For(&multiarchv1beta1.ClusterPodPlacementConfig{},
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(e event.CreateEvent) bool { return true },
+				DeleteFunc: func(e event.DeleteEvent) bool { return true },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+						return true
+					}
+					if !e.ObjectOld.GetDeletionTimestamp().Equal(e.ObjectNew.GetDeletionTimestamp()) {
+						return true
+					}
+					if !slices.Equal(e.ObjectOld.GetFinalizers(), e.ObjectNew.GetFinalizers()) {
+						return true
+					}
+					return false
+				},
+				GenericFunc: func(e event.GenericEvent) bool { return true },
+			}),
+		).
 		// Watch PodPlacementConfig to reconcile ClusterPodPlacementConfig only on create/delete events.
 		// Updates to PodPlacementConfig are intentionally ignored.
 		Watches(

--- a/internal/controller/operator/predicate_test.go
+++ b/internal/controller/operator/predicate_test.go
@@ -1,0 +1,147 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	multiarchv1beta1 "github.com/openshift/multiarch-tuning-operator/api/v1beta1"
+)
+
+func TestCppcUpdatePredicate(t *testing.T) {
+	now := metav1.Now()
+	p := cppcUpdatePredicate()
+
+	tests := []struct {
+		name string
+		old  *multiarchv1beta1.ClusterPodPlacementConfig
+		new  *multiarchv1beta1.ClusterPodPlacementConfig
+		want bool
+	}{
+		{
+			name: "generation change passes",
+			old: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+			},
+			want: true,
+		},
+		{
+			name: "deletionTimestamp change passes",
+			old: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, DeletionTimestamp: &now},
+			},
+			want: true,
+		},
+		{
+			name: "finalizer change passes",
+			old: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Finalizers: []string{"cleanup"}},
+			},
+			want: true,
+		},
+		{
+			name: "status-only update filtered",
+			old: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: multiarchv1beta1.ClusterPodPlacementConfigStatus{
+					Conditions: []metav1.Condition{
+						{Type: "Available", Status: metav1.ConditionTrue, LastTransitionTime: now, Reason: "Ready"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "label-only update filtered",
+			old: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Labels: map[string]string{"foo": "bar"}},
+			},
+			want: false,
+		},
+		{
+			name: "annotation-only update filtered",
+			old: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Annotations: map[string]string{"note": "test"}},
+			},
+			want: false,
+		},
+		{
+			name: "no change filtered",
+			old: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Finalizers: []string{"cleanup"}},
+			},
+			new: &multiarchv1beta1.ClusterPodPlacementConfig{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, Finalizers: []string{"cleanup"}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.Update(event.UpdateEvent{
+				ObjectOld: tt.old,
+				ObjectNew: tt.new,
+			})
+			if got != tt.want {
+				t.Errorf("UpdateFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCppcUpdatePredicate_CreateDeleteGenericPassThrough(t *testing.T) {
+	p := cppcUpdatePredicate()
+	now := metav1.Now()
+	obj := &multiarchv1beta1.ClusterPodPlacementConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", DeletionTimestamp: &now},
+	}
+
+	if !p.Create(event.CreateEvent{Object: obj}) {
+		t.Error("CreateFunc should always return true")
+	}
+	if !p.Delete(event.DeleteEvent{Object: obj}) {
+		t.Error("DeleteFunc should always return true")
+	}
+	if !p.Generic(event.GenericEvent{Object: obj}) {
+		t.Error("GenericFunc should always return true")
+	}
+}
+
+func TestCppcUpdatePredicate_BothTimestampsSet(t *testing.T) {
+	p := cppcUpdatePredicate()
+	t1 := metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	t2 := metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 1, 0, time.UTC))
+
+	got := p.Update(event.UpdateEvent{
+		ObjectOld: &multiarchv1beta1.ClusterPodPlacementConfig{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1, DeletionTimestamp: &t1},
+		},
+		ObjectNew: &multiarchv1beta1.ClusterPodPlacementConfig{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1, DeletionTimestamp: &t2},
+		},
+	})
+	if !got {
+		t.Error("different deletionTimestamps should pass")
+	}
+}

--- a/internal/controller/operator/requeue_test.go
+++ b/internal/controller/operator/requeue_test.go
@@ -1,0 +1,130 @@
+package operator
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRequeueAfterError_ErrorsAs(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		msg      string
+	}{
+		{
+			name:     "5s requeue for progressing",
+			duration: 5 * time.Second,
+			msg:      clusterPodPlacementConfigNotReady,
+		},
+		{
+			name:     "10s requeue for ungating",
+			duration: 10 * time.Second,
+			msg:      waitingForUngatingPodsError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := newRequeueAfterError(tt.duration, tt.msg)
+			if err == nil {
+				t.Fatal("expected non-nil error")
+			}
+			if err.Error() != tt.msg {
+				t.Errorf("Error() = %q, want %q", err.Error(), tt.msg)
+			}
+
+			var requeueErr *requeueAfterError
+			if !errors.As(err, &requeueErr) {
+				t.Fatal("errors.As should unwrap requeueAfterError")
+			}
+			if requeueErr.duration != tt.duration {
+				t.Errorf("duration = %v, want %v", requeueErr.duration, tt.duration)
+			}
+			if requeueErr.msg != tt.msg {
+				t.Errorf("msg = %q, want %q", requeueErr.msg, tt.msg)
+			}
+		})
+	}
+}
+
+func TestRequeueAfterError_NotMatchPlainError(t *testing.T) {
+	plainErr := errors.New("some error")
+	var requeueErr *requeueAfterError
+	if errors.As(plainErr, &requeueErr) {
+		t.Fatal("errors.As should not match plain error as requeueAfterError")
+	}
+}
+
+func TestMergeWithStatusErr(t *testing.T) {
+	primaryErr := errors.New("primary failure")
+	plainStatusErr := errors.New("status update failed")
+
+	tests := []struct {
+		name           string
+		statusErr      error
+		primaryErrs    []error
+		wantRequeue    bool
+		wantRequeueDur time.Duration
+		wantNil        bool
+	}{
+		{
+			name:           "requeueAfterError takes priority over primary errors",
+			statusErr:      newRequeueAfterError(5*time.Second, "progressing"),
+			primaryErrs:    []error{primaryErr},
+			wantRequeue:    true,
+			wantRequeueDur: 5 * time.Second,
+		},
+		{
+			name:        "plain status error aggregates with primary",
+			statusErr:   plainStatusErr,
+			primaryErrs: []error{primaryErr},
+			wantRequeue: false,
+		},
+		{
+			name:        "nil status error returns primary only",
+			statusErr:   nil,
+			primaryErrs: []error{primaryErr},
+			wantRequeue: false,
+		},
+		{
+			name:        "nil status and nil primary returns nil",
+			statusErr:   nil,
+			primaryErrs: nil,
+			wantNil:     true,
+		},
+		{
+			name:           "requeueAfterError with multiple primary errors",
+			statusErr:      newRequeueAfterError(5*time.Second, "progressing"),
+			primaryErrs:    []error{primaryErr, errors.New("another error")},
+			wantRequeue:    true,
+			wantRequeueDur: 5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeWithStatusErr(tt.statusErr, tt.primaryErrs...)
+
+			if tt.wantNil {
+				if result != nil {
+					t.Fatalf("expected nil, got %v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil error")
+			}
+
+			var requeueErr *requeueAfterError
+			gotRequeue := errors.As(result, &requeueErr)
+			if gotRequeue != tt.wantRequeue {
+				t.Fatalf("errors.As(requeueAfterError) = %v, want %v", gotRequeue, tt.wantRequeue)
+			}
+			if gotRequeue && requeueErr.duration != tt.wantRequeueDur {
+				t.Fatalf("requeue duration = %v, want %v", requeueErr.duration, tt.wantRequeueDur)
+			}
+		})
+	}
+}

--- a/pkg/utils/export_test.go
+++ b/pkg/utils/export_test.go
@@ -1,0 +1,15 @@
+package utils
+
+// ResetGenerations clears the generation tracking state for test isolation.
+func ResetGenerations() {
+	generationsMu.Lock()
+	defer generationsMu.Unlock()
+	generations = nil
+}
+
+// GenerationsLen returns the length of the generations slice under the mutex.
+func GenerationsLen() int {
+	generationsMu.Lock()
+	defer generationsMu.Unlock()
+	return len(generations)
+}

--- a/pkg/utils/resource.go
+++ b/pkg/utils/resource.go
@@ -161,24 +161,21 @@ var (
 	generations   []operatorv1.GenerationStatus
 )
 
-// ResetGenerations clears the generation tracking state. Intended for test isolation.
-func ResetGenerations() {
-	generationsMu.Lock()
-	defer generationsMu.Unlock()
-	generations = nil
-}
-
 // applyDeployment wraps library-go's ApplyDeployment with generation tracking so that
 // the spec-hash skip path works correctly. Without tracking, passing expectedGeneration=0
 // disables the skip path entirely, causing an Update on every reconcile.
 func applyDeployment(ctx context.Context, client appsv1client.DeploymentsGetter, recorder events.Recorder,
 	required *appsv1.Deployment) (*appsv1.Deployment, bool, error) {
 	generationsMu.Lock()
-	defer generationsMu.Unlock()
 	expectedGen := resourcemerge.ExpectedDeploymentGeneration(required, generations)
+	generationsMu.Unlock()
+
 	result, modified, err := resourceapply.ApplyDeployment(ctx, client, recorder, required, expectedGen)
+
 	if err == nil && result != nil {
+		generationsMu.Lock()
 		resourcemerge.SetDeploymentGeneration(&generations, result)
+		generationsMu.Unlock()
 	}
 	return result, modified, err
 }
@@ -187,11 +184,15 @@ func applyDeployment(ctx context.Context, client appsv1client.DeploymentsGetter,
 func applyDaemonSet(ctx context.Context, client appsv1client.DaemonSetsGetter, recorder events.Recorder,
 	required *appsv1.DaemonSet) (*appsv1.DaemonSet, bool, error) {
 	generationsMu.Lock()
-	defer generationsMu.Unlock()
 	expectedGen := resourcemerge.ExpectedDaemonSetGeneration(required, generations)
+	generationsMu.Unlock()
+
 	result, modified, err := resourceapply.ApplyDaemonSet(ctx, client, recorder, required, expectedGen)
+
 	if err == nil && result != nil {
+		generationsMu.Lock()
 		resourcemerge.SetDaemonSetGeneration(&generations, result)
+		generationsMu.Unlock()
 	}
 	return result, modified, err
 }

--- a/pkg/utils/resource.go
+++ b/pkg/utils/resource.go
@@ -3,11 +3,13 @@ package utils
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -15,11 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
@@ -66,9 +70,9 @@ func ApplyResource(ctx context.Context, clientSet *kubernetes.Clientset, client 
 	obj client.Object) (client.Object, bool, error) {
 	switch t := obj.(type) {
 	case *appsv1.Deployment:
-		return resourceapply.ApplyDeployment(ctx, clientSet.AppsV1(), recorder, t, 0)
+		return applyDeployment(ctx, clientSet.AppsV1(), recorder, t)
 	case *appsv1.DaemonSet:
-		return resourceapply.ApplyDaemonSet(ctx, clientSet.AppsV1(), recorder, t, 0)
+		return applyDaemonSet(ctx, clientSet.AppsV1(), recorder, t)
 	case *corev1.Service:
 		return applyService(ctx, clientSet.CoreV1(), recorder, t)
 	case *admissionv1.MutatingWebhookConfiguration:
@@ -148,14 +152,54 @@ func DeleteResources(ctx context.Context, toDeleteRefs []ToDeleteRef) error {
 	return nil
 }
 
-// applyService is a copy of the original method from
-// https://github.com/openshift/library-go/blob/964bcb3f545c24f15294fd8ba914529bf4fe8c4d/pkg/operator/resource/resourceapply/core.go#L132
-// The original method updates the service only if either the selector or the service type change.
-// This method updates the service in any case. A better solution would be to use the spec hash on the service, but
-// since the api server will default some values (e.g. clusterIP), this method would continue to detect changes and
-// update the service always. Therefore, that logic is stripped for now and considered 'good/safe enough' as we handle
-// just a few services.
-// TODO[integration-tests]: integration tests for this function in a suite dedicated to this package
+// generations tracks the last-applied generation for each Deployment/DaemonSet using
+// the standard OpenShift operatorv1.GenerationStatus type and library-go helpers.
+// On pod restart the slice is empty, so the first reconcile always applies
+// (ExpectedDeploymentGeneration returns -1 when no entry is found).
+var (
+	generationsMu sync.Mutex
+	generations   []operatorv1.GenerationStatus
+)
+
+// ResetGenerations clears the generation tracking state. Intended for test isolation.
+func ResetGenerations() {
+	generationsMu.Lock()
+	defer generationsMu.Unlock()
+	generations = nil
+}
+
+// applyDeployment wraps library-go's ApplyDeployment with generation tracking so that
+// the spec-hash skip path works correctly. Without tracking, passing expectedGeneration=0
+// disables the skip path entirely, causing an Update on every reconcile.
+func applyDeployment(ctx context.Context, client appsv1client.DeploymentsGetter, recorder events.Recorder,
+	required *appsv1.Deployment) (*appsv1.Deployment, bool, error) {
+	generationsMu.Lock()
+	defer generationsMu.Unlock()
+	expectedGen := resourcemerge.ExpectedDeploymentGeneration(required, generations)
+	result, modified, err := resourceapply.ApplyDeployment(ctx, client, recorder, required, expectedGen)
+	if err == nil && result != nil {
+		resourcemerge.SetDeploymentGeneration(&generations, result)
+	}
+	return result, modified, err
+}
+
+// applyDaemonSet wraps library-go's ApplyDaemonSet with generation tracking.
+func applyDaemonSet(ctx context.Context, client appsv1client.DaemonSetsGetter, recorder events.Recorder,
+	required *appsv1.DaemonSet) (*appsv1.DaemonSet, bool, error) {
+	generationsMu.Lock()
+	defer generationsMu.Unlock()
+	expectedGen := resourcemerge.ExpectedDaemonSetGeneration(required, generations)
+	result, modified, err := resourceapply.ApplyDaemonSet(ctx, client, recorder, required, expectedGen)
+	if err == nil && result != nil {
+		resourcemerge.SetDaemonSetGeneration(&generations, result)
+	}
+	return result, modified, err
+}
+
+// applyService compares the fields the operator manages (ports, selector, type) against the
+// existing Service and only issues an Update when they differ. Server-defaulted fields
+// (clusterIP, sessionAffinity, ipFamilies, etc.) are ignored to avoid unnecessary updates
+// that would trigger Owns() watch events and feed a reconciliation storm.
 func applyService(ctx context.Context, client v1.ServicesGetter, recorder events.Recorder,
 	requiredOriginal *corev1.Service) (*corev1.Service, bool, error) {
 	required := requiredOriginal.DeepCopy()
@@ -165,8 +209,6 @@ func applyService(ctx context.Context, client v1.ServicesGetter, recorder events
 		actual, err := client.Services(requiredCopy.Namespace).
 			Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Service),
 				metav1.CreateOptions{})
-		// The following method is not exported by the resource apply package and is flattened in the next rows
-		// reportCreateEvent(recorder, requiredCopy, err)
 		gvk := resourcehelper.GuessObjectGroupVersionKind(requiredCopy)
 		if err == nil {
 			recorder.Eventf(fmt.Sprintf("%sCreated", gvk.Kind), "Created %s because it was missing",
@@ -175,17 +217,19 @@ func applyService(ctx context.Context, client v1.ServicesGetter, recorder events
 			recorder.Warningf(fmt.Sprintf("%sCreateFailed", gvk.Kind), "Failed to create %s: %v",
 				resourcehelper.FormatResourceForCLIWithNamespace(requiredCopy), err)
 		}
-		// End flattened method reportCreateEvent
 		return actual, true, err
 	}
 	if err != nil {
 		return nil, false, err
 	}
+
+	if serviceSpecMatchesRequired(existing.Spec, required.Spec) {
+		return existing, false, nil
+	}
+
 	existingCopy := existing.DeepCopy()
 	existingCopy.Spec = required.Spec
 
-	// the following method is not exported by the resourceapply package and is flattened in the next rows
-	// reportUpdateEvent(recorder, required, err)
 	actual, err := client.Services(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	gvk := resourcehelper.GuessObjectGroupVersionKind(required)
 	if err != nil {
@@ -195,6 +239,51 @@ func applyService(ctx context.Context, client v1.ServicesGetter, recorder events
 		recorder.Eventf(fmt.Sprintf("%sUpdated", gvk.Kind), "Updated %s because it changed",
 			resourcehelper.FormatResourceForCLIWithNamespace(required))
 	}
-	// end flattened method reportUpdateEvent
 	return actual, true, err
+}
+
+// serviceSpecMatchesRequired compares only the fields the operator manages:
+// ports (name, protocol, port, targetPort), selector, and type.
+func serviceSpecMatchesRequired(existing, required corev1.ServiceSpec) bool {
+	if !equality.Semantic.DeepEqual(existing.Selector, required.Selector) {
+		return false
+	}
+	existingType := existing.Type
+	if len(existingType) == 0 {
+		existingType = corev1.ServiceTypeClusterIP
+	}
+	requiredType := required.Type
+	if len(requiredType) == 0 {
+		requiredType = corev1.ServiceTypeClusterIP
+	}
+	if existingType != requiredType {
+		return false
+	}
+	return servicePortsMatch(existing.Ports, required.Ports)
+}
+
+// servicePortsMatch compares the managed port fields, ignoring server-defaulted
+// fields like NodePort. Ports are compared positionally (buildService always
+// produces the same ordered list).
+func servicePortsMatch(existing, required []corev1.ServicePort) bool {
+	if len(existing) != len(required) {
+		return false
+	}
+	for i := range required {
+		existingProto := existing[i].Protocol
+		if len(existingProto) == 0 {
+			existingProto = corev1.ProtocolTCP
+		}
+		requiredProto := required[i].Protocol
+		if len(requiredProto) == 0 {
+			requiredProto = corev1.ProtocolTCP
+		}
+		if existing[i].Name != required[i].Name ||
+			existingProto != requiredProto ||
+			existing[i].Port != required[i].Port ||
+			existing[i].TargetPort != required[i].TargetPort {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/utils/resource_test.go
+++ b/pkg/utils/resource_test.go
@@ -1,0 +1,510 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/clock"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestServiceSpecMatchesRequired(t *testing.T) {
+	basePorts := []corev1.ServicePort{
+		{
+			Name:       "https",
+			Port:       443,
+			TargetPort: intstr.FromInt32(9443),
+			Protocol:   corev1.ProtocolTCP,
+		},
+		{
+			Name:       "metrics",
+			Port:       8443,
+			TargetPort: intstr.FromInt32(8443),
+			Protocol:   corev1.ProtocolTCP,
+		},
+	}
+	baseSelector := map[string]string{
+		"app":        "test",
+		"controller": "pod-placement-controller",
+	}
+
+	tests := []struct {
+		name     string
+		existing corev1.ServiceSpec
+		required corev1.ServiceSpec
+		want     bool
+	}{
+		{
+			name: "identical specs match",
+			existing: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			want: true,
+		},
+		{
+			name: "empty required type matches ClusterIP",
+			existing: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+			},
+			want: true,
+		},
+		{
+			name: "server-defaulted fields ignored",
+			existing: corev1.ServiceSpec{
+				Ports:           basePorts,
+				Selector:        baseSelector,
+				Type:            corev1.ServiceTypeClusterIP,
+				ClusterIP:       "10.0.0.1",
+				ClusterIPs:      []string{"10.0.0.1"},
+				SessionAffinity: corev1.ServiceAffinityNone,
+				IPFamilies:      []corev1.IPFamily{corev1.IPv4Protocol},
+			},
+			required: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+			},
+			want: true,
+		},
+		{
+			name: "changed port number detected",
+			existing: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 8080, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+			},
+			want: false,
+		},
+		{
+			name: "changed port name detected",
+			existing: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "http", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+			},
+			want: false,
+		},
+		{
+			name: "changed targetPort detected",
+			existing: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(8080), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+			},
+			want: false,
+		},
+		{
+			name: "changed protocol detected",
+			existing: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolUDP},
+				},
+				Selector: baseSelector,
+			},
+			want: false,
+		},
+		{
+			name: "different number of ports detected",
+			existing: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+			},
+			want: false,
+		},
+		{
+			name: "changed selector detected",
+			existing: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: basePorts,
+				Selector: map[string]string{
+					"app": "different",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "changed type detected",
+			existing: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports:    basePorts,
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeNodePort,
+			},
+			want: false,
+		},
+		{
+			name: "nil selector in both matches",
+			existing: corev1.ServiceSpec{
+				Ports: basePorts,
+				Type:  corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: basePorts,
+			},
+			want: true,
+		},
+		{
+			name: "empty protocol defaults to TCP",
+			existing: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443)},
+				},
+				Selector: baseSelector,
+			},
+			want: true,
+		},
+		{
+			name: "nodePort in existing ignored",
+			existing: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP, NodePort: 30443},
+				},
+				Selector: baseSelector,
+				Type:     corev1.ServiceTypeClusterIP,
+			},
+			required: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+				},
+				Selector: baseSelector,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := serviceSpecMatchesRequired(tt.existing, tt.required)
+			if got != tt.want {
+				t.Errorf("serviceSpecMatchesRequired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newTestRecorder() events.Recorder {
+	return events.NewInMemoryRecorder("test", clock.RealClock{})
+}
+
+func TestApplyDeployment_SkipsNoOpUpdate(t *testing.T) {
+	ResetGenerations()
+	defer ResetGenerations()
+
+	required := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy",
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(2),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	client := kubefake.NewSimpleClientset().AppsV1()
+	recorder := newTestRecorder()
+
+	result1, modified1, err := applyDeployment(context.Background(), client, recorder, required)
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if !modified1 {
+		t.Fatal("first apply should report modified=true (creation)")
+	}
+
+	// Second apply with identical spec should skip
+	result2, modified2, err := applyDeployment(context.Background(), client, recorder, required)
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if modified2 {
+		t.Fatal("second apply should report modified=false (no-op)")
+	}
+	if result2.Generation != result1.Generation {
+		t.Fatalf("generation should be stable: got %d, want %d", result2.Generation, result1.Generation)
+	}
+}
+
+func TestApplyDeployment_DetectsExternalChange(t *testing.T) {
+	ResetGenerations()
+	defer ResetGenerations()
+
+	required := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy",
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(2),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	client := kubefake.NewSimpleClientset().AppsV1()
+	recorder := newTestRecorder()
+
+	// First apply (creation)
+	_, _, err := applyDeployment(context.Background(), client, recorder, required)
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	// Simulate external modification. A real API server bumps generation on
+	// spec changes; the fake clientset does not, so we bump it manually.
+	existing, err := client.Deployments("test-ns").Get(context.Background(), "test-deploy", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	existing.Spec.Replicas = int32Ptr(5)
+	existing.Generation++
+	_, err = client.Deployments("test-ns").Update(context.Background(), existing, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("external update: %v", err)
+	}
+
+	// Next apply should detect the external change and re-apply
+	result, modified, err := applyDeployment(context.Background(), client, recorder, required)
+	if err != nil {
+		t.Fatalf("apply after external change: %v", err)
+	}
+	if !modified {
+		t.Fatal("apply after external change should report modified=true")
+	}
+	if *result.Spec.Replicas != 2 {
+		t.Fatalf("replicas should be restored to 2, got %d", *result.Spec.Replicas)
+	}
+}
+
+func TestApplyDaemonSet_SkipsNoOpUpdate(t *testing.T) {
+	ResetGenerations()
+	defer ResetGenerations()
+
+	required := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ds",
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	client := kubefake.NewSimpleClientset().AppsV1()
+	recorder := newTestRecorder()
+
+	_, modified1, err := applyDaemonSet(context.Background(), client, recorder, required)
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if !modified1 {
+		t.Fatal("first apply should report modified=true (creation)")
+	}
+
+	_, modified2, err := applyDaemonSet(context.Background(), client, recorder, required)
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if modified2 {
+		t.Fatal("second apply should report modified=false (no-op)")
+	}
+}
+
+func TestApplyService_SkipsNoOpUpdate(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-svc",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+			},
+			Selector: map[string]string{"app": "test"},
+		},
+	}
+
+	fakeClient := kubefake.NewSimpleClientset()
+	recorder := newTestRecorder()
+
+	// First apply (creation)
+	_, modified1, err := applyService(context.Background(), fakeClient.CoreV1(), recorder, svc)
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if !modified1 {
+		t.Fatal("first apply should report modified=true (creation)")
+	}
+
+	// Second apply with identical spec should skip
+	_, modified2, err := applyService(context.Background(), fakeClient.CoreV1(), recorder, svc)
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if modified2 {
+		t.Fatal("second apply should report modified=false (no-op)")
+	}
+}
+
+func TestApplyService_DetectsPortChange(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-svc",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "https", Port: 443, TargetPort: intstr.FromInt32(9443), Protocol: corev1.ProtocolTCP},
+			},
+			Selector: map[string]string{"app": "test"},
+		},
+	}
+
+	fakeClient := kubefake.NewSimpleClientset()
+	recorder := newTestRecorder()
+
+	// Create
+	_, _, err := applyService(context.Background(), fakeClient.CoreV1(), recorder, svc)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Simulate external port change
+	existing, _ := fakeClient.CoreV1().Services("test-ns").Get(context.Background(), "test-svc", metav1.GetOptions{})
+	existing.Spec.Ports[0].Port = 8080
+	_, err = fakeClient.CoreV1().Services("test-ns").Update(context.Background(), existing, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("external update: %v", err)
+	}
+
+	// Apply should detect the change and update
+	result, modified, err := applyService(context.Background(), fakeClient.CoreV1(), recorder, svc)
+	if err != nil {
+		t.Fatalf("apply after change: %v", err)
+	}
+	if !modified {
+		t.Fatal("should report modified=true after external port change")
+	}
+	if result.Spec.Ports[0].Port != 443 {
+		t.Fatalf("port should be restored to 443, got %d", result.Spec.Ports[0].Port)
+	}
+}
+
+func TestGenerations_Isolation(t *testing.T) {
+	ResetGenerations()
+	defer ResetGenerations()
+
+	if GenerationsLen() != 0 {
+		t.Fatalf("generations should be empty after reset, got %d entries", GenerationsLen())
+	}
+
+	required := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"a": "b"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "i"}}},
+			},
+		},
+	}
+	client := kubefake.NewSimpleClientset().AppsV1()
+	recorder := newTestRecorder()
+	if _, _, err := applyDeployment(context.Background(), client, recorder, required); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if GenerationsLen() == 0 {
+		t.Fatal("generations should have entries after apply")
+	}
+
+	ResetGenerations()
+	if GenerationsLen() != 0 {
+		t.Fatal("reset should clear all entries")
+	}
+}
+
+func int32Ptr(i int32) *int32 { return &i }


### PR DESCRIPTION
Summary

  Fixes a reconciliation storm ([MULTIARCH-6271](https://redhat.atlassian.net/browse/MULTIARCH-6271)) where the operator enters a tight loop after OLM bundle install, preventing convergence and blocking CPPC finalizer processing. The root cause was three interacting feedback loops:

  - Service always-update: applyService issued an unconditional Update() on every reconcile because server-defaulted fields (clusterIP, sessionAffinity, ipFamilies) never matched the required spec. This triggered Owns() watch events, feeding the loop. Observed: 472 Service updates in 27 minutes.
  - Deploy/DaemonSet expectedGeneration=0: Passing 0 to library-go's ApplyDeployment/ApplyDaemonSet disables the spec-hash skip path entirely, causing an Update on every reconcile even when nothing changed.
  - Sub-millisecond requeue on progressing: updateStatus returned a plain error when progressing, which goes through controller-runtime's exponential backoff starting at 1ms — effectively an immediate requeue. Combined with status  updates re-triggering the unfiltered For() watch, this created a near-continuous reconciliation loop.

  Changes

  - Diff-aware applyService (pkg/utils/resource.go): Compare only operator-managed fields (ports, selector, type) against existing state. Skip the Update when nothing changed. Handles server-defaulted Type (empty → ClusterIP) and Protocol (empty → TCP).
  - Generation-tracked applyDeployment/applyDaemonSet (pkg/utils/resource.go): Wrap library-go's apply functions with in-memory generation tracking using operatorv1.GenerationStatus and resourcemerge helpers — the standard OpenShift  pattern. On first reconcile (or pod restart), ExpectedDeploymentGeneration returns -1, so the first apply always runs. After that, updates are skipped when the generation matches.
  - 5s requeue when progressing (clusterpodplacementconfig_controller.go): Replace plain error return with requeueAfterError(5*time.Second, ...), which uses ctrl.Result{RequeueAfter: 5s} and calls queue.Forget() to reset the rate  limiter.
  - Filter Owns() watch events (clusterpodplacementconfig_controller.go): Add GenerationChangedPredicate to MutatingWebhookConfiguration, ServiceMonitor, and PrometheusRule Owns() watches. Intentionally left off Deployment/DaemonSet (status-only changes like crashes don't bump generation) and RBAC resources (generation never increments).
  - Filter status-only updates on primary CPPC watch (clusterpodplacementconfig_controller.go): Custom predicate on For() that passes generation changes, deletionTimestamp changes, and finalizer changes, but filters pure status updates. This prevents r.Status().Update() from immediately re-triggering reconciliation and nullifying the 5s requeue.
  - CSV stabilization wait (hack/deploy-and-e2e.sh): Poll for CSV existence (with RBAC/API error distinction and per-request timeout), wait for Succeeded phase, and add 10s stabilization sleep before running e2e tests in OLM
  deployments.
  - Unit tests (pkg/utils/resource_test.go): 20 test cases covering Service comparison (13 cases), Deployment skip/detect (2), DaemonSet skip (1), Service apply skip/detect (2), generation isolation (1), and a helper.


Cherrypick of https://github.com/openshift/multiarch-tuning-operator/pull/522