### PR TITLE
WIP: MULTIARCH-6340 make PodPlacementConfig.spec.plugins optional for back…

### DIFF
--- a/api/v1beta1/podplacementconfig_types.go
+++ b/api/v1beta1/podplacementconfig_types.go
@@ -33,9 +33,8 @@ type PodPlacementConfigSpec struct {
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 
 	// Plugins defines the configurable plugins for this component.
-	// This field is required.
-	// +kubebuilder:validation:Required
-	Plugins *plugins.LocalPlugins `json:"plugins"`
+	// +optional
+	Plugins *plugins.LocalPlugins `json:"plugins,omitempty"`
 
 	// Priority defines the priority of the PodPlacementConfig and only accepts values in the range 0-255.
 	// This field is optional and will default to 0 if not set.

--- a/bundle/manifests/multiarch.openshift.io_podplacementconfigs.yaml
+++ b/bundle/manifests/multiarch.openshift.io_podplacementconfigs.yaml
@@ -90,9 +90,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               plugins:
-                description: |-
-                  Plugins defines the configurable plugins for this component.
-                  This field is required.
+                description: Plugins defines the configurable plugins for this component.
                 properties:
                   nodeAffinityScoring:
                     description: NodeAffinityScoring is the plugin that implements
@@ -144,8 +142,6 @@ spec:
                 maximum: 255
                 minimum: 0
                 type: integer
-            required:
-            - plugins
             type: object
           status:
             description: PodPlacementConfigStatus defines the observed state of PodPlacementConfig

--- a/config/crd/bases/multiarch.openshift.io_podplacementconfigs.yaml
+++ b/config/crd/bases/multiarch.openshift.io_podplacementconfigs.yaml
@@ -90,9 +90,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               plugins:
-                description: |-
-                  Plugins defines the configurable plugins for this component.
-                  This field is required.
+                description: Plugins defines the configurable plugins for this component.
                 properties:
                   nodeAffinityScoring:
                     description: NodeAffinityScoring is the plugin that implements
@@ -144,8 +142,6 @@ spec:
                 maximum: 255
                 minimum: 0
                 type: integer
-            required:
-            - plugins
             type: object
           status:
             description: PodPlacementConfigStatus defines the observed state of PodPlacementConfig


### PR DESCRIPTION
…ward compatibility

Making spec.plugins required in v1beta1 is a breaking change that would cause validation failures on existing PodPlacementConfig objects created without the plugins field.